### PR TITLE
Fix TC-44: TR fd leak observed when new HTTPS DS is added without cert

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
@@ -170,15 +170,6 @@ public class ConfigHandler {
 					} catch (InterruptedException e) {
 						LOGGER.warn("Failed to notify certificates publisher we're waiting for certificates", e);
 					}
-
-					while (!cancelled.get() && !publishStatusQueue.isEmpty()) {
-						try {
-							LOGGER.info("Waiting for https certificates to support new config " + String.format("%x", publishStatusQueue.hashCode()));
-							Thread.sleep(1000L);
-						} catch (Throwable t) {
-							LOGGER.warn("Interrupted while waiting for status on publishing ssl certs", t);
-						}
-					}
 				}
 
 				if (cancelled.get()) {


### PR DESCRIPTION
@dneuman64 @trevorackerman Could you help to review? thanks.

The RC is that the certificate waiting loop blocks the threads which shall process the HTTP responses from TM.
More details for RC at : https://issues.apache.org/jira/browse/TC-44

The fix is to avoid the waiting loop. Thus all the CrConfig will be loaded even if there is an HTTPS delivery service which does not have cert/key. For such a DS, TR will close the TCP connection when a request comes in. 

At Slack, I got from David that not loading a CrConfig for no cert HTTPS DS is to be consistent with the behavior of DNSSEC. But loading the CrConfig for such a DS does not seem to affect much as the requests to this DS still got banned. Could you help to comment?