### PR TITLE
[TC-83] make sure parent process will wait child exit before fork

### DIFF
--- a/traffic_ops/app/lib/UI/Utils.pm
+++ b/traffic_ops/app/lib/UI/Utils.pm
@@ -384,6 +384,7 @@ sub rascal_hosts_by_cdn {
 
 sub exec_command {
 	my ( $class, $command, @args ) = @_;
+	$SIG{CHLD} = 'DEFAULT';
 	my $pid    = fork();
 	my $result = 0;
 


### PR DESCRIPTION
In every 5 minutes, "GET /internal/api/1.2/cdns/dnsseckeys/refresh.json" will be triggered, and code in "sub dnssec_keys_refresh" will call "$self->daemonize();".

Code in "daemonize()" will make "$SIG{CHLD} = 'IGNORE';", which causes child process automatically reaped. And "wait" in parent process will fail with return code -1.

And traffic_ops have a group of child processes to process UI/API http requests. So after several hours almost all those child processes will set CHLD handler to "IGNORE". Issue TC-83 will be triggered then.