### PR TITLE
[TC-68] - to support an HA TO, regex_revalidate.config can't live on the file system

### DIFF
--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -29,7 +29,6 @@ insert into type (name, description, use_in_table) values ('CONFIG_EXTENSION', '
 insert into type (name, description, use_in_table) values ('STATISTIC_EXTENSION', 'Extension source for 12M graphs', 'to_extension') ON CONFLICT DO NOTHING;
 insert into type (name, description, use_in_table) values ('RESOLVE4', 'federation type resolve4', 'federation') ON CONFLICT DO NOTHING;
 insert into type (name, description, use_in_table) values ('RESOLVE6', 'federation type resolve6', 'federation') ON CONFLICT DO NOTHING;
-insert into parameter (name, config_file, value) values ('snapshot_dir', 'regex_revalidate.config','public/Trafficserver-Snapshots/') ON CONFLICT DO NOTHING;
 insert into parameter (name, config_file, value) values ('ttl_max_hours', 'regex_revalidate.config', '672') ON CONFLICT DO NOTHING;
 insert into parameter (name, config_file, value) values ('ttl_min_hours', 'regex_revalidate.config', '48') ON CONFLICT DO NOTHING;
 insert into parameter (name, config_file, value) values ('maxRevalDurationDays', 'regex_revalidate.config', '90') ON CONFLICT DO NOTHING;

--- a/traffic_ops/app/lib/Fixtures/Integration/Parameter.pm
+++ b/traffic_ops/app/lib/Fixtures/Integration/Parameter.pm
@@ -4167,8 +4167,8 @@ use namespace::autoclean;
 			config_file => 'plugin.config',
 		},
 	},
-	## id => 415
-	'414' => {
+	## id => 416
+	'415' => {
 			new => 'Parameter',
 			using => {
 				name => 'tld.soa.admin',

--- a/traffic_ops/app/lib/Fixtures/Integration/Parameter.pm
+++ b/traffic_ops/app/lib/Fixtures/Integration/Parameter.pm
@@ -4169,16 +4169,6 @@ use namespace::autoclean;
 	},
 	## id => 415
 	'414' => {
-		new => 'Parameter',
-		using => {
-			name => 'snapshot_dir',
-	 		config_file => 'regex_revalidate.config',
-			last_updated => '2015-12-10 15:43:46',
-			value => 'public/Trafficserver-Snapshots/',
-		},
-	},
-	## id => 416
-	'415' => {
 			new => 'Parameter',
 			using => {
 				name => 'tld.soa.admin',

--- a/traffic_ops/app/lib/Fixtures/Integration/ProfileParameter.pm
+++ b/traffic_ops/app/lib/Fixtures/Integration/ProfileParameter.pm
@@ -2134,7 +2134,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:35',
-			parameter => '436',
+			parameter => '435',
 			profile => '8',
  		},
 	},
@@ -2182,7 +2182,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:27',
-			parameter => '444',
+			parameter => '443',
 			profile => '8',
  		},
 	},
@@ -2190,7 +2190,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:22',
-			parameter => '439',
+			parameter => '438',
 			profile => '8',
  		},
 	},
@@ -2242,7 +2242,6 @@ my %definition_for = (
 			profile => '8',
  		},
 	},
-########
 	'278' => {
  		new => 'ProfileParameter',
  		using => {
@@ -4295,7 +4294,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:12',
-			parameter => '436',
+			parameter => '435',
 			profile => '16',
  		},
 	},
@@ -4328,7 +4327,7 @@ my %definition_for = (
  		using => {
 			profile => '16',
 			last_updated => '2015-12-10 15:44:18',
-			parameter => '439',
+			parameter => '438',
  		},
 	},
 	'540' => {
@@ -4387,7 +4386,6 @@ my %definition_for = (
 			profile => '16',
  		},
 	},
-########
 	'547' => {
  		new => 'ProfileParameter',
  		using => {
@@ -4528,7 +4526,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:21',
-			parameter => '422',
+			parameter => '421',
 			profile => '1',
  		},
 	},
@@ -4536,14 +4534,14 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:11',
-			parameter => '425',
+			parameter => '424',
 			profile => '1',
  		},
 	},
 	'566' => {
  		new => 'ProfileParameter',
  		using => {
-			parameter => '421',
+			parameter => '420',
 			profile => '1',
 			last_updated => '2015-12-10 15:44:09',
  		},
@@ -4553,14 +4551,14 @@ my %definition_for = (
  		using => {
 			profile => '1',
 			last_updated => '2015-12-10 15:44:32',
-			parameter => '423',
+			parameter => '422',
  		},
 	},
 	'568' => {
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:11',
-			parameter => '417',
+			parameter => '416',
 			profile => '1',
  		},
 	},
@@ -4568,7 +4566,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:02',
-			parameter => '418',
+			parameter => '417',
 			profile => '1',
  		},
 	},
@@ -4576,7 +4574,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:19',
-			parameter => '416',
+			parameter => '415',
 			profile => '1',
  		},
 	},
@@ -4584,7 +4582,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:33',
-			parameter => '420',
+			parameter => '419',
 			profile => '1',
  		},
 	},
@@ -4592,7 +4590,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:16',
-			parameter => '419',
+			parameter => '418',
 			profile => '1',
  		},
 	},
@@ -4620,12 +4618,11 @@ my %definition_for = (
 			profile => '1',
  		},
 	},
-########
 	'576' => {
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:18',
-			parameter => '435',
+			parameter => '434',
 			profile => '12',
  		},
 	},
@@ -4633,7 +4630,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:32',
-			parameter => '434',
+			parameter => '433',
 			profile => '12',
  		},
 	},
@@ -4641,7 +4638,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:06',
-			parameter => '430',
+			parameter => '429',
 			profile => '12',
  		},
 	},
@@ -4649,7 +4646,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:35',
-			parameter => '432',
+			parameter => '431',
 			profile => '12',
  		},
 	},
@@ -4657,7 +4654,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:09',
-			parameter => '431',
+			parameter => '430',
 			profile => '12',
  		},
 	},
@@ -4665,7 +4662,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:35',
-			parameter => '440',
+			parameter => '439',
 			profile => '12',
  		},
 	},
@@ -4673,11 +4670,10 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:28',
-			parameter => '441',
+			parameter => '440',
 			profile => '12',
  		},
 	},
-########
 	'583' => {
  		new => 'ProfileParameter',
  		using => {
@@ -4818,14 +4814,14 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:12',
-			parameter => '422',
+			parameter => '421',
 			profile => '2',
  		},
 	},
 	'601' => {
  		new => 'ProfileParameter',
  		using => {
-			parameter => '421',
+			parameter => '420',
 			profile => '2',
 			last_updated => '2015-12-10 15:44:04',
  		},
@@ -4834,7 +4830,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:32',
-			parameter => '417',
+			parameter => '416',
 			profile => '2',
  		},
 	},
@@ -4843,14 +4839,14 @@ my %definition_for = (
  		using => {
 			profile => '2',
 			last_updated => '2015-12-10 15:44:30',
-			parameter => '418',
+			parameter => '417',
  		},
 	},
 	'604' => {
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:18',
-			parameter => '416',
+			parameter => '415',
 			profile => '2',
  		},
 	},
@@ -4858,7 +4854,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:02',
-			parameter => '420',
+			parameter => '419',
 			profile => '2',
  		},
 	},
@@ -4866,7 +4862,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:36',
-			parameter => '419',
+			parameter => '418',
 			profile => '2',
  		},
 	},
@@ -4874,7 +4870,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:23',
-			parameter => '424',
+			parameter => '423',
 			profile => '2',
  		},
 	},
@@ -4898,7 +4894,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:34',
-			parameter => '426',
+			parameter => '425',
 			profile => '2',
  		},
 	},
@@ -4910,7 +4906,6 @@ my %definition_for = (
 			profile => '2',
  		},
 	},
-########
 	'612' => {
  		new => 'ProfileParameter',
  		using => {
@@ -4923,14 +4918,14 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:14',
-			parameter => '427',
+			parameter => '426',
 			profile => '19',
  		},
 	},
 	'614' => {
  		new => 'ProfileParameter',
  		using => {
-			parameter => '428',
+			parameter => '427',
 			profile => '19',
 			last_updated => '2015-12-10 15:44:18',
  		},
@@ -4939,7 +4934,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:15',
-			parameter => '429',
+			parameter => '428',
 			profile => '19',
  		},
 	},
@@ -4948,7 +4943,7 @@ my %definition_for = (
  		using => {
 			profile => '19',
 			last_updated => '2015-12-10 15:44:29',
-			parameter => '433',
+			parameter => '432',
  		},
 	},
 	'617' => {
@@ -4991,7 +4986,6 @@ my %definition_for = (
 			profile => '19',
  		},
 	},
-########
 	'622' => {
  		new => 'ProfileParameter',
  		using => {
@@ -5004,7 +4998,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:12',
-			parameter => '427',
+			parameter => '426',
 			profile => '20',
  		},
 	},
@@ -5012,7 +5006,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:31',
-			parameter => '428',
+			parameter => '427',
 			profile => '20',
  		},
 	},
@@ -5020,7 +5014,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:07',
-			parameter => '429',
+			parameter => '428',
 			profile => '20',
  		},
 	},
@@ -5028,7 +5022,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:18',
-			parameter => '433',
+			parameter => '432',
 			profile => '20',
  		},
 	},
@@ -5072,7 +5066,6 @@ my %definition_for = (
 			profile => '20',
  		},
 	},
-########
 	'632' => {
  		new => 'ProfileParameter',
  		using => {
@@ -7229,7 +7222,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:25',
-			parameter => '436',
+			parameter => '435',
 			profile => '6',
  		},
 	},
@@ -7276,7 +7269,7 @@ my %definition_for = (
 	'908' => {
  		new => 'ProfileParameter',
  		using => {
-			parameter => '443',
+			parameter => '442',
 			profile => '6',
 			last_updated => '2015-12-10 15:44:19',
  		},
@@ -7285,7 +7278,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:01',
-			parameter => '438',
+			parameter => '437',
 			profile => '6',
  		},
 	},
@@ -7433,7 +7426,6 @@ my %definition_for = (
 			profile => '6',
  		},
 	},
-########
 	'928' => {
  		new => 'ProfileParameter',
  		using => {
@@ -9726,7 +9718,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:24',
-			parameter => '436',
+			parameter => '435',
 			profile => '3',
  		},
 	},
@@ -9774,7 +9766,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:12',
-			parameter => '443',
+			parameter => '442',
 			profile => '3',
  		},
 	},
@@ -9782,7 +9774,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:34',
-			parameter => '438',
+			parameter => '437',
 			profile => '3',
  		},
 	},
@@ -9898,7 +9890,6 @@ my %definition_for = (
 			last_updated => '2015-12-10 15:44:04',
  		},
 	},
-########
 	'1237' => {
  		new => 'ProfileParameter',
  		using => {
@@ -11992,7 +11983,7 @@ my %definition_for = (
  		using => {
 			profile => '14',
 			last_updated => '2015-12-10 15:44:12',
-			parameter => '436',
+			parameter => '435',
  		},
 	},
 	'1500' => {
@@ -12023,7 +12014,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:10',
-			parameter => '438',
+			parameter => '437',
 			profile => '14',
  		},
 	},
@@ -12131,7 +12122,6 @@ my %definition_for = (
 			profile => '14',
  		},
 	},
-########
 	'1517' => {
  		new => 'ProfileParameter',
  		using => {
@@ -14272,7 +14262,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:14',
-			parameter => '436',
+			parameter => '435',
 			profile => '9',
  		},
 	},
@@ -14320,7 +14310,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:30',
-			parameter => '443',
+			parameter => '442',
 			profile => '9',
  		},
 	},
@@ -14328,7 +14318,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:25',
-			parameter => '438',
+			parameter => '437',
 			profile => '9',
  		},
 	},
@@ -14444,7 +14434,6 @@ my %definition_for = (
 			profile => '9',
  		},
 	},
-########
 	'1807' => {
  		new => 'ProfileParameter',
  		using => {
@@ -16585,7 +16574,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:33',
-			parameter => '436',
+			parameter => '435',
 			profile => '10',
  		},
 	},
@@ -16633,7 +16622,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:14',
-			parameter => '443',
+			parameter => '442',
 			profile => '10',
  		},
 	},
@@ -16641,7 +16630,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:08',
-			parameter => '438',
+			parameter => '437',
 			profile => '10',
  		},
 	},
@@ -16797,7 +16786,6 @@ my %definition_for = (
 			last_updated => '2015-12-10 15:44:28',
  		},
 	},
-########
 	'2102' => {
  		new => 'ProfileParameter',
  		using => {
@@ -18858,7 +18846,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:00',
-			parameter => '436',
+			parameter => '435',
 			profile => '7',
  		},
 	},
@@ -18970,7 +18958,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:22',
-			parameter => '437',
+			parameter => '436',
 			profile => '7',
  		},
 	},
@@ -19083,7 +19071,7 @@ my %definition_for = (
  		using => {
 			profile => '7',
 			last_updated => '2015-12-10 15:44:27',
-			parameter => '442',
+			parameter => '441',
  		},
 	},
 	'2389' => {
@@ -19230,7 +19218,6 @@ my %definition_for = (
 			profile => '7',
  		},
 	},
-########
 	'2407' => {
  		new => 'ProfileParameter',
  		using => {
@@ -21427,7 +21414,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:25',
-			parameter => '436',
+			parameter => '435',
 			profile => '4',
  		},
 	},
@@ -21540,7 +21527,7 @@ my %definition_for = (
  		using => {
 			profile => '4',
 			last_updated => '2015-12-10 15:44:13',
-			parameter => '437',
+			parameter => '436',
  		},
 	},
 	'2697' => {
@@ -21651,7 +21638,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:11',
-			parameter => '442',
+			parameter => '441',
 			profile => '4',
  		},
 	},
@@ -21767,7 +21754,6 @@ my %definition_for = (
 			last_updated => '2015-12-10 15:44:30',
  		},
 	},
-########
 	'2725' => {
  		new => 'ProfileParameter',
  		using => {
@@ -23771,7 +23757,7 @@ my %definition_for = (
 	'2976' => {
  		new => 'ProfileParameter',
  		using => {
-			parameter => '436',
+			parameter => '435',
 			profile => '15',
 			last_updated => '2015-12-10 15:44:16',
  		},
@@ -23876,7 +23862,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:13',
-			parameter => '437',
+			parameter => '436',
 			profile => '15',
  		},
 	},
@@ -24072,7 +24058,6 @@ my %definition_for = (
 			parameter => '37',
  		},
 	},
-########
 	'3014' => {
  		new => 'ProfileParameter',
  		using => {
@@ -26092,7 +26077,7 @@ my %definition_for = (
 	'3267' => {
  		new => 'ProfileParameter',
  		using => {
-			parameter => '436',
+			parameter => '435',
 			profile => '13',
 			last_updated => '2015-12-10 15:44:27',
  		},
@@ -26197,7 +26182,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:12',
-			parameter => '437',
+			parameter => '436',
 			profile => '13',
  		},
 	},
@@ -26401,7 +26386,6 @@ my %definition_for = (
 			profile => '13',
  		},
 	},
-########
 	'3306' => {
  		new => 'ProfileParameter',
  		using => {
@@ -26498,7 +26482,6 @@ my %definition_for = (
 			profile => '22',
  		},
 	},
-########
 	'3318' => {
  		new => 'ProfileParameter',
  		using => {
@@ -28552,7 +28535,7 @@ my %definition_for = (
  		using => {
 			profile => '11',
 			last_updated => '2015-12-10 15:44:06',
-			parameter => '436',
+			parameter => '435',
  		},
 	},
 	'3576' => {
@@ -28671,7 +28654,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:35',
-			parameter => '437',
+			parameter => '436',
 			profile => '11',
  		},
 	},
@@ -28783,7 +28766,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:20',
-			parameter => '442',
+			parameter => '441',
 			profile => '11',
  		},
 	},
@@ -28931,7 +28914,6 @@ my %definition_for = (
 			parameter => '382',
  		},
 	},
-########
 	'3623' => {
  		new => 'ProfileParameter',
  		using => {
@@ -31048,7 +31030,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:00',
-			parameter => '436',
+			parameter => '435',
 			profile => '5',
  		},
 	},
@@ -31161,7 +31143,7 @@ my %definition_for = (
  		using => {
 			profile => '5',
 			last_updated => '2015-12-10 15:44:22',
-			parameter => '437',
+			parameter => '436',
  		},
 	},
 	'3903' => {
@@ -31272,7 +31254,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:17',
-			parameter => '442',
+			parameter => '441',
 			profile => '5',
  		},
 	},
@@ -31492,7 +31474,6 @@ my %definition_for = (
 			profile => '5',
  		},
 	},
-########
 	'3944' => {
  		new => 'ProfileParameter',
  		using => {
@@ -31633,7 +31614,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:02',
-			parameter => '422',
+			parameter => '421',
 			profile => '21',
  		},
 	},
@@ -31641,14 +31622,14 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:28',
-			parameter => '421',
+			parameter => '420',
 			profile => '21',
  		},
 	},
 	'3963' => {
  		new => 'ProfileParameter',
  		using => {
-			parameter => '417',
+			parameter => '416',
 			profile => '21',
 			last_updated => '2015-12-10 15:44:09',
  		},
@@ -31657,7 +31638,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:09',
-			parameter => '418',
+			parameter => '417',
 			profile => '21',
  		},
 	},
@@ -31665,7 +31646,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:29',
-			parameter => '416',
+			parameter => '415',
 			profile => '21',
  		},
 	},
@@ -31673,7 +31654,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:20',
-			parameter => '420',
+			parameter => '419',
 			profile => '21',
  		},
 	},
@@ -31682,14 +31663,14 @@ my %definition_for = (
  		using => {
 			profile => '21',
 			last_updated => '2015-12-10 15:44:08',
-			parameter => '419',
+			parameter => '418',
  		},
 	},
 	'3968' => {
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:23',
-			parameter => '424',
+			parameter => '423',
 			profile => '21',
  		},
 	},
@@ -31713,7 +31694,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:06',
-			parameter => '426',
+			parameter => '425',
 			profile => '21',
  		},
 	},
@@ -31725,7 +31706,6 @@ my %definition_for = (
 			last_updated => '2015-12-10 15:44:13',
  		},
 	},
-########
 	'3973' => {
  		new => 'ProfileParameter',
  		using => {
@@ -31738,11 +31718,10 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:25',
-			parameter => '445',
+			parameter => '444',
 			profile => '17',
  		},
 	},
-########
 	'3975' => {
  		new => 'ProfileParameter',
  		using => {
@@ -31755,7 +31734,7 @@ my %definition_for = (
  		new => 'ProfileParameter',
  		using => {
 			last_updated => '2015-12-10 15:44:19',
-			parameter => '445',
+			parameter => '444',
 			profile => '18',
  		},
 	},

--- a/traffic_ops/app/lib/Fixtures/Parameter.pm
+++ b/traffic_ops/app/lib/Fixtures/Parameter.pm
@@ -551,15 +551,6 @@ my %definition_for = (
 			value       => 'INT 33554432',
 		},
 	},
-	'regex_revalidate.config_snapshot_dir' => {
-		new   => 'Parameter',
-		using => {
-			id          => 62,
-			name        => 'snapshot_dir',
-			config_file => 'regex_revalidate.config',
-			value       => 'public/Trafficserver-Snapshots/',
-		},
-	},
 	'regex_revalidate.config_max_days' => {
 		new   => 'Parameter',
 		using => {

--- a/traffic_ops/app/lib/UI/Job.pm
+++ b/traffic_ops/app/lib/UI/Job.pm
@@ -166,9 +166,7 @@ sub newjob {
 			# my $ds_id =
 			# 	$self->db->resultset('Deliveryservice')->search( { xml_id => $ds_xml_id }, { prefetch => ['profile'] } )->get_column('id')->single();
 			my $rs       = $self->db->resultset('Deliveryservice')->search( { 'me.xml_id' => $ds_xml_id }, { prefetch => 'cdn' } )->single;
-			my $cdn_name = $rs->cdn->name;
 			my $ds_id    = $rs->id;
-			$self->snapshot_regex_revalidate($cdn_name);
 
 			$self->set_update_server_bits($ds_id);
 

--- a/traffic_ops/app/t/purge.t
+++ b/traffic_ops/app/t/purge.t
@@ -171,7 +171,7 @@ $t->post_ok(
 $t->post_ok(
 	'/job/external/new' => form => {
 		keyword    => 'PURGE',
-		asset_url  => 'http://jvd.comcast.net' . $test_string,
+		asset_url  => 'http://foo.bar.net' . $test_string,
 		asset_type => 'SMOOTH'
 	}
 )->status_is(200)->json_is( '/status' => 'failure' );
@@ -224,22 +224,6 @@ $t->post_ok(
 $t->get_ok( '/job/external/result/view/' . $job_id )->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
 	->json_is( '/0/agent' => 1 )->json_is( '/0/result' => 'COMPLETED' )->json_is( '/0/description' => 'Test progressed successfully' )
 	->json_is( '/0/job' => $job_id );
-
-diag "checking snapshots...";
-foreach my $cache ( keys %{$slist} ) {
-	note "checking shapshot " . $cache . " for " . $slist->{$cache};
-	my $response = $t->ua->get( '/Trafficserver-Snapshots/' . $slist->{$cache} . '/regex_revalidate.config' );
-	my $content  = $response->res->content->asset->{content};
-	if ( $slist->{$cache} eq $cdn_name ) {
-		ok( $content =~ qr/$test_string/m, $cache . ' snapshot should have test_string in regex_revalidate.config' );
-	}
-	else {
-		# JvD note: there are mutliple delivery services that are in both CDNs but have the same origin.
-		# if ( $ds_name !~ /omg-.*/ ) {    #
-		# 	ok( $content !~ qr/$test_string/m, $cache . ' snapshot should not have test_string in regex_revalidate.config' );
-		# }
-	}
-}
 
 diag "spot checking /genfiles...";
 my $rand = 10 + int( rand(10) );    # only test every x server; there's too many, this gets too slow.

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -2156,12 +2156,7 @@ sub set_url {
 
 	return if (!defined($cfg_file_tracker->{$filename}->{'fname-in-TO'}));
 
-	if ( $filename ne "regex_revalidate.config" ) {
-		return "$traffic_ops_host\/genfiles\/view\/$hostname_short\/" . $cfg_file_tracker->{$filename}->{'fname-in-TO'};
-	}
-	else {
-		return "$traffic_ops_host\/Trafficserver-Snapshots\/$my_cdn_name\/" . $cfg_file_tracker->{$filename}->{'fname-in-TO'};
-	}
+	return "$traffic_ops_host\/genfiles\/view\/$hostname_short\/" . $cfg_file_tracker->{$filename}->{'fname-in-TO'};
 }
 
 sub scrape_unencode_text {


### PR DESCRIPTION
you'll have to use the "genfiles" route to fetch regex_revalidate.config. i.e. 

GET /genfiles/view/:host_name/regex_revalidate.config

therefore, you'll see a change to ORT in this PR.