### PR TITLE
[TC-136] Fixes a logic bug that prevented the easy case for finding b…

### DIFF
--- a/traffic_server/plugins/astats_over_http/astats_over_http.c
+++ b/traffic_server/plugins/astats_over_http/astats_over_http.c
@@ -326,6 +326,8 @@ static int getSpeed(char *interface, char *buffer, int bufferSize) {
 	char *inf;
 	char b[256];
 	int speed = 0;
+	int i = 0;
+	const char *fnames[] = {"slave_", "lower_"};
 
 	if (!interface)
 		return 0;
@@ -333,7 +335,7 @@ static int getSpeed(char *interface, char *buffer, int bufferSize) {
 	str = getFile("/sys/class/net/bonding_masters", buffer, bufferSize);
 	if (str) {
 		str = strstr(str, interface);
-		if (!str)
+		if (str)
 			return getSpeedForIF(interface, buffer, bufferSize);
 	}
 
@@ -342,10 +344,13 @@ static int getSpeed(char *interface, char *buffer, int bufferSize) {
 
 	if (dp != NULL) {
 		while ((ep = readdir (dp))) {
-			str = strstr(ep->d_name, "slave_");
-			if (str) {
-				inf = str + strlen("slave_");
-				speed += getSpeedForIF (inf, buffer, bufferSize);
+			for (i = 0; i < sizeof(fnames)/sizeof(fnames[0]); i++) {
+				str = strstr(ep->d_name, fnames[i]);
+				if (str) {
+					inf = str + strlen(fnames[i]);
+					speed += getSpeedForIF (inf, buffer, bufferSize);
+					break; // in case we happen to have slave_ and lower_ for some odd reason
+				}
 			}
 		}
 

--- a/traffic_server/plugins/astats_over_http/astats_over_http.c
+++ b/traffic_server/plugins/astats_over_http/astats_over_http.c
@@ -297,29 +297,6 @@ static int getSpeedForIF(char *inf, char *buffer, int bufferSize) {
 }
 
 static int getSpeed(char *interface, char *buffer, int bufferSize) {
-	//  List<String> interfaces = new ArrayList<String>();
-	//  String str = getFile("/sys/class/net/bonding_masters");
-	//  if(str !=null && str.contains(myInterface)) {
-	//          String base = "/sys/class/net/"+myInterface+"/";
-	//          File directory = new File(base);
-	//          String[] children = directory.list();
-	//          for(String child : children) {
-	//                  if(child.contains("slave_")) {
-	//                          child = child.replace("slave_", "");
-	//                          interfaces.add(child);
-	//                  }
-	//          }
-	//  } else {
-	//          interfaces.add(myInterface);
-	//  }
-
-	//  for(String ifName : interfaces) {
-	//          str = getFile("/sys/class/net/" +ifName+ "/operstate");
-	//          if(str.contains("up")) {
-	//                  str = getFile("/sys/class/net/" +ifName+ "/speed");
-	//                  result.speed += Long.parseLong(str.trim());
-	//          }
-	//  }
 	DIR *dp;
 	struct dirent *ep;
 	char *str;

--- a/traffic_server/plugins/astats_over_http/astats_over_http.spec
+++ b/traffic_server/plugins/astats_over_http/astats_over_http.spec
@@ -19,13 +19,13 @@
 %global install_prefix "/opt"
 
 Name:		astats_over_http
-Version:	1.1.0
+Version:	1.2
 Release:	1%{?dist}
 Summary:	Apache Traffic Server %{name} plugin
 Vendor:		Comcast
 Group:		Applications/Communications
 License:	Apache License, Version 2.0
-URL:		https://github.com/Comcast/traffic_control/tree/master/traffic_server/plugins/astats_over_http
+URL:		https://github.com/apache/incubator-trafficcontrol/tree/master/traffic_server/plugins/astats_over_http
 Source0:	%{name}.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Requires:	trafficserver = 5.2.0
@@ -35,7 +35,7 @@ BuildRequires:	trafficserver = 5.2.0
 Apache Traffic Server plugin
 
 %prep
-%setup -n %{name}
+%setup -q -n %{name}
 
 %build
 %{install_prefix}/trafficserver/bin/tsxs -v -c %{name}.c -o %{name}.so


### PR DESCRIPTION
…ond speed, and handle the case where the CentOS 7.3 3.10.0-514 kernel uses lower_X as a pointer to enslaved interfaces, while retaining the slave_X case from earlier kernels.