### PR TITLE
[TC-99] api/{version}/cdns/:cdn_name/health returns the health of all…

### DIFF
--- a/traffic_ops/app/lib/API/Cdn.pm
+++ b/traffic_ops/app/lib/API/Cdn.pm
@@ -434,8 +434,14 @@ sub capacity {
 
 sub health {
 	my $self = shift;
+	my $args = {};
 
-	return $self->get_cache_health();
+	my $cdn_name = $self->param('name');
+	if (defined($cdn_name)) {
+		$args->{'cdn_name'} = $cdn_name;
+	}
+
+	return $self->get_cache_health($args);
 }
 
 sub routing {

--- a/traffic_ops/app/lib/MojoPlugins/Health.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Health.pm
@@ -159,7 +159,7 @@ sub register {
 				cachegroups  => [],
 			};
 
-			$self->app->log->debug("get_cache_health() - " . 
+			$self->app->log->trace("get_cache_health() - " . 
 				Data::Dumper->Dump([$args, [keys(%{$rascal_data})]], [qw(args rascal_keys)]));
 
 			my $cachegroup_data = {};

--- a/traffic_ops/app/lib/MojoPlugins/Health.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Health.pm
@@ -159,9 +159,6 @@ sub register {
 				cachegroups  => [],
 			};
 
-			$self->app->log->trace("get_cache_health() - " . 
-				Data::Dumper->Dump([$args, [keys(%{$rascal_data})]], [qw(args rascal_keys)]));
-
 			my $cachegroup_data = {};
 			my $capacity_data = { total => 0 };
 

--- a/traffic_ops/app/lib/MojoPlugins/Health.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Health.pm
@@ -159,6 +159,9 @@ sub register {
 				cachegroups  => [],
 			};
 
+			$self->app->log->debug("get_cache_health() - " . 
+				Data::Dumper->Dump([$args, [keys(%{$rascal_data})]], [qw(args rascal_keys)]));
+
 			my $cachegroup_data = {};
 			my $capacity_data = { total => 0 };
 


### PR DESCRIPTION
… cdns

Both `/api/$version/cdns/:name/health` and `/api/$version/cdns/health`  route to `Cdn#health`. 

Problem: 
The `health` method called `get_cache_health()` without passing cdn_name as an argument, resulting with an aggregated health status.

Fix:
The `health` method extracts `:name` from request, and pass to `get_cache_health()` method