### PR TITLE
PSQL - fix migration

### DIFF
--- a/traffic_ops/app/db/migrations/20160910092026_fix_column_types.sql
+++ b/traffic_ops/app/db/migrations/20160910092026_fix_column_types.sql
@@ -8,9 +8,8 @@ ALTER TABLE cachegroup ALTER COLUMN longitude TYPE numeric;
 ALTER TABLE cdn
   ALTER COLUMN dnssec_enabled DROP DEFAULT,
 	ALTER COLUMN dnssec_enabled TYPE boolean
-		USING CASE WHEN dnssec_enabled = 0 THEN FALSE
-			WHEN dnssec_enabled = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN dnssec_enabled = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN dnssec_enabled SET DEFAULT FALSE;
 
@@ -20,99 +19,80 @@ ALTER TABLE deliveryservice ALTER COLUMN miss_long                    TYPE numer
 ALTER TABLE deliveryservice
   ALTER COLUMN active DROP DEFAULT,
 	ALTER COLUMN active TYPE boolean
-		USING CASE WHEN active = 0 THEN FALSE
-			WHEN active = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN active = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN active SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
   ALTER COLUMN signed DROP DEFAULT,
 	ALTER COLUMN signed TYPE boolean
-		USING CASE WHEN signed = 0 THEN FALSE
-			WHEN signed = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN signed = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN signed SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
   ALTER COLUMN ipv6_routing_enabled DROP DEFAULT,
 	ALTER COLUMN ipv6_routing_enabled TYPE boolean
-		USING CASE WHEN ipv6_routing_enabled = 0 THEN FALSE
-			WHEN ipv6_routing_enabled = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN ipv6_routing_enabled = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN ipv6_routing_enabled SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
   ALTER COLUMN multi_site_origin DROP DEFAULT,
 	ALTER COLUMN multi_site_origin TYPE boolean
-		USING CASE WHEN multi_site_origin = 0 THEN FALSE
-			WHEN multi_site_origin = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN multi_site_origin = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN multi_site_origin SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
   ALTER COLUMN regional_geo_blocking DROP DEFAULT,
 	ALTER COLUMN regional_geo_blocking TYPE boolean
-		USING CASE WHEN regional_geo_blocking = 0 THEN FALSE
-			WHEN regional_geo_blocking = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN regional_geo_blocking = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN regional_geo_blocking SET DEFAULT FALSE;
 
 ALTER TABLE deliveryservice
   ALTER COLUMN logs_enabled DROP DEFAULT,
 	ALTER COLUMN logs_enabled TYPE boolean
-		USING CASE WHEN logs_enabled = 0 THEN FALSE
-			WHEN logs_enabled = 1 THEN TRUE
-			ELSE NULL
-			END,
-  ALTER COLUMN logs_enabled SET DEFAULT FALSE;
-
-ALTER TABLE goose_db_version
-  ALTER COLUMN is_applied DROP DEFAULT,
-	ALTER COLUMN is_applied TYPE boolean
-		USING CASE WHEN is_applied = 0 THEN FALSE
-			WHEN is_applied = 1 THEN TRUE
+		USING CASE WHEN logs_enabled = 1 THEN TRUE
 			ELSE FALSE
 			END,
-  ALTER COLUMN is_applied SET DEFAULT FALSE;
+  ALTER COLUMN logs_enabled SET DEFAULT FALSE;
 
 ALTER TABLE parameter
   ALTER COLUMN secure DROP DEFAULT,
 	ALTER COLUMN secure TYPE boolean
-		USING CASE WHEN secure = 0 THEN FALSE
-			WHEN secure = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN secure = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN secure SET DEFAULT FALSE;
 
 ALTER TABLE server
   ALTER COLUMN upd_pending DROP DEFAULT,
 	ALTER COLUMN upd_pending TYPE boolean
-		USING CASE WHEN upd_pending = 0 THEN FALSE
-			WHEN upd_pending = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN upd_pending = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN upd_pending SET DEFAULT FALSE;
 
 ALTER TABLE tm_user
   ALTER COLUMN new_user DROP DEFAULT,
 	ALTER COLUMN new_user TYPE boolean
-		USING CASE WHEN new_user = 0 THEN FALSE
-			WHEN new_user = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN new_user = 1 THEN TRUE
+			ELSE FALSE
 			END,
   ALTER COLUMN new_user SET DEFAULT FALSE;
 
 ALTER TABLE to_extension
   ALTER COLUMN isactive DROP DEFAULT,
 	ALTER COLUMN isactive TYPE boolean
-		USING CASE WHEN isactive = 0 THEN FALSE
-			WHEN isactive = 1 THEN TRUE
-			ELSE NULL
+		USING CASE WHEN isactive = 1 THEN TRUE
+			ELSE FALSE
 			END,
     ALTER COLUMN isactive SET DEFAULT FALSE;
 
@@ -166,12 +146,6 @@ ALTER TABLE deliveryservice
 	ALTER COLUMN logs_enabled TYPE SMALLINT
    USING CASE WHEN logs_enabled THEN 1 ELSE 0 END,
   ALTER COLUMN logs_enabled SET DEFAULT 0;
-
-ALTER TABLE goose_db_version
-  ALTER COLUMN is_applied DROP DEFAULT,
-	ALTER COLUMN is_applied TYPE SMALLINT
-   USING CASE WHEN is_applied THEN 1 ELSE 0 END,
-  ALTER COLUMN is_applied SET DEFAULT 0;
 
 ALTER TABLE parameter
   ALTER COLUMN secure DROP DEFAULT,


### PR DESCRIPTION
psql migration needs to work when no data is loaded. i.e. during --env=test where data is loaded by fixtures after