### PR TITLE
TM - remove ASF header from json files

### DIFF
--- a/traffic_monitor/src/main/conf/traffic_monitor_config.js
+++ b/traffic_monitor/src/main/conf/traffic_monitor_config.js
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 {
 	"traffic_monitor_config": {
 		"health.polling.interval": "5000",

--- a/traffic_monitor/src/test/resources/conf/traffic_monitor_config.js
+++ b/traffic_monitor/src/test/resources/conf/traffic_monitor_config.js
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 {"traffic_monitor_config": {
   "tm.healthParams.polling.url": "https://${tmHostname}/health/${cdnName}",
   "hack.ttl": "30",


### PR DESCRIPTION
These were incorrectly added by automated tool and broke traffic monitor