### PR TITLE
Fix issue that a DB file maybe deleted if its polling.url points to a…

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -165,7 +165,7 @@ public abstract class AbstractServiceUpdater {
 			}
 
 		} finally {
-			if (newDB != null && newDB.exists()) {
+			if (newDB != null && newDB != existingDB && newDB.exists()) {
 				LOGGER.info("[" + getClass().getSimpleName() + "] Try to delete downloaded temp file");
 				deleteDatabase(newDB);
 			}


### PR DESCRIPTION
Fix an issue that a DB file maybe deleted if its polling.url points to a file with old timestamps (double commit this to 1.7.x).
