### PR TITLE
Fix for Issue #TC-33

### DIFF
--- a/traffic_ops/app/lib/API/Deliveryservice.pm
+++ b/traffic_ops/app/lib/API/Deliveryservice.pm
@@ -32,7 +32,7 @@ use Validate::Tiny ':all';
 
 sub index {
 	my $self         = shift;
-	my $orderby      = $self->param('orderby') || "xml_id";
+	my $orderby      = "xml_id";
 	my $logs_enabled = $self->param('logsEnabled');
 	my $current_user = $self->current_user()->{username};
 	my @data;


### PR DESCRIPTION
order_by can only sort for columns that exist on the table