### PR TITLE
[TC-7] use mysql 5.5 for conversion; use env_file in docker-compose

### DIFF
--- a/traffic_ops/app/db/pg-migration/Dockerfile-mysql
+++ b/traffic_ops/app/db/pg-migration/Dockerfile-mysql
@@ -11,7 +11,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-FROM mysql:5.6
+FROM mysql:5.5
 
 MAINTAINER Dan Kirkwood
 

--- a/traffic_ops/app/db/pg-migration/dataimport.env
+++ b/traffic_ops/app/db/pg-migration/dataimport.env
@@ -1,3 +1,4 @@
+#!/bin/bash -x
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -11,14 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-version: '2'
 
-services:
-  postgres_host:
-    build:
-      context: ..
-      dockerfile: pg-migration/Dockerfile-postgres
-    env_file:
-      - postgres.env
-    ports:
-      - 5432
+TO_SERVER=http://traffic_ops.example.com
+TO_USER=to_user
+TO_PASSWORD=twelve
+

--- a/traffic_ops/app/db/pg-migration/dataimport.env
+++ b/traffic_ops/app/db/pg-migration/dataimport.env
@@ -1,4 +1,3 @@
-#!/bin/bash -x
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-
 TO_SERVER=http://traffic_ops.example.com
 TO_USER=to_user
 TO_PASSWORD=twelve

--- a/traffic_ops/app/db/pg-migration/dataimport.yml
+++ b/traffic_ops/app/db/pg-migration/dataimport.yml
@@ -20,7 +20,5 @@ services:
         context: .
         dockerfile: Dockerfile-traffic_ops-client
     restart: "no"
-    environment:
-      - TO_USER
-      - TO_PASSWORD
-      - TO_SERVER
+    env_file:
+      - dataimport.env

--- a/traffic_ops/app/db/pg-migration/docker-compose.yml
+++ b/traffic_ops/app/db/pg-migration/docker-compose.yml
@@ -43,10 +43,6 @@ services:
     extends:
       service: postgres_host
       file: postgres_host.yml
-    environment:
-      - POSTGRES_DB=traffic_ops
-      - POSTGRES_PASSWORD=twelve
-      - POSTGRES_USER=traffic_ops
     depends_on:
       - mysql
     volumes:

--- a/traffic_ops/app/db/pg-migration/mysql.env
+++ b/traffic_ops/app/db/pg-migration/mysql.env
@@ -1,4 +1,3 @@
-#!/bin/bash -x
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-
 MYSQL_DATABASE=traffic_ops_db
 MYSQL_HOST=mysql
 MYSQL_RANDOM_ROOT_PASSWORD=yes

--- a/traffic_ops/app/db/pg-migration/postgres.env
+++ b/traffic_ops/app/db/pg-migration/postgres.env
@@ -1,4 +1,3 @@
-#!/bin/bash -x
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-
 POSTGRES_HOST=postgres
 POSTGRES_DB=traffic_ops
 POSTGRES_PASSWORD=twelve


### PR DESCRIPTION
mysql 5.6 has trouble initializing..   Recommendation on the web is use 5.5 -- not really relevant which we use for this conversion.  And env vars better handled in env_file for docker