### PR TITLE
TC-19 - ORT now errors if a https cert is not found

### DIFF
--- a/traffic_ops/app/script/update_riak_for_search.pl
+++ b/traffic_ops/app/script/update_riak_for_search.pl
@@ -40,6 +40,9 @@ foreach my $ds (@$dss) {
 		my $xml_id = $ds->{xmlId};
 		my $cdn = $ds->{cdnName};
 		my $record = &get_riak_record($xml_id, $to_url, $ua);
+		if (!defined($record)) {
+			next;
+		}
 		$record->{deliveryservice} = $xml_id;
 		$record->{cdn} = $cdn;
 		$record->{certificate}->{crt} = decode_base64($record->{certificate}->{crt});
@@ -117,8 +120,8 @@ sub get_riak_record {
 	my $response = $ua->get( $url );
 
 	if(!$response->is_success() || $response->code() > 400) {
-		print "Could not get ssl record for $xml_id from riak!  Response was ". $response->{_rc} . " - " . $response->{_msg} . "\n";
-		exit 1;
+		print "Could not get ssl record for $xml_id from riak!  Response was ". $response->{_rc} . " - " . $response->{_msg} . "Skipping...\n";
+		return;
 	}
 
 	my $content = decode_json($response->{_content});

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -2544,11 +2544,14 @@ sub adv_processing_ssl {
 					$cfg_file_tracker->{ $keypair->{'cert_name'} }->{'component'} = "SSL";
 					$cfg_file_tracker->{ $keypair->{'cert_name'} }->{'contents'}  = $ssl_cert;
 					$cfg_file_tracker->{ $keypair->{'cert_name'} }->{'fname-in-TO'}  = $keypair->{'cert_name'};
+					return 0;
 				}
 			}
+				#if no cert is found, log error and exit
+				( $log_level >> $FATAL ) && print "FATAL SSL certificate for $remap not found!\n";
+				exit 1;
 		}
 	}
-	return 0;
 }
 
 sub setup_lwp {


### PR DESCRIPTION
If a https certificate is not found for a delivery service, ORT now logs a FATAL message and exits.  This fixes [TC-19](https://issues.apache.org/jira/browse/TC-19).

Also updated the update_riak_for_search script so it does not exit when it gets an error.