### PR TITLE
Fix psql migration to convert the right stuff to bools and leave other stuff alone

### DIFF
--- a/traffic_ops/app/db/migrations/20160910092026_fix_column_types.sql
+++ b/traffic_ops/app/db/migrations/20160910092026_fix_column_types.sql
@@ -21,76 +21,178 @@ ALTER TABLE cachegroup ALTER COLUMN latitude  TYPE numeric;
 ALTER TABLE cachegroup ALTER COLUMN longitude TYPE numeric;
 
 ALTER TABLE cdn
+  ALTER COLUMN dnssec_enabled DROP DEFAULT,
 	ALTER COLUMN dnssec_enabled TYPE boolean
 		USING CASE WHEN dnssec_enabled = 0 THEN FALSE
 			WHEN dnssec_enabled = 1 THEN TRUE
-			ELSE NULL;
+			ELSE FALSE
+			END,
+  ALTER COLUMN dnssec_enabled SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice ALTER COLUMN miss_lat                     TYPE numeric;
 ALTER TABLE deliveryservice ALTER COLUMN miss_long                    TYPE numeric;
 
 ALTER TABLE deliveryservice
+  ALTER COLUMN active DROP DEFAULT,
 	ALTER COLUMN active TYPE boolean
 		USING CASE WHEN active = 0 THEN FALSE
 			WHEN active = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN active SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
+  ALTER COLUMN signed DROP DEFAULT,
 	ALTER COLUMN signed TYPE boolean
 		USING CASE WHEN signed = 0 THEN FALSE
 			WHEN signed = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN signed SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
+  ALTER COLUMN ipv6_routing_enabled DROP DEFAULT,
 	ALTER COLUMN ipv6_routing_enabled TYPE boolean
 		USING CASE WHEN ipv6_routing_enabled = 0 THEN FALSE
 			WHEN ipv6_routing_enabled = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN ipv6_routing_enabled SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
+  ALTER COLUMN multi_site_origin DROP DEFAULT,
 	ALTER COLUMN multi_site_origin TYPE boolean
 		USING CASE WHEN multi_site_origin = 0 THEN FALSE
 			WHEN multi_site_origin = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN multi_site_origin SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
+  ALTER COLUMN regional_geo_blocking DROP DEFAULT,
 	ALTER COLUMN regional_geo_blocking TYPE boolean
 		USING CASE WHEN regional_geo_blocking = 0 THEN FALSE
 			WHEN regional_geo_blocking = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN regional_geo_blocking SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
+  ALTER COLUMN logs_enabled DROP DEFAULT,
 	ALTER COLUMN logs_enabled TYPE boolean
 		USING CASE WHEN logs_enabled = 0 THEN FALSE
 			WHEN logs_enabled = 1 THEN TRUE
-			ELSE NULL;
-
-ALTER TABLE deliveryservice
-	ALTER COLUMN logs_enabled TYPE boolean
-		USING CASE WHEN logs_enabled = 0 THEN FALSE
-			WHEN logs_enabled = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN logs_enabled SET DEFAULT FALSE;
 
 ALTER TABLE parameter
+  ALTER COLUMN secure DROP DEFAULT,
 	ALTER COLUMN secure TYPE boolean
 		USING CASE WHEN secure = 0 THEN FALSE
 			WHEN secure = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN secure SET DEFAULT FALSE;
 
 ALTER TABLE server
+  ALTER COLUMN upd_pending DROP DEFAULT,
 	ALTER COLUMN upd_pending TYPE boolean
 		USING CASE WHEN upd_pending = 0 THEN FALSE
 			WHEN upd_pending = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN upd_pending SET DEFAULT FALSE;
 
 ALTER TABLE tm_user
+  ALTER COLUMN new_user DROP DEFAULT,
 	ALTER COLUMN new_user TYPE boolean
 		USING CASE WHEN new_user = 0 THEN FALSE
 			WHEN new_user = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+  ALTER COLUMN new_user SET DEFAULT FALSE;
 
 ALTER TABLE to_extension
+  ALTER COLUMN isactive DROP DEFAULT,
 	ALTER COLUMN isactive TYPE boolean
 		USING CASE WHEN isactive = 0 THEN FALSE
 			WHEN isactive = 1 THEN TRUE
-			ELSE NULL;
+			ELSE NULL
+			END,
+    ALTER COLUMN isactive SET DEFAULT FALSE;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE cachegroup ALTER COLUMN latitude  TYPE double precision;
+ALTER TABLE cachegroup ALTER COLUMN longitude TYPE double precision;
+
+ALTER TABLE cdn
+  ALTER COLUMN dnssec_enabled DROP DEFAULT,
+	ALTER COLUMN dnssec_enabled TYPE SMALLINT
+   USING CASE WHEN dnssec_enabled THEN 1 ELSE 0 END,
+  ALTER COLUMN dnssec_enabled SET DEFAULT 0;
+
+ALTER TABLE deliveryservice ALTER COLUMN miss_lat  TYPE double precision;
+ALTER TABLE deliveryservice ALTER COLUMN miss_long TYPE double precision;
+
+ALTER TABLE deliveryservice
+  ALTER COLUMN active DROP DEFAULT,
+	ALTER COLUMN active TYPE SMALLINT
+   USING CASE WHEN active THEN 1 ELSE 0 END,
+  ALTER COLUMN active SET DEFAULT 0;
+
+ALTER TABLE deliveryservice
+  ALTER COLUMN signed DROP DEFAULT,
+	ALTER COLUMN signed TYPE SMALLINT
+   USING CASE WHEN signed THEN 1 ELSE 0 END,
+  ALTER COLUMN signed SET DEFAULT 0;
+
+ALTER TABLE deliveryservice
+  ALTER COLUMN ipv6_routing_enabled DROP DEFAULT,
+	ALTER COLUMN ipv6_routing_enabled TYPE SMALLINT
+   USING CASE WHEN ipv6_routing_enabled THEN 1 ELSE 0 END,
+  ALTER COLUMN ipv6_routing_enabled SET DEFAULT 0;
+
+ALTER TABLE deliveryservice
+  ALTER COLUMN multi_site_origin DROP DEFAULT,
+	ALTER COLUMN multi_site_origin TYPE SMALLINT
+   USING CASE WHEN multi_site_origin THEN 1 ELSE 0 END,
+  ALTER COLUMN multi_site_origin SET DEFAULT 0;
+
+ALTER TABLE deliveryservice
+  ALTER COLUMN regional_geo_blocking DROP DEFAULT,
+	ALTER COLUMN regional_geo_blocking TYPE SMALLINT
+   USING CASE WHEN regional_geo_blocking THEN 1 ELSE 0 END,
+  ALTER COLUMN regional_geo_blocking SET DEFAULT 0;
+
+ALTER TABLE deliveryservice
+  ALTER COLUMN logs_enabled DROP DEFAULT,
+	ALTER COLUMN logs_enabled TYPE SMALLINT
+   USING CASE WHEN logs_enabled THEN 1 ELSE 0 END,
+  ALTER COLUMN logs_enabled SET DEFAULT 0;
+
+ALTER TABLE parameter
+  ALTER COLUMN secure DROP DEFAULT,
+	ALTER COLUMN secure TYPE SMALLINT
+   USING CASE WHEN secure THEN 1 ELSE 0 END,
+  ALTER COLUMN secure SET DEFAULT 0;
+
+ALTER TABLE server
+  ALTER COLUMN upd_pending DROP DEFAULT,
+	ALTER COLUMN upd_pending TYPE SMALLINT
+   USING CASE WHEN upd_pending THEN 1 ELSE 0 END,
+  ALTER COLUMN upd_pending SET DEFAULT 0;
+
+ALTER TABLE tm_user
+  ALTER COLUMN new_user DROP DEFAULT,
+	ALTER COLUMN new_user TYPE SMALLINT
+   USING CASE WHEN new_user THEN 1 ELSE 0 END,
+  ALTER COLUMN new_user SET DEFAULT 0;
+
+ALTER TABLE to_extension
+  ALTER COLUMN isactive DROP DEFAULT,
+	ALTER COLUMN isactive TYPE SMALLINT
+   USING CASE WHEN isactive THEN 1 ELSE 0 END,
+  ALTER COLUMN isactive SET DEFAULT 0;

--- a/traffic_ops/app/db/migrations/20160910092026_fix_column_types.sql
+++ b/traffic_ops/app/db/migrations/20160910092026_fix_column_types.sql
@@ -20,73 +20,77 @@
 ALTER TABLE cachegroup ALTER COLUMN latitude  TYPE numeric;
 ALTER TABLE cachegroup ALTER COLUMN longitude TYPE numeric;
 
-ALTER TABLE deliveryservice ALTER COLUMN signed TYPE smallint USING (signed::int::smallint);
-ALTER TABLE deliveryservice ALTER COLUMN qstring_ignore TYPE smallint USING (qstring_ignore::int::smallint);
-
-ALTER TABLE deliveryservice
-  ALTER COLUMN geo_limit DROP DEFAULT,
-  ALTER COLUMN geo_limit TYPE smallint USING (geo_limit::int::smallint),
-  ALTER COLUMN geo_limit SET DEFAULT '0';
+ALTER TABLE cdn
+	ALTER COLUMN dnssec_enabled TYPE boolean
+		USING CASE WHEN dnssec_enabled = 0 THEN FALSE
+			WHEN dnssec_enabled = 1 THEN TRUE
+			ELSE NULL;
 
 ALTER TABLE deliveryservice ALTER COLUMN miss_lat                     TYPE numeric;
 ALTER TABLE deliveryservice ALTER COLUMN miss_long                    TYPE numeric;
-ALTER TABLE deliveryservice ALTER COLUMN multi_site_origin            TYPE smallint USING (multi_site_origin::int::smallint);
-ALTER TABLE deliveryservice ALTER COLUMN regional_geo_blocking        TYPE smallint USING (regional_geo_blocking::int::smallint);
-ALTER TABLE deliveryservice ALTER COLUMN logs_enabled                 TYPE smallint USING (logs_enabled::int::smallint);
-ALTER TABLE deliveryservice ALTER COLUMN multi_site_origin_algorithm  TYPE smallint USING (multi_site_origin_algorithm::int::smallint);
-
-ALTER TABLE parameter
-  ALTER COLUMN secure DROP DEFAULT,
-  ALTER COLUMN secure TYPE smallint USING (secure::int::smallint),
-  ALTER COLUMN secure SET DEFAULT '0';
-
-ALTER TABLE server
-  ALTER COLUMN upd_pending DROP DEFAULT,
-  ALTER COLUMN upd_pending TYPE smallint USING (upd_pending::int::smallint),
-  ALTER COLUMN upd_pending SET DEFAULT '0';
-
-ALTER TABLE tm_user
-  ALTER COLUMN new_user DROP DEFAULT,
-  ALTER COLUMN new_user TYPE smallint USING (new_user::int::smallint),
-  ALTER COLUMN new_user SET DEFAULT '1';
-
-ALTER TABLE to_extension  ALTER COLUMN isactive TYPE smallint USING (isactive::int::smallint);
-
-
-
--- +goose Down
--- SQL section 'Down' is executed when this migration is rolled back
-
-ALTER TABLE cachegroup ALTER COLUMN latitude  TYPE double precision;
-ALTER TABLE cachegroup ALTER COLUMN longitude TYPE double precision;
-
-ALTER TABLE deliveryservice ALTER COLUMN signed         TYPE boolean USING (signed::int::boolean);
-ALTER TABLE deliveryservice ALTER COLUMN qstring_ignore TYPE boolean USING (qstring_ignore::int::boolean);
 
 ALTER TABLE deliveryservice
-  ALTER COLUMN geo_limit DROP DEFAULT,
-  ALTER COLUMN geo_limit TYPE boolean USING (geo_limit::int::boolean),
-  ALTER COLUMN geo_limit SET DEFAULT FALSE;
+	ALTER COLUMN active TYPE boolean
+		USING CASE WHEN active = 0 THEN FALSE
+			WHEN active = 1 THEN TRUE
+			ELSE NULL;
 
-ALTER TABLE deliveryservice ALTER COLUMN miss_lat                     TYPE double precision;
-ALTER TABLE deliveryservice ALTER COLUMN miss_long                    TYPE double precision;
-ALTER TABLE deliveryservice ALTER COLUMN multi_site_origin            TYPE boolean USING (multi_site_origin::int::boolean);
-ALTER TABLE deliveryservice ALTER COLUMN regional_geo_blocking        TYPE boolean USING (regional_geo_blocking::int::boolean);
-ALTER TABLE deliveryservice ALTER COLUMN multi_site_origin_algorithm  TYPE boolean USING (multi_site_origin_algorithm::int::boolean);
+ALTER TABLE deliveryservice
+	ALTER COLUMN signed TYPE boolean
+		USING CASE WHEN signed = 0 THEN FALSE
+			WHEN signed = 1 THEN TRUE
+			ELSE NULL;
+
+ALTER TABLE deliveryservice
+	ALTER COLUMN ipv6_routing_enabled TYPE boolean
+		USING CASE WHEN ipv6_routing_enabled = 0 THEN FALSE
+			WHEN ipv6_routing_enabled = 1 THEN TRUE
+			ELSE NULL;
+
+ALTER TABLE deliveryservice
+	ALTER COLUMN multi_site_origin TYPE boolean
+		USING CASE WHEN multi_site_origin = 0 THEN FALSE
+			WHEN multi_site_origin = 1 THEN TRUE
+			ELSE NULL;
+
+ALTER TABLE deliveryservice
+	ALTER COLUMN regional_geo_blocking TYPE boolean
+		USING CASE WHEN regional_geo_blocking = 0 THEN FALSE
+			WHEN regional_geo_blocking = 1 THEN TRUE
+			ELSE NULL;
+
+ALTER TABLE deliveryservice
+	ALTER COLUMN logs_enabled TYPE boolean
+		USING CASE WHEN logs_enabled = 0 THEN FALSE
+			WHEN logs_enabled = 1 THEN TRUE
+			ELSE NULL;
+
+ALTER TABLE deliveryservice
+	ALTER COLUMN logs_enabled TYPE boolean
+		USING CASE WHEN logs_enabled = 0 THEN FALSE
+			WHEN logs_enabled = 1 THEN TRUE
+			ELSE NULL;
 
 ALTER TABLE parameter
-  ALTER COLUMN secure DROP DEFAULT,
-  ALTER COLUMN secure TYPE boolean USING (secure::int::boolean),
-  ALTER COLUMN secure SET DEFAULT FALSE;
+	ALTER COLUMN secure TYPE boolean
+		USING CASE WHEN secure = 0 THEN FALSE
+			WHEN secure = 1 THEN TRUE
+			ELSE NULL;
 
 ALTER TABLE server
-  ALTER COLUMN upd_pending DROP DEFAULT,
-  ALTER COLUMN upd_pending TYPE boolean USING (upd_pending::int::boolean),
-  ALTER COLUMN upd_pending SET DEFAULT FALSE;
+	ALTER COLUMN upd_pending TYPE boolean
+		USING CASE WHEN upd_pending = 0 THEN FALSE
+			WHEN upd_pending = 1 THEN TRUE
+			ELSE NULL;
 
 ALTER TABLE tm_user
-  ALTER COLUMN new_user DROP DEFAULT,
-  ALTER COLUMN new_user TYPE boolean USING (new_user::int::boolean),
-  ALTER COLUMN new_user SET DEFAULT TRUE;
+	ALTER COLUMN new_user TYPE boolean
+		USING CASE WHEN new_user = 0 THEN FALSE
+			WHEN new_user = 1 THEN TRUE
+			ELSE NULL;
 
-ALTER TABLE to_extension  ALTER COLUMN isactive TYPE boolean USING (isactive::int::boolean);
+ALTER TABLE to_extension
+	ALTER COLUMN isactive TYPE boolean
+		USING CASE WHEN isactive = 0 THEN FALSE
+			WHEN isactive = 1 THEN TRUE
+			ELSE NULL;


### PR DESCRIPTION
pgloader converts all tinyints to smallints but some of these need to be converted to bools and some need to be left as smallints. this migration converts the appropriate ones to bools.

here are the tinyints that get converted to bools

cdn.dnssec_enabled
ds.active
ds.signed
ds.ipv6_routing_enabled
ds.multi_site_origin
ds.regional_geo_blocking
ds.logs_enabled
parameter.secure
server.upd_pending
tm_user.new_user
to_extension.isactive

and here are the tinyints that will stay as smallints

ds.qstring_ignore
ds.geo_limit
ds.protocol
ds.range_request_handling
ds.geo_provider
ds.multi_site_origin_algorithm