### PR TITLE
TC-38 - Traffic Ops now always sends correct Content-Type header on Riak PUT

### DIFF
--- a/traffic_ops/app/lib/Connection/RiakAdapter.pm
+++ b/traffic_ops/app/lib/Connection/RiakAdapter.pm
@@ -96,12 +96,10 @@ sub put {
 	my $value        = shift || confess("Supply a value");
 	my $content_type = shift || 'application/json';
 
-	$ua->default_header( 'Content-Type' => $content_type );
-
 	my $key_uri = $self->get_key_uri( $bucket, $key );
 	my $fqdn = $self->get_url($key_uri);
 
-	return $ua->put( $fqdn, Content => $value );
+	return $ua->put( $fqdn, Content => $value, 'Content-Type'=> $content_type );
 }
 
 sub delete {


### PR DESCRIPTION
Changed the Riak Adapter to set the Content-Type as part of the request instead of using default_header.  This fixes [TC-38](https://issues.apache.org/jira/browse/TC-38).