### PR TITLE
[TC-132] Fix proper RP for sync

### DIFF
--- a/traffic_stats/influxdb_tools/sync/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync/sync_ts_databases.go
@@ -184,7 +184,7 @@ func syncCacheStat(sourceClient influx.Client, targetClient influx.Client, statN
 		RetentionPolicy: "monthly",
 	})
 
-	queryString := fmt.Sprintf("select time, cdn, hostname, type, value from \"%s\".\"%s\"", rp, statName)
+	queryString := fmt.Sprintf("select time, cdn, hostname, type, value from \"%s\".\"%s\"", "monthly", statName)
 
 	if days > 0 {
 		queryString = fmt.Sprintf("%s where time > now() - %dd", queryString, days)
@@ -254,7 +254,7 @@ func syncDeliveryServiceStat(sourceClient influx.Client, targetClient influx.Cli
 		RetentionPolicy: rp,
 	})
 
-	queryString := fmt.Sprintf("select time, cachegroup, cdn, deliveryservice, value from \"monthly\".\"%s\"", statName)
+	queryString := fmt.Sprintf("select time, cachegroup, cdn, deliveryservice, value from \"%s\".\"%s\"", rp, statName)
 	if days > 0 {
 		queryString = fmt.Sprintf("%s where time > now() - %dd", queryString, days)
 	}

--- a/traffic_stats/influxdb_tools/sync/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync/sync_ts_databases.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/apache/incubator-trafficcontrol/traffic_stats/influxdb"
@@ -176,16 +177,24 @@ func syncDailyDb(ch chan string, sourceClient influx.Client, targetClient influx
 func syncCacheStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
 	//get records from source DB
 	db := cache
+	rp := "monthly"
+
+	if strings.Contains(statName, "1day") {
+		rp = "indefinite"
+	}
+
 	bps, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
 		Database:        db,
 		Precision:       "ms",
-		RetentionPolicy: "monthly",
+		RetentionPolicy: rp,
 	})
 
-	queryString := fmt.Sprintf("select time, cdn, hostname, type, value from \"monthly\".\"%s\"", statName)
+	queryString := fmt.Sprintf("select time, cdn, hostname, type, value from \"%s\".\"%s\"", rp, statName)
+
 	if days > 0 {
 		queryString = fmt.Sprintf("%s where time > now() - %dd", queryString, days)
 	}
+
 	fmt.Println("queryString ", queryString)
 	res, err := queryDB(sourceClient, queryString, db)
 	if err != nil {
@@ -298,8 +307,9 @@ func syncDailyStat(sourceClient influx.Client, targetClient influx.Client, statN
 
 	db := daily
 	bps, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
-		Database:  db,
-		Precision: "s",
+		Database:        db,
+		Precision:       "s",
+		RetentionPolicy: "indefinite",
 	})
 	//get records from source DB
 	queryString := fmt.Sprintf("select time, cdn, deliveryservice, value from \"%s\"", statName)

--- a/traffic_stats/influxdb_tools/sync/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync/sync_ts_databases.go
@@ -177,16 +177,11 @@ func syncDailyDb(ch chan string, sourceClient influx.Client, targetClient influx
 func syncCacheStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
 	//get records from source DB
 	db := cache
-	rp := "monthly"
-
-	if strings.Contains(statName, "1day") {
-		rp = "indefinite"
-	}
 
 	bps, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
 		Database:        db,
 		Precision:       "ms",
-		RetentionPolicy: rp,
+		RetentionPolicy: "monthly",
 	})
 
 	queryString := fmt.Sprintf("select time, cdn, hostname, type, value from \"%s\".\"%s\"", rp, statName)
@@ -247,10 +242,16 @@ func syncCacheStat(sourceClient influx.Client, targetClient influx.Client, statN
 func syncDeliveryServiceStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
 
 	db := deliveryService
+	rp := "monthly"
+
+	if strings.Contains(statName, "1day") {
+		rp = "indefinite"
+	}
+
 	bps, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
 		Database:        db,
 		Precision:       "ms",
-		RetentionPolicy: "monthly",
+		RetentionPolicy: rp,
 	})
 
 	queryString := fmt.Sprintf("select time, cachegroup, cdn, deliveryservice, value from \"monthly\".\"%s\"", statName)


### PR DESCRIPTION
This is still very static, but does what is intended to do.
- daily_stats: Put data in indefinite instead of DEFAULT
- deliveryservice_stats: use "indefinite" source/target RP when measurement contains "1day"