### PR TITLE
get dnssec from old-releases dir

### DIFF
--- a/traffic_router/build/build_rpm.sh
+++ b/traffic_router/build/build_rpm.sh
@@ -36,7 +36,7 @@ function installDnsSec {
 	local dnssecversion=0.12
 	local dnssectools=jdnssec-tools
 	local dnssec="$dnssectools-$dnssecversion"
-	local dnssecurl=http://www.verisignlabs.com/dnssec-tools/packages
+	local dnssecurl=http://www.verisignlabs.com/dnssec-tools/packages/old-releases
 
 	curl -o "$dnssec".tar.gz "$dnssecurl/$dnssec".tar.gz || \
 		{ echo "Could not download required $dnssec library: $?"; exit 1; }


### PR DESCRIPTION
for 1.8.0 -- dnssec made a new release 0.13.   The version we have been using is 0.12, which was moved to old-releases directory.

Referencing that directory for download until the new version is evaluated or dnssec is removed.