### PR TITLE
TC-10: update client import paths

### DIFF
--- a/traffic_ops/client/fixtures/cachegroup.go
+++ b/traffic_ops/client/fixtures/cachegroup.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // Cachegroups returns a default CacheGroupResponse to be used for testing.
 func Cachegroups() *client.CacheGroupResponse {

--- a/traffic_ops/client/fixtures/cdn.go
+++ b/traffic_ops/client/fixtures/cdn.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // CDNs returns a default CDNResponse to be used for testing.
 func CDNs() *client.CDNResponse {

--- a/traffic_ops/client/fixtures/delivery_service.go
+++ b/traffic_ops/client/fixtures/delivery_service.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // DeliveryServices returns a default DeliveryServiceResponse to be used for testing.
 func DeliveryServices() *client.DeliveryServiceResponse {

--- a/traffic_ops/client/fixtures/hardware.go
+++ b/traffic_ops/client/fixtures/hardware.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // Hardware returns a default HardwareResponse to be used for testing.
 func Hardware() *client.HardwareResponse {

--- a/traffic_ops/client/fixtures/parameter.go
+++ b/traffic_ops/client/fixtures/parameter.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // Parameters returns a default ParamResponse to be used for testing.
 func Parameters() *client.ParamResponse {

--- a/traffic_ops/client/fixtures/profile.go
+++ b/traffic_ops/client/fixtures/profile.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // Profiles returns a default ProfileResponse to be used for testing.
 func Profiles() *client.ProfileResponse {

--- a/traffic_ops/client/fixtures/server.go
+++ b/traffic_ops/client/fixtures/server.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // Servers returns a default ServerResponse to be used for testing.
 func Servers() *client.ServerResponse {

--- a/traffic_ops/client/fixtures/stats_summary.go
+++ b/traffic_ops/client/fixtures/stats_summary.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // StatsSummary returns a default StatsSummaryResponse to be used for testing.
 func StatsSummary() *client.StatsSummaryResponse {

--- a/traffic_ops/client/fixtures/traffic_monitor_config.go
+++ b/traffic_ops/client/fixtures/traffic_monitor_config.go
@@ -1,6 +1,6 @@
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // TrafficMonitorConfig returns a default TMConfigResponse to be used for testing.
 func TrafficMonitorConfig() *client.TMConfigResponse {

--- a/traffic_ops/client/fixtures/traffic_router_config.go
+++ b/traffic_ops/client/fixtures/traffic_router_config.go
@@ -1,6 +1,6 @@
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // TrafficRouterConfig returns a default TRConfigResponse to be used for testing.
 func TrafficRouterConfig() *client.TRConfigResponse {

--- a/traffic_ops/client/fixtures/types.go
+++ b/traffic_ops/client/fixtures/types.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // Types returns a default TypeResponse to be used for testing.
 func Types() *client.TypeResponse {

--- a/traffic_ops/client/fixtures/user.go
+++ b/traffic_ops/client/fixtures/user.go
@@ -16,7 +16,7 @@
 
 package fixtures
 
-import "github.com/Comcast/traffic_control/traffic_ops/client"
+import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
 // Users returns a default UserResponse to be used for testing.
 func Users() *client.UserResponse {

--- a/traffic_ops/client/tests/cachegroup_test.go
+++ b/traffic_ops/client/tests/cachegroup_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/cdn_test.go
+++ b/traffic_ops/client/tests/cdn_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/delivery_service_test.go
+++ b/traffic_ops/client/tests/delivery_service_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/hardware_test.go
+++ b/traffic_ops/client/tests/hardware_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/parameter_test.go
+++ b/traffic_ops/client/tests/parameter_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/profile_test.go
+++ b/traffic_ops/client/tests/profile_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/server_test.go
+++ b/traffic_ops/client/tests/server_test.go
@@ -21,8 +21,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/stats_summary_test.go
+++ b/traffic_ops/client/tests/stats_summary_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/traffic_monitor_config_test.go
+++ b/traffic_ops/client/tests/traffic_monitor_config_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/traffic_ops_test.go
+++ b/traffic_ops/client/tests/traffic_ops_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/traffic_router_config_test.go
+++ b/traffic_ops/client/tests/traffic_router_config_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/type_test.go
+++ b/traffic_ops/client/tests/type_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 

--- a/traffic_ops/client/tests/user_test.go
+++ b/traffic_ops/client/tests/user_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Comcast/traffic_control/traffic_ops/client"
-	"github.com/Comcast/traffic_control/traffic_ops/client/fixtures"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/client/fixtures"
 	"github.com/jheitz200/test_helper"
 )
 


### PR DESCRIPTION
This updates the import paths to reference the new
`apache/incubator-trafficcontrol` over the old `Comcast/traffic_control`.