### PR TITLE
fix the issue failed to delete sslkeys by TrafficOps API

### DIFF
--- a/traffic_ops/app/lib/Connection/RiakAdapter.pm
+++ b/traffic_ops/app/lib/Connection/RiakAdapter.pm
@@ -111,7 +111,7 @@ sub delete {
 	my $key     = shift || confess("Supply a key");
 	my $key_uri = $self->get_key_uri( $bucket, $key );
 	my $key_ctx = $self->get_url($key_uri);
-	return $ua->delete( $self->get_url($key_ctx) );
+	return $ua->delete( $self->$key_ctx );
 }
 
 sub get {


### PR DESCRIPTION
@dneuman64 
I open a issue : https://issues.apache.org/jira/browse/TC-98

1. I tried to delete SSL keys by API for Delivery Services: https001 as follows:
/api/1.1/deliveryservices/xmlId/https001/sslkeys/delete.json
2.The result was failure, the sslkey for https001 stilled in Traffic Vault.

3. The root cause is the delete function in traffic_ops/app/lib/Connection/RiakAdapter.pm