### PR TITLE
TC-16 changed repo path from github.com/Comcast to github.com/apache/incuba…

### DIFF
--- a/traffic_ops/experimental/ats_config/ats_config_cli.go
+++ b/traffic_ops/experimental/ats_config/ats_config_cli.go
@@ -17,8 +17,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	configfiles "github.com/Comcast/traffic_control/traffic_ops/experimental/ats_config/config_files"
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/ats_config/traffic_ops"
+	configfiles "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/ats_config/config_files"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/ats_config/traffic_ops"
 )
 
 // Args encapsulates the command line arguments

--- a/traffic_ops/experimental/server/README.md
+++ b/traffic_ops/experimental/server/README.md
@@ -90,7 +90,7 @@ Note: for now, we are using the web.go method to get the swagger pages up, later
   ```
   [jvd@laika swagger-api]$ pwd
   /Users/jvd/work/gh/swagger-api
-  [jvd@laika swagger-api]$ swagger -apiPackage github.com/Comcast/traffic_control/traffic_ops/experimental/server/api -mainApiFile github.com/Comcast/traffic_control/traffic_ops/experimental/server/api/api.go -format go
+  [jvd@laika swagger-api]$ swagger -apiPackage github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/api -mainApiFile github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/api/api.go -format go
   2016/01/16 09:57:34 Start parsing
   2016/01/16 09:57:36 Finish parsing
   2016/01/16 09:57:36 Doc file generated

--- a/traffic_ops/experimental/server/api/asns.go
+++ b/traffic_ops/experimental/server/api/asns.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/cachegroups.go
+++ b/traffic_ops/experimental/server/api/cachegroups.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/cachegroups_parameters.go
+++ b/traffic_ops/experimental/server/api/cachegroups_parameters.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/cachegroups_types.go
+++ b/traffic_ops/experimental/server/api/cachegroups_types.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/cdns.go
+++ b/traffic_ops/experimental/server/api/cdns.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/crconfig_snapshots.go
+++ b/traffic_ops/experimental/server/api/crconfig_snapshots.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/deliveryservices.go
+++ b/traffic_ops/experimental/server/api/deliveryservices.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/deliveryservices_regexes.go
+++ b/traffic_ops/experimental/server/api/deliveryservices_regexes.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/deliveryservices_servers.go
+++ b/traffic_ops/experimental/server/api/deliveryservices_servers.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/deliveryservices_types.go
+++ b/traffic_ops/experimental/server/api/deliveryservices_types.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/deliveryservices_users.go
+++ b/traffic_ops/experimental/server/api/deliveryservices_users.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/divisions.go
+++ b/traffic_ops/experimental/server/api/divisions.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/domains.go
+++ b/traffic_ops/experimental/server/api/domains.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/extensions.go
+++ b/traffic_ops/experimental/server/api/extensions.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/extensions_types.go
+++ b/traffic_ops/experimental/server/api/extensions_types.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/federation_resolvers.go
+++ b/traffic_ops/experimental/server/api/federation_resolvers.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/federation_users.go
+++ b/traffic_ops/experimental/server/api/federation_users.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/federations.go
+++ b/traffic_ops/experimental/server/api/federations.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/federations_deliveryservices.go
+++ b/traffic_ops/experimental/server/api/federations_deliveryservices.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/federations_federation_resolvers.go
+++ b/traffic_ops/experimental/server/api/federations_federation_resolvers.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/goose_db_version.go
+++ b/traffic_ops/experimental/server/api/goose_db_version.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/log.go
+++ b/traffic_ops/experimental/server/api/log.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/parameters.go
+++ b/traffic_ops/experimental/server/api/parameters.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/phys_locations.go
+++ b/traffic_ops/experimental/server/api/phys_locations.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/profiles.go
+++ b/traffic_ops/experimental/server/api/profiles.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/profiles_parameters.go
+++ b/traffic_ops/experimental/server/api/profiles_parameters.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/regexes.go
+++ b/traffic_ops/experimental/server/api/regexes.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/regexes_types.go
+++ b/traffic_ops/experimental/server/api/regexes_types.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/regions.go
+++ b/traffic_ops/experimental/server/api/regions.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/roles.go
+++ b/traffic_ops/experimental/server/api/roles.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/servers.go
+++ b/traffic_ops/experimental/server/api/servers.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/servers_types.go
+++ b/traffic_ops/experimental/server/api/servers_types.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/snapshot_crconfig.go
+++ b/traffic_ops/experimental/server/api/snapshot_crconfig.go
@@ -18,8 +18,8 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/crconfig"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/crconfig"
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 )

--- a/traffic_ops/experimental/server/api/staticdnsentries.go
+++ b/traffic_ops/experimental/server/api/staticdnsentries.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/staticdnsentries_types.go
+++ b/traffic_ops/experimental/server/api/staticdnsentries_types.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/stats_summary.go
+++ b/traffic_ops/experimental/server/api/stats_summary.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	"log"
 	"time"

--- a/traffic_ops/experimental/server/api/statuses.go
+++ b/traffic_ops/experimental/server/api/statuses.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/api/users.go
+++ b/traffic_ops/experimental/server/api/users.go
@@ -18,7 +18,7 @@ package api
 
 import (
 	"encoding/json"
-	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	_ "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format" // needed for swagger
 	"github.com/jmoiron/sqlx"
 	null "gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/auth/auth.go
+++ b/traffic_ops/experimental/server/auth/auth.go
@@ -20,7 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	api "github.com/Comcast/traffic_control/traffic_ops/experimental/server/api"
+	api "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/api"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/jmoiron/sqlx"
 	"io/ioutil"

--- a/traffic_ops/experimental/server/csconfig/csconfig.go
+++ b/traffic_ops/experimental/server/csconfig/csconfig.go
@@ -15,7 +15,7 @@ package csconfig
 
 import (
 	"fmt"
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/api"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/api"
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/guregu/null.v3"
 	"log"

--- a/traffic_ops/experimental/server/main.go
+++ b/traffic_ops/experimental/server/main.go
@@ -14,9 +14,9 @@
 package main
 
 import (
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/auth"
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/db"
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/routes"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/auth"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/db"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/routes"
 
 	"encoding/gob"
 	"encoding/json"

--- a/traffic_ops/experimental/server/routes/routes.go
+++ b/traffic_ops/experimental/server/routes/routes.go
@@ -16,10 +16,10 @@
 package routes
 
 import (
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/api"
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/auth"
-	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/csconfig"
-	output "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/api"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/auth"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/csconfig"
+	output "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format"
 
 	"encoding/json"
 	"fmt"

--- a/traffic_ops/experimental/server/tools/gen_goto2.go
+++ b/traffic_ops/experimental/server/tools/gen_goto2.go
@@ -134,7 +134,7 @@ func writeFile(schemas []ColumnSchema, table string) (int, error) {
 	if strings.Contains(sString, "null.") {
 		header += "null \"gopkg.in/guregu/null.v3\"\n"
 	}
-	header += "_ \"github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format\" // needed for swagger\n"
+	header += "_ \"github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/output_format\" // needed for swagger\n"
 	if strings.Contains(sString, "time.") {
 		header += "\"time\"\n"
 	}


### PR DESCRIPTION
TC-16 (should have included in title)

The paths have changed but there are errors with the following files:

ats_config_cli.go
import "github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/ats_config/traffic_ops" is a program, not an importable package
      and
github.com/apache/incubator-trafficcontrol/traffic_ops/experimental/server/auth/auth.go
invalid operation: token.Claims["userid"] (type jwt.Claims does not support indexing)
token.Claims["userid"]
token.Claims["role"]
token.Claims["exp"]