### PR TITLE
TC-34 - Traffic Ops can now return ssl certificate information for DSs with periods in the xml_id

### DIFF
--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -515,7 +515,7 @@ sub api_routes {
 	# -- DELIVERYSERVICE: SSL KEYS
 	# Support for SSL private keys, certs, and csrs
 	# gets the latest key by default unless a version query param is provided with ?version=x
-	$r->get("/api/$version/deliveryservices/xmlId/:xmlid/sslkeys")->over( authenticated => 1 )
+	$r->get("/api/$version/deliveryservices/xmlId/#xmlid/sslkeys")->over( authenticated => 1 )
 		->to( 'SslKeys#view_by_xml_id', namespace => 'API::DeliveryService' );
 	$r->get("/api/$version/deliveryservices/hostname/#hostname/sslkeys")->over( authenticated => 1 )
 		->to( 'SslKeys#view_by_hostname', namespace => 'API::DeliveryService' );

--- a/traffic_ops/app/script/update_riak_for_search.pl
+++ b/traffic_ops/app/script/update_riak_for_search.pl
@@ -39,6 +39,7 @@ foreach my $ds (@$dss) {
 	if ($ds->{protocol} > 0) {
 		my $xml_id = $ds->{xmlId};
 		my $cdn = $ds->{cdnName};
+		print "Updating record for: $xml_id\n";
 		my $record = &get_riak_record($xml_id, $to_url, $ua);
 		if (!defined($record)) {
 			next;

--- a/traffic_ops/app/t/api/1.1/deliveryservice/ssl_keys.t
+++ b/traffic_ops/app/t/api/1.1/deliveryservice/ssl_keys.t
@@ -138,6 +138,13 @@ ok $t->get_ok("/api/1.1/deliveryservices/xmlId/$key/sslkeys.json")->json_has("/r
 	->json_is( "/response/version" => $version )->json_is( "/response/country" => $country )->json_is( "/response/hostname" => $hostname )->status_is(200)
 	->or( sub { diag $t->tx->res->content->asset->{content}; } );
 
+# #get key with period
+ok $t->get_ok("/api/1.1/deliveryservices/xmlId/foo.bar/sslkeys.json")->json_has("/response")->json_has("/response/certificate/csr")
+	->json_has("/response/certificate/key")->json_has("/response/certificate/crt")->json_is( "/response/organization" => $org )
+	->json_is( "/response/state" => $state )->json_is( "/response/city" => $city )->json_is( "/response/businessUnit" => $unit )
+	->json_is( "/response/version" => $version )->json_is( "/response/country" => $country )->json_is( "/response/hostname" => $hostname )->status_is(200)
+	->or( sub { diag $t->tx->res->content->asset->{content}; } );
+
 #get key by hostname
 my $gen_hostname = "edge.foo.top.kabletown.com";
 ok $t->get_ok("/api/1.1/deliveryservices/hostname/$gen_hostname/sslkeys.json")->json_has("/response")->json_has("/response/certificate/csr")


### PR DESCRIPTION
Traffic Ops now returns ssl certificate information for delivery services with periods in the name.  This caused an issue in update_riak_for_search.pl where  the ssl keys for a delivery service were not indexed because the keys could not be gotten from riak.

This fixes TC-34.