### PR TITLE
[TC-142] Fixed configuration in traffic_ops/app/conf/production/influxdb.conf

### DIFF
--- a/traffic_ops/app/conf/production/influxdb.conf
+++ b/traffic_ops/app/conf/production/influxdb.conf
@@ -1,6 +1,6 @@
 {
 	"user": "influxuser",
 	"password": "password",
-   "delivery_stats_db_name":"delivery_stats",
-   "cache_stats_db_name":"cache_stats"
+	"deliveryservice_stats_db_name": "deliveryservice_stats",
+	"cache_stats_db_name": "cache_stats"
 }


### PR DESCRIPTION
The bug prevented graphs from being shows in the portal, on production systems.

Now this file is consistent with it's sibling in test/ and development/.