### PR TITLE
Traffic Ops client bug fixes, Traffic Monitor 2.0 fixes & features

### DIFF
--- a/traffic_monitor_golang/common/poller/poller.go
+++ b/traffic_monitor_golang/common/poller/poller.go
@@ -120,6 +120,14 @@ func NewMonitorConfig(interval time.Duration) MonitorConfigPoller {
 func (p MonitorConfigPoller) Poll() {
 	tick := time.NewTicker(p.Interval)
 	defer tick.Stop()
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("MonitorConfigPoller panic: %v\n", err)
+		} else {
+			log.Errorf("MonitorConfigPoller failed without panic\n")
+		}
+		os.Exit(1) // The Monitor can't run without a MonitorConfigPoller
+	}()
 	for {
 		select {
 		case opsConfig := <-p.OpsConfigChannel:

--- a/traffic_monitor_golang/traffic_monitor/crconfig/data.go
+++ b/traffic_monitor_golang/traffic_monitor/crconfig/data.go
@@ -1,0 +1,239 @@
+package crconfig
+
+import (
+	"time"
+)
+
+// CRConfig is JSON-serializable as the CRConfig used by Traffic Control. However, it also contains diff timestamps, for the last update time of each field. These can be used to return only fields which have changed since a given time.
+type CRConfig struct {
+	Config               Config                       `json:"config,omitempty"`
+	ConfigTime           time.Time                    `json:"-"`
+	ContentServers       map[string]Server            `json:"contentServers,omitempty"`
+	ContentServersTime   map[string]time.Time         `json:"-"`
+	ContentRouters       map[string]Router            `json:"contentRouters,omitempty"`
+	ContentRoutersTime   map[string]time.Time         `json:"-"`
+	DeliveryServices     map[string]DeliveryService   `json:"deliveryServices,omitempty"`
+	DeliveryServicesTime map[string]time.Time         `json:"-"`
+	EdgeLocations        map[string]LatitudeLongitude `json:"edgeLocations,omitempty"`
+	EdgeLocationsTime    map[string]time.Time         `json:"-"`
+	Monitors             map[string]Monitor           `json:"monitors,omitempty"`
+	MonitorsTime         map[string]time.Time         `json:"-"`
+	Stats                Stats                        `json:"stats,omitempty"`
+	StatsTime            time.Time                    `json:"-"`
+}
+
+type MatchSet struct {
+	Protocol  string      `json:"protocol"`
+	MatchList []MatchType `json:"matchlist"`
+}
+
+type MatchType struct {
+	MatchType string `json:"match-type"`
+	Regex     string `json:"regex"`
+}
+
+type Config struct {
+	APICacheControlMaxAge                          *int      `json:"api.cache-control.max_age,string,omitempty"`
+	APICacheControlMaxAgeLastTime                  time.Time `json:"-"`
+	ConsistentDNSRouting                           *bool     `json:"consistent.dns.routing,string,omitempty"`
+	ConsistentDNSRoutingTime                       time.Time `json:"-"`
+	CoverageZonePollingIntervalSeconds             *int      `json:"coveragezone.polling.interval,string,omitempty"`
+	CoverageZonePollingIntervalSecondsTime         time.Time `json:"-"`
+	CoverageZonePollingURL                         *string   `json:"coveragezone.polling.url,omitempty"`
+	CoverageZonePollingURLTime                     time.Time `json:"-"`
+	DNSSecDynamicResponseExpiration                *string   `json:"dnssec.dynamic.response.expiration,omitempty"`
+	DNSSecDynamicResponseExpirationTime            time.Time `json:"-"`
+	DNSSecEnabled                                  *bool     `json:"dnssec.enabled,string,omitempty"`
+	DNSSecEnabledTime                              time.Time `json:"-"`
+	DomainName                                     *string   `json:"domain_name,omitempty"`
+	DomainNameTime                                 time.Time `json:"-"`
+	FederationMappingPollingIntervalSeconds        *int      `json:"federationmapping.polling.interval,string,omitempty"`
+	FederationMappingPollingIntervalSecondsTime    time.Time `json:"-"`
+	FederationMappingPollingURL                    *string   `json:"federationmapping.polling.url"`
+	FederationMappingPollingURLTime                time.Time `json:"-"`
+	GeoLocationPollingInterval                     *int      `json:"geolocation.polling.interval,string,omitempty"`
+	GeoLocationPollingIntervalTime                 time.Time `json:"-"`
+	GeoLocationPollingURL                          *string   `json:"geolocation.polling.url,omitempty"`
+	GeoLocationPollingURLTime                      time.Time `json:"-"`
+	KeyStoreMaintenanceIntervalSeconds             *int      `json:"keystore.maintenance.interval,string,omitempty"`
+	KeyStoreMaintenanceIntervalSecondsTime         time.Time `json:"-"`
+	NeustarPollingIntervalSeconds                  *int      `json:"neustar.polling.interval,string,omitempty"`
+	NeustarPollingIntervalSecondsTime              time.Time `json:"-"`
+	NeustarPollingURL                              *string   `json:"neustar.polling.url,omitempty"`
+	NeustarPollingURLTime                          time.Time `json:"-"`
+	SOA                                            *SOA      `json:"soa,omitempty"`
+	SOATime                                        time.Time `json:"-"`
+	DNSSecInceptionSeconds                         *int      `json:"dnssec.inception,string,omitempty"`
+	DNSSecInceptionSecondsTime                     time.Time `json:"-"`
+	Ttls                                           *TTL      `json:"ttls,omitempty"`
+	TtlsTime                                       time.Time `json:"-"`
+	Weight                                         *float64  `json:"weight,string,omitempty"`
+	WeightTime                                     time.Time `json:"-"`
+	ZoneManagerCacheMaintenanceIntervalSeconds     *int      `json:"zonemanager.cache.maintenance.interval,string,omitempty"`
+	ZoneManagerCacheMaintenanceIntervalSecondsTime time.Time `json:"-"`
+	ZoneManagerThreadpoolScale                     *float64  `json:"zonemanager.threadpool.scale,string,omitempty"`
+	ZoneManagerThreadpoolScaleTime                 time.Time `json:"-"`
+}
+
+type SOA struct {
+	Admin              *string `json:"admin,omitempty"`
+	AdminTime          time.Time
+	ExpireSeconds      *int `json:"expire,string,omitempty"`
+	ExpireSecondsTime  time.Time
+	MinimumSeconds     *int `json:"minimum,string,omitempty"`
+	MinimumSecondsTime time.Time
+	RefreshSeconds     *int `json:"refresh,string,omitempty"`
+	RefreshSecondsTime time.Time
+	RetrySeconds       *int `json:"retry,string,omitempty"`
+	RetrySecondsTime   time.Time
+}
+
+type TTL struct {
+	ASeconds          *int `json:"A,string,omitempty"`
+	ASecondsTime      time.Time
+	AAAASeconds       *int `json:"AAAA,string,omitempty"`
+	AAAASecondsTime   time.Time
+	DNSkeySeconds     *int `json:"DNSKEY,string,omitempty"`
+	DNSkeySecondsTime time.Time
+	DSSeconds         *int `json:"DS,string,omitempty"`
+	DSSecondsTime     time.Time
+	NSSeconds         *int `json:"NS,string,omitempty"`
+	NSSecondsTime     time.Time
+	SOASeconds        *int `json:"SOA,string,omitempty"`
+	SOASecondsTime    time.Time
+}
+
+type Router struct {
+	APIPort       *int `json:"apiPort,string,omitempty"`
+	APIPortTime   time.Time
+	FQDN          *string `json:"fqdn,omitempty"`
+	FQDNTime      time.Time
+	HTTPSPort     *int `json:"httpsPort,string,omitempty"`
+	HTTPSPortTime time.Time
+	IP            *string `json:"ip,omitempty"`
+	IPTime        time.Time
+	IP6           *string `json:"ip6,omitempty"`
+	IP6Time       time.Time
+	Location      *string `json:"location,omitempty"`
+	LocationTime  time.Time
+	Port          *int `json:"port,string,omitempty"`
+	PortTime      time.Time
+	Profile       *string `json:"profile,omitempty"`
+	ProfileTime   time.Time
+	Status        *Status `json:"status,omitempty"`
+	StatusTime    time.Time
+}
+
+type Status string
+
+type Server struct {
+	CacheGroup           *string             `json:"cacheGroup,omitempty"`
+	CacheGroupTime       time.Time           `json:"-"`
+	DeliveryServices     map[string][]string `json:"deliveryServices,omitempty"`
+	DeliveryServicesTime time.Time           `json:"-"`
+	Fqdn                 *string             `json:"fqdn,omitempty"`
+	FqdnTime             time.Time           `json:"-"`
+	HashCount            *int                `json:"hashCount,omitempty"`
+	HashCountTime        time.Time           `json:"-"`
+	HashId               *string             `json:"hashId,omitempty"`
+	HashIdTime           time.Time           `json:"-"`
+	HttpsPort            *int                `json:"httpsPort,string,omitempty"`
+	HttpsPortTime        time.Time           `json:"-"`
+	InterfaceName        *string             `json:"interfaceName,omitempty"`
+	InterfaceNameTime    time.Time           `json:"-"`
+	Ip                   *string             `json:"ip,omitempty"`
+	IpTime               time.Time           `json:"-"`
+	Ip6                  *string             `json:"ip6,omitempty"`
+	Ip6Time              time.Time           `json:"-"`
+	LocationId           *string             `json:"locationId,omitempty"`
+	LocationIdTime       time.Time           `json:"-"`
+	Port                 *int                `json:"port,string,omitempty"`
+	PortTime             time.Time           `json:"-"`
+	Profile              *string             `json:"profile,omitempty"`
+	ProfileTime          time.Time           `json:"-"`
+	Status               *Status             `json:"status,omitempty"`
+	StatusTime           time.Time           `json:"-"`
+	ServerType           *string             `json:"type,omitempty"`
+	ServerTypeTime       time.Time           `json:"-"`
+}
+
+type DeliveryService struct {
+	CoverageZoneOnly        *bool                    `json:"coverageZoneOnly,string,omitempty"`
+	CoverageZoneOnlyTime    time.Time                `json:"-"`
+	Dispersion              *Dispersion              `json:"dispersion,omitempty"`
+	DispersionTime          time.Time                `json:"-"`
+	Domains                 []string                 `json:"domains,omitempty"`
+	DomainsTime             time.Time                `json:"-"`
+	GeoLocationProvider     *string                  `json:"geoLocationProvider,omitempty"`
+	GeoLocationProviderTime time.Time                `json:"-"`
+	MatchSets               []MatchSet               `json:"matchSets,omitempty"`
+	MatchSetsTime           time.Time                `json:"-"`
+	MissLocation            *LatLon                  `json:"missLocation,omitempty"`
+	MissLocationTime        time.Time                `json:"-"`
+	Protocol                *DeliveryServiceProtocol `json:"protocol,omitempty"`
+	ProtocolTime            time.Time                `json:"-"`
+	RegionalGeoBlocking     *bool                    `json:"regionalGeoBlocking,string,omitempty"`
+	RegionalGeoBlockingTime time.Time                `json:"-"`
+	ResponseHeaders         map[string]string        `json:"responseHeaders,omitempty"`
+	ResponseHeadersTime     time.Time                `json:"-"`
+	Soa                     *SOA                     `json:"soa,omitempty"`
+	SoaTime                 time.Time                `json:"-"`
+	SSLEnabled              *bool                    `json:"sslEnabled,string,omitempty"`
+	SSLEnabledTime          time.Time                `json:"-"`
+	TTL                     *int                     `json:"ttl,string,omitempty"`
+	TTLTime                 time.Time                `json:"-"`
+	TTLs                    *TTL                     `json:"ttls,omitempty"`
+	TTLsTime                time.Time                `json:"-"`
+}
+type Dispersion struct {
+	Limit    int  `json:"limit,omitempty"`
+	Shuffled bool `json:"shuffled,string,omitempty"`
+}
+type LatLon struct {
+	Lat float64 `json:"lat,string"`
+	Lon float64 `json:"lon,string"`
+}
+
+type LatitudeLongitude struct {
+	Lat float64 `json:"latitude"`
+	Lon float64 `json:"longitude"`
+}
+
+type DeliveryServiceProtocol struct {
+	AcceptHTTPS     bool `json:"acceptHttps,string,omitempty"`
+	RedirectOnHTTPS bool `json:"redirectOnHttps,string,omitempty"`
+}
+
+type Monitor struct {
+	FQDN          *string   `json:"fqdn,omitempty"`
+	FQDNTime      time.Time `json:"-"`
+	HTTPSPort     *int      `json:"httpsPort,string,omitempty"`
+	HTTPSPortTime time.Time `json:"-"`
+	IP            *string   `json:"ip,omitempty"`
+	IPTime        time.Time `json:"-"`
+	IP6           *string   `json:"ip6,omitempty"`
+	IP6Time       time.Time `json:"-"`
+	Location      *string   `json:"location,omitempty"`
+	LocationTime  time.Time `json:"-"`
+	Port          *int      `json:"port,string,omitempty"`
+	PortTime      time.Time `json:"-"`
+	Profile       *string   `json:"profile,omitempty"`
+	ProfileTime   time.Time `json:"-"`
+	Status        *Status   `json:"status,omitempty"`
+	StatusTime    time.Time `json:"-"`
+}
+
+type Stats struct {
+	CDNName             *string   `json:"CDN_name,omitempty"`
+	CDNNameTime         time.Time `json:"-"`
+	DateUnixSeconds     *int64    `json:"date,omitempty"`
+	DateUnixSecondsTime time.Time `json:"-"`
+	TMHost              *string   `json:"tm_host,omitempty"`
+	TMHostTime          time.Time `json:"-"`
+	TMPath              *string   `json:"tm_path,omitempty"`
+	TMPathTime          time.Time `json:"-"`
+	TMUser              *string   `json:"tm_user,omitempty"`
+	TMUserTime          time.Time `json:"-"`
+	TMVersion           *string   `json:"tm_version,omitempty"`
+	TMVersionTime       time.Time `json:"-"`
+}

--- a/traffic_monitor_golang/traffic_monitor/manager/datarequest.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/datarequest.go
@@ -777,8 +777,15 @@ func MakeDispatchMap(
 		"/api/bandwidth-capacity-kbps": wrap(WrapBytes(func() []byte {
 			return srvAPIBandwidthCapacityKbps(statMaxKbpses)
 		}, ContentTypeJSON)),
+		"/api/monitor-config": wrap(WrapErr(errorCount, func() ([]byte, error) {
+			return srvMonitorConfig(monitorConfig)
+		}, ContentTypeJSON)),
 	}
 	return addTrailingSlashEndpoints(dispatchMap)
+}
+
+func srvMonitorConfig(mcThs TrafficMonitorConfigMapThreadsafe) ([]byte, error) {
+	return json.Marshal(mcThs.Get())
 }
 
 // latestResultInfoTimeMS returns the length of time in milliseconds that it took to request the most recent non-errored result info.

--- a/traffic_monitor_golang/traffic_monitor/manager/monitorconfig.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/monitorconfig.go
@@ -21,6 +21,7 @@ package manager
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -191,6 +192,14 @@ func monitorConfigListen(
 	cfg config.Config,
 	staticAppData StaticAppData,
 ) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("MonitorConfigManager panic: %v\n", err)
+		} else {
+			log.Errorf("MonitorConfigManager failed without panic\n")
+		}
+		os.Exit(1) // The Monitor can't run without a MonitorConfigManager
+	}()
 	for monitorConfig := range monitorConfigPollChan {
 		monitorConfigTS.Set(monitorConfig)
 		healthURLs := map[string]poller.PollConfig{}

--- a/traffic_monitor_golang/traffic_monitor/manager/monitorconfig.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/monitorconfig.go
@@ -275,7 +275,7 @@ func monitorConfigListen(
 		for _, ds := range monitorConfig.DeliveryService {
 			// since caches default to unavailable, also default DS false
 			if _, exists := localStates.GetDeliveryService(enum.DeliveryServiceName(ds.XMLID)); !exists {
-				localStates.SetDeliveryService(enum.DeliveryServiceName(ds.XMLID), peer.Deliveryservice{IsAvailable: false, DisabledLocations: []enum.CacheName{}}) // important to initialize DisabledLocations, so JSON is `[]` not `null`
+				localStates.SetDeliveryService(enum.DeliveryServiceName(ds.XMLID), peer.Deliveryservice{IsAvailable: false, DisabledLocations: []enum.CacheGroupName{}}) // important to initialize DisabledLocations, so JSON is `[]` not `null`
 			}
 		}
 		for ds := range localStates.GetDeliveryServices() {

--- a/traffic_monitor_golang/traffic_monitor/manager/monitorconfig.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/monitorconfig.go
@@ -211,7 +211,7 @@ func monitorConfigListen(
 
 			srvStatus := enum.CacheStatusFromString(srv.Status)
 			if srvStatus == enum.CacheStatusOnline {
-				localStates.SetCache(cacheName, peer.IsAvailable{IsAvailable: true})
+				localStates.AddCache(cacheName, peer.IsAvailable{IsAvailable: true})
 				continue
 			}
 			if srvStatus == enum.CacheStatusOffline {
@@ -219,7 +219,7 @@ func monitorConfigListen(
 			}
 			// seed states with available = false until our polling cycle picks up a result
 			if _, exists := localStates.GetCache(cacheName); !exists {
-				localStates.SetCache(cacheName, peer.IsAvailable{IsAvailable: false})
+				localStates.AddCache(cacheName, peer.IsAvailable{IsAvailable: false})
 			}
 
 			url := monitorConfig.Profile[srv.Profile].Parameters.HealthPollingURL

--- a/traffic_monitor_golang/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/opsconfig.go
@@ -159,7 +159,8 @@ func StartOpsConfigManager(
 				continue
 			}
 
-			realToSession, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent)
+			useCache := false // TODO add config
+			realToSession, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache)
 			if err != nil {
 				handleErr(fmt.Errorf("MonitorConfigPoller: error instantiating Session with traffic_ops: %s\n", err))
 				continue

--- a/traffic_monitor_golang/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/opsconfig.go
@@ -159,8 +159,11 @@ func StartOpsConfigManager(
 				continue
 			}
 
-			useCache := false // TODO add config
-			realToSession, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache)
+			// TODO config? parameter?
+			useCache := false
+			trafficOpsRequestTimeout := time.Second * time.Duration(10)
+
+			realToSession, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
 			if err != nil {
 				handleErr(fmt.Errorf("MonitorConfigPoller: error instantiating Session with traffic_ops: %s\n", err))
 				continue

--- a/traffic_monitor_golang/traffic_monitor/manager/statecombiner.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/statecombiner.go
@@ -118,7 +118,7 @@ func combineCacheState(cacheName enum.CacheName, localCacheState peer.IsAvailabl
 }
 
 func combineDSState(deliveryServiceName enum.DeliveryServiceName, localDeliveryService peer.Deliveryservice, events health.ThreadsafeEvents, peerOptimistic bool, peerStates peer.CRStatesPeersThreadsafe, localStates peer.Crstates, combinedStates peer.CRStatesThreadsafe, overrideMap map[enum.CacheName]bool, toData todata.TOData) {
-	deliveryService := peer.Deliveryservice{IsAvailable: false, DisabledLocations: []enum.CacheName{}} // important to initialize DisabledLocations, so JSON is `[]` not `null`
+	deliveryService := peer.Deliveryservice{IsAvailable: false, DisabledLocations: []enum.CacheGroupName{}} // important to initialize DisabledLocations, so JSON is `[]` not `null`
 	if localDeliveryService.IsAvailable {
 		deliveryService.IsAvailable = true
 	}
@@ -148,18 +148,18 @@ func combineCrStates(events health.ThreadsafeEvents, peerOptimistic bool, peerSt
 }
 
 // CacheNameSlice is a slice of cache names, which fulfills the `sort.Interface` interface.
-type CacheNameSlice []enum.CacheName
+type CacheGroupNameSlice []enum.CacheGroupName
 
-func (p CacheNameSlice) Len() int           { return len(p) }
-func (p CacheNameSlice) Less(i, j int) bool { return p[i] < p[j] }
-func (p CacheNameSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p CacheGroupNameSlice) Len() int           { return len(p) }
+func (p CacheGroupNameSlice) Less(i, j int) bool { return p[i] < p[j] }
+func (p CacheGroupNameSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // intersection returns strings in both a and b.
 // Note this modifies a and b. Specifically, it sorts them. If that isn't acceptable, pass copies of your real data.
-func intersection(a []enum.CacheName, b []enum.CacheName) []enum.CacheName {
-	sort.Sort(CacheNameSlice(a))
-	sort.Sort(CacheNameSlice(b))
-	c := []enum.CacheName{} // important to initialize, so JSON is `[]` not `null`
+func intersection(a []enum.CacheGroupName, b []enum.CacheGroupName) []enum.CacheGroupName {
+	sort.Sort(CacheGroupNameSlice(a))
+	sort.Sort(CacheGroupNameSlice(b))
+	c := []enum.CacheGroupName{} // important to initialize, so JSON is `[]` not `null`
 	for _, s := range a {
 		i := sort.Search(len(b), func(i int) bool { return b[i] >= s })
 		if i < len(b) && b[i] == s {

--- a/traffic_monitor_golang/traffic_monitor/peer/crstates.go
+++ b/traffic_monitor_golang/traffic_monitor/peer/crstates.go
@@ -78,8 +78,8 @@ type IsAvailable struct {
 
 // Deliveryservice contains data about the availability of a particular delivery service, and which caches in that delivery service have been marked as unavailable.
 type Deliveryservice struct {
-	DisabledLocations []enum.CacheName `json:"disabledLocations"`
-	IsAvailable       bool             `json:"isAvailable"`
+	DisabledLocations []enum.CacheGroupName `json:"disabledLocations"`
+	IsAvailable       bool                  `json:"isAvailable"`
 }
 
 // CrstatesUnMarshall takes bytes of a JSON string, and unmarshals them into a Crstates object.

--- a/traffic_monitor_golang/traffic_monitor/static/index.html
+++ b/traffic_monitor_golang/traffic_monitor/static/index.html
@@ -498,6 +498,7 @@ under the License.
 				<li class="endpoint"><a href="/api/cache-statuses">/api/cache-statuses</a></li>
 				<li class="endpoint"><a href="/api/bandwidth-kbps">/api/bandwidth-kbps</a></li>
 				<li class="endpoint"><a href="/api/bandwidth-capacity-kbps">/api/bandwidth-capacity-kbps</a></li>
+				<li class="endpoint"><a href="/api/monitor-config">/api/monitor-config</a></li>
 			</ul>
 		</div>
 

--- a/traffic_monitor_golang/traffic_monitor/trafficopswrapper/trafficopswrapper.go
+++ b/traffic_monitor_golang/traffic_monitor/trafficopswrapper/trafficopswrapper.go
@@ -136,35 +136,69 @@ func CreateMonitorConfig(crConfig crconfig.CRConfig, mc *to.TrafficMonitorConfig
 	// Dump the "live" monitoring.json servers, and populate with the "snapshotted" CRConfig
 	mc.TrafficServer = map[string]to.TrafficServer{}
 	for name, srv := range crConfig.ContentServers {
-		mc.TrafficServer[name] = to.TrafficServer{
-			Profile:       *srv.Profile,
-			IP:            *srv.Ip,
-			Status:        string(*srv.Status),
-			CacheGroup:    *srv.CacheGroup,
-			IP6:           *srv.Ip6,
-			Port:          *srv.Port,
-			HostName:      name,
-			FQDN:          *srv.Fqdn,
-			InterfaceName: *srv.InterfaceName,
-			Type:          *srv.ServerType,
-			HashID:        *srv.HashId,
+		s := to.TrafficServer{}
+		if srv.Profile != nil {
+			s.Profile = *srv.Profile
 		}
+		if srv.Ip != nil {
+			s.IP = *srv.Ip
+		}
+		if srv.Status != nil {
+			s.Status = string(*srv.Status)
+		}
+		if srv.CacheGroup != nil {
+			s.CacheGroup = *srv.CacheGroup
+		}
+		if srv.Ip6 != nil {
+			s.IP6 = *srv.Ip6
+		}
+		if srv.Port != nil {
+			s.Port = *srv.Port
+		}
+		s.HostName = name
+		if srv.Fqdn != nil {
+			s.FQDN = *srv.Fqdn
+		}
+		if srv.InterfaceName != nil {
+			s.InterfaceName = *srv.InterfaceName
+		}
+		if srv.ServerType != nil {
+			s.Type = *srv.ServerType
+		}
+		if srv.HashId != nil {
+			s.HashID = *srv.HashId
+		}
+		mc.TrafficServer[name] = s
 	}
 
 	// Dump the "live" monitoring.json monitors, and populate with the "snapshotted" CRConfig
 	mc.TrafficMonitor = map[string]to.TrafficMonitor{}
 	for name, mon := range crConfig.Monitors {
 		// monitorProfile = *mon.Profile
-		mc.TrafficMonitor[name] = to.TrafficMonitor{
-			Port:     *mon.Port,
-			IP6:      *mon.IP6,
-			IP:       *mon.IP,
-			HostName: name,
-			FQDN:     *mon.FQDN,
-			Profile:  *mon.Profile,
-			Location: *mon.Location,
-			Status:   string(*mon.Status),
+		m := to.TrafficMonitor{}
+		if mon.Port != nil {
+			m.Port = *mon.Port
 		}
+		if mon.IP6 != nil {
+			m.IP6 = *mon.IP6
+		}
+		if mon.IP != nil {
+			m.IP = *mon.IP
+		}
+		m.HostName = name
+		if mon.FQDN != nil {
+			m.FQDN = *mon.FQDN
+		}
+		if mon.Profile != nil {
+			m.Profile = *mon.Profile
+		}
+		if mon.Location != nil {
+			m.Location = *mon.Location
+		}
+		if mon.Status != nil {
+			m.Status = string(*mon.Status)
+		}
+		mc.TrafficMonitor[name] = m
 	}
 
 	// Dump the "live" monitoring.json DeliveryServices, and populate with the "snapshotted" CRConfig

--- a/traffic_monitor_golang/traffic_monitor/trafficopswrapper/trafficopswrapper.go
+++ b/traffic_monitor_golang/traffic_monitor/trafficopswrapper/trafficopswrapper.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/common/log"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/crconfig"
 	to "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 )
@@ -139,34 +140,54 @@ func CreateMonitorConfig(crConfig crconfig.CRConfig, mc *to.TrafficMonitorConfig
 		s := to.TrafficServer{}
 		if srv.Profile != nil {
 			s.Profile = *srv.Profile
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing Profile field\n", name)
 		}
 		if srv.Ip != nil {
 			s.IP = *srv.Ip
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing IP field\n", name)
 		}
 		if srv.Status != nil {
 			s.Status = string(*srv.Status)
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing Status field\n", name)
 		}
 		if srv.CacheGroup != nil {
 			s.CacheGroup = *srv.CacheGroup
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing CacheGroup field\n", name)
 		}
 		if srv.Ip6 != nil {
 			s.IP6 = *srv.Ip6
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing IP6 field\n", name)
 		}
 		if srv.Port != nil {
 			s.Port = *srv.Port
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing Port field\n", name)
 		}
 		s.HostName = name
 		if srv.Fqdn != nil {
 			s.FQDN = *srv.Fqdn
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing FQDN field\n", name)
 		}
 		if srv.InterfaceName != nil {
 			s.InterfaceName = *srv.InterfaceName
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing InterfaceName field\n", name)
 		}
 		if srv.ServerType != nil {
 			s.Type = *srv.ServerType
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing Type field\n", name)
 		}
 		if srv.HashId != nil {
 			s.HashID = *srv.HashId
+		} else {
+			log.Warnf("Creating monitor config: CRConfig server %s missing HashId field\n", name)
 		}
 		mc.TrafficServer[name] = s
 	}
@@ -178,25 +199,39 @@ func CreateMonitorConfig(crConfig crconfig.CRConfig, mc *to.TrafficMonitorConfig
 		m := to.TrafficMonitor{}
 		if mon.Port != nil {
 			m.Port = *mon.Port
+		} else {
+			log.Warnf("Creating monitor config: CRConfig monitor %s missing Port field\n", name)
 		}
 		if mon.IP6 != nil {
 			m.IP6 = *mon.IP6
+		} else {
+			log.Warnf("Creating monitor config: CRConfig monitor %s missing IP6 field\n", name)
 		}
 		if mon.IP != nil {
 			m.IP = *mon.IP
+		} else {
+			log.Warnf("Creating monitor config: CRConfig monitor %s missing IP field\n", name)
 		}
 		m.HostName = name
 		if mon.FQDN != nil {
 			m.FQDN = *mon.FQDN
+		} else {
+			log.Warnf("Creating monitor config: CRConfig monitor %s missing FQDN field\n", name)
 		}
 		if mon.Profile != nil {
 			m.Profile = *mon.Profile
+		} else {
+			log.Warnf("Creating monitor config: CRConfig monitor %s missing Profile field\n", name)
 		}
 		if mon.Location != nil {
 			m.Location = *mon.Location
+		} else {
+			log.Warnf("Creating monitor config: CRConfig monitor %s missing Location field\n", name)
 		}
 		if mon.Status != nil {
 			m.Status = string(*mon.Status)
+		} else {
+			log.Warnf("Creating monitor config: CRConfig monitor %s missing Status field\n", name)
 		}
 		mc.TrafficMonitor[name] = m
 	}

--- a/traffic_monitor_golang/traffic_monitor/trafficopswrapper/trafficopswrapper.go
+++ b/traffic_monitor_golang/traffic_monitor/trafficopswrapper/trafficopswrapper.go
@@ -158,16 +158,22 @@ func CreateMonitorConfig(crConfig crconfig.CRConfig, mc *to.TrafficMonitorConfig
 	}
 
 	// Dump the "live" monitoring.json DeliveryServices, and populate with the "snapshotted" CRConfig
+	// But keep using the monitoring.json thresholds, because they're not in the CRConfig.
+	rawDeliveryServices := mc.DeliveryService
 	mc.DeliveryService = map[string]to.TMDeliveryService{}
 	for name, _ := range crConfig.DeliveryServices {
-		mc.DeliveryService[name] = to.TMDeliveryService{
-			XMLID:              name,
-			TotalTPSThreshold:  0,          // TODO verify
-			Status:             "Reported", // TODO verify
-			TotalKbpsThreshold: 0,          // TODO verify
+		if rawDS, ok := rawDeliveryServices[name]; ok {
+			// use the raw DS if it exists, because the CRConfig doesn't have thresholds or statuses
+			mc.DeliveryService[name] = rawDS
+		} else {
+			mc.DeliveryService[name] = to.TMDeliveryService{
+				XMLID:              name,
+				TotalTPSThreshold:  0,
+				Status:             "REPORTED",
+				TotalKbpsThreshold: 0,
+			}
 		}
 	}
-
 	return mc, nil
 }
 

--- a/traffic_monitor_golang/traffic_monitor/trafficopswrapper/trafficopswrapper.go
+++ b/traffic_monitor_golang/traffic_monitor/trafficopswrapper/trafficopswrapper.go
@@ -20,9 +20,11 @@ package trafficopswrapper
  */
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/crconfig"
 	to "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 )
 
@@ -34,6 +36,7 @@ type ITrafficOpsSession interface {
 	URL() (string, error)
 	User() (string, error)
 	Servers() ([]to.Server, error)
+	Profiles() ([]to.Profile, error)
 	Parameters(profileName string) ([]to.Parameter, error)
 	DeliveryServices() ([]to.DeliveryService, error)
 	CacheGroups() ([]to.CacheGroup, error)
@@ -83,8 +86,8 @@ func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 	return b, e
 }
 
-// TrafficMonitorConfigMap returns the Traffic Monitor config map from the Traffic Ops. This is safe for multiple goroutines.
-func (s TrafficOpsSessionThreadsafe) TrafficMonitorConfigMap(cdn string) (*to.TrafficMonitorConfigMap, error) {
+// TrafficMonitorConfigMapRaw returns the Traffic Monitor config map from the Traffic Ops, directly from the monitoring.json endpoint. This is not usually what is needed, rather monitoring needs the snapshotted CRConfig data, which is filled in by `TrafficMonitorConfigMap`. This is safe for multiple goroutines.
+func (s TrafficOpsSessionThreadsafe) TrafficMonitorConfigMapRaw(cdn string) (*to.TrafficMonitorConfigMap, error) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	if s.session == nil || *s.session == nil {
@@ -92,6 +95,185 @@ func (s TrafficOpsSessionThreadsafe) TrafficMonitorConfigMap(cdn string) (*to.Tr
 	}
 	d, e := (*s.session).TrafficMonitorConfigMap(cdn)
 	return d, e
+}
+
+// TrafficMonitorConfigMap returns the Traffic Monitor config map from the Traffic Ops. This is safe for multiple goroutines.
+func (s TrafficOpsSessionThreadsafe) TrafficMonitorConfigMap(cdn string) (*to.TrafficMonitorConfigMap, error) {
+	mc, err := s.TrafficMonitorConfigMapRaw(cdn)
+	if err != nil {
+		fmt.Printf("DEBUG4 TrafficMonitorConfigMap err: %v\n", err)
+		return nil, fmt.Errorf("getting monitor config map: %v", err)
+	}
+
+	crcData, err := s.CRConfigRaw(cdn)
+	if err != nil {
+		fmt.Printf("DEBUG4 CRConfigRaw err: %v\n", err)
+		return nil, fmt.Errorf("getting CRConfig: %v", err)
+	}
+
+	crConfig := crconfig.CRConfig{}
+	if err := json.Unmarshal(crcData, &crConfig); err != nil {
+		fmt.Printf("DEBUG4 CRConfig Unmarshal err: %v\n", err)
+		return nil, fmt.Errorf("Error unmarshalling CRConfig JSON: %v", err)
+		return nil, err
+	}
+
+	mc, err = CreateMonitorConfig(crConfig, mc)
+	if err != nil {
+		fmt.Printf("DEBUG4 CreateMonitorConfig err: %v\n", err)
+		return nil, fmt.Errorf("Error creating Traffic Monitor Config: %v", err)
+	}
+
+	// mcMap, err := to.TrafficMonitorTransformToMap(mc)
+	// if err != nil {
+	// 	fmt.Printf("DEBUG4 TrafficMonitorTransformToMap err: %v\n", err)
+	// 	return nil, fmt.Errorf("Error transforming Traffic Monitor Config to Map: %v", err)
+	// }
+
+	// debug
+
+	// if bytes, err := json.Marshal(mcMap); err != nil {
+	// 	fmt.Printf("DEBUG4 error marshalling map: %v\n", err)
+	// } else {
+	// 	fmt.Printf("DEBUG4 New Map: %v\n\n", string(bytes))
+	// }
+
+	return mc, nil
+}
+
+func CreateMonitorConfig(crConfig crconfig.CRConfig, mc *to.TrafficMonitorConfigMap) (*to.TrafficMonitorConfigMap, error) {
+	// mc := to.TrafficMonitorConfig{}
+
+	// cgs, err := s.CacheGroups()
+	// if err != nil {
+	// 	return nil, fmt.Errorf("Error getting CacheGroups: %v", err)
+	// }
+
+	// allProfiles, err := s.Profiles()
+	// if err != nil {
+	// 	return nil, fmt.Errorf("Error getting Profiles: %v", err)
+	// }
+
+	// Dump the "live" monitoring.json servers, and populate with the "snapshotted" CRConfig
+	mc.TrafficServer = map[string]to.TrafficServer{}
+	for name, srv := range crConfig.ContentServers {
+		mc.TrafficServer[name] = to.TrafficServer{
+			Profile:       *srv.Profile,
+			IP:            *srv.Ip,
+			Status:        string(*srv.Status),
+			CacheGroup:    *srv.CacheGroup,
+			IP6:           *srv.Ip6,
+			Port:          *srv.Port,
+			HostName:      name,
+			FQDN:          *srv.Fqdn,
+			InterfaceName: *srv.InterfaceName,
+			Type:          *srv.ServerType,
+			HashID:        *srv.HashId,
+		}
+	}
+
+	// for _, cg := range cgs {
+	// 	mc.CacheGroups = append(mc.CacheGroups, to.TMCacheGroup{
+	// 		Name: cg.Name,
+	// 		Coordinates: to.Coordinates{
+	// 			Latitude:  cg.Latitude,
+	// 			Longitude: cg.Longitude,
+	// 		},
+	// 	})
+	// }
+
+	// monitorProfile := ""
+
+	// Dump the "live" monitoring.json monitors, and populate with the "snapshotted" CRConfig
+	mc.TrafficMonitor = map[string]to.TrafficMonitor{}
+	for name, mon := range crConfig.Monitors {
+		// monitorProfile = *mon.Profile
+		mc.TrafficMonitor[name] = to.TrafficMonitor{
+			Port:     *mon.Port,
+			IP6:      *mon.IP6,
+			IP:       *mon.IP,
+			HostName: name,
+			FQDN:     *mon.FQDN,
+			Profile:  *mon.Profile,
+			Location: *mon.Location,
+			Status:   string(*mon.Status),
+		}
+	}
+
+	// monitorParams, err := s.Parameters(monitorProfile)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("Error getting profile %v parameters: %v", monitorProfile, err)
+	// }
+	// mc.Config = map[string]interface{}{}
+	// for _, param := range monitorParams {
+	// 	if numParam, err := strconv.ParseFloat(param.Value, 64); err == nil {
+	// 		mc.Config[param.Name] = numParam
+	// 	} else {
+	// 		mc.Config[param.Name] = param.Value
+	// 	}
+	// }
+
+	// Dump the "live" monitoring.json DeliveryServices, and populate with the "snapshotted" CRConfig
+	mc.DeliveryService = map[string]to.TMDeliveryService{}
+	for name, _ := range crConfig.DeliveryServices {
+		mc.DeliveryService[name] = to.TMDeliveryService{
+			XMLID:              name,
+			TotalTPSThreshold:  0,          // TODO verify
+			Status:             "Reported", // TODO verify
+			TotalKbpsThreshold: 0,          // TODO verify
+		}
+	}
+
+	// mc.Profiles = []to.TMProfile{}
+	// for _, prof := range allProfiles {
+	// 	if strings.HasPrefix(prof.Name, "EDGE") || strings.HasPrefix(prof.Name, "TEAK") {
+	// 		mc.Profiles = append(mc.Profiles, to.TMProfile{
+	// 			Name: prof.Name,
+	// 			Type: "EDGE",
+	// 		})
+	// 	} else if strings.HasPrefix(prof.Name, "MID") {
+	// 		mc.Profiles = append(mc.Profiles, to.TMProfile{
+	// 			Name: prof.Name,
+	// 			Type: "MID",
+	// 		})
+	// 	}
+	// }
+	// for profI, prof := range mc.Profiles {
+	// 	// MID2_TOP_v5.3.2-757
+	// 	prof.Parameters.Thresholds = map[string]to.HealthThreshold{}
+	// 	// TODO lock
+	// 	params, err := s.Parameters(prof.Name)
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("Error getting profile %v parameters: %v", prof, err)
+	// 	}
+	// 	fmt.Printf("DEBUG5 profile %v len(params) %v\n", prof.Name, len(params))
+	// 	for _, param := range params {
+	// 		if param.Name == "health.connection.timeout" {
+	// 			i, err := strconv.Atoi(param.Value)
+	// 			if err != nil {
+	// 				return nil, fmt.Errorf("Error getting profile %v parameter %v: %v", prof, param.Name, err)
+	// 			}
+	// 			prof.Parameters.HealthConnectionTimeout = i
+	// 		} else if param.Name == "health.polling.url" {
+	// 			prof.Parameters.HealthPollingURL = param.Value
+	// 		} else if param.Name == "history.count" {
+	// 			i, err := strconv.Atoi(param.Value)
+	// 			if err != nil {
+	// 				return nil, fmt.Errorf("Error getting profile %v parameter %v: %v", prof, param.Name, err)
+	// 			}
+	// 			prof.Parameters.HistoryCount = i
+	// 		} else if strings.HasPrefix(param.Name, "health.threshold.") {
+	// 			stat := param.Name[len("health.threshold."):]
+	// 			thresh, err := to.StrToThreshold(param.Value)
+	// 			if err != nil {
+	// 				return nil, fmt.Errorf("Error getting profile %v parameter %v: %v", prof, param.Name, err)
+	// 			}
+	// 			prof.Parameters.Thresholds[stat] = thresh
+	// 		}
+	// 	}
+	// 	mc.Profiles[profI] = prof
+	// }
+	return mc, nil
 }
 
 // Set sets the internal Traffic Ops session. This is safe for multiple goroutines, being aware they will race.
@@ -108,6 +290,15 @@ func (s TrafficOpsSessionThreadsafe) Servers() ([]to.Server, error) {
 		return nil, ErrNilSession
 	}
 	return (*s.session).Servers()
+}
+
+func (s TrafficOpsSessionThreadsafe) Profiles() ([]to.Profile, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.session == nil || *s.session == nil {
+		return nil, ErrNilSession
+	}
+	return (*s.session).Profiles()
 }
 
 func (s TrafficOpsSessionThreadsafe) Parameters(profileName string) ([]to.Parameter, error) {

--- a/traffic_monitor_golang/traffic_monitor/version.go
+++ b/traffic_monitor_golang/traffic_monitor/version.go
@@ -20,4 +20,4 @@ package main
  */
 
 // Version is the current version of the app, in string form.
-var Version = "2.0.3"
+var Version = "2.0.4"

--- a/traffic_monitor_golang/traffic_monitor/version.go
+++ b/traffic_monitor_golang/traffic_monitor/version.go
@@ -20,4 +20,4 @@ package main
  */
 
 // Version is the current version of the app, in string form.
-var Version = "2.0.2"
+var Version = "2.0.3"

--- a/traffic_monitor_golang/traffic_monitor/version.go
+++ b/traffic_monitor_golang/traffic_monitor/version.go
@@ -20,4 +20,4 @@ package main
  */
 
 // Version is the current version of the app, in string form.
-var Version = "2.0.4"
+var Version = "2.0.5"

--- a/traffic_ops/client/traffic_ops.go
+++ b/traffic_ops/client/traffic_ops.go
@@ -127,7 +127,7 @@ func ResumeSession(toURL string, insecure bool) (*Session, error) {
 }
 
 // Deprecated: Login is deprecated, use LoginWithAgent instead. The `Login` function with its present signature will be removed in the next version and replaced with `Login(toURL string, toUser string, toPasswd string, insecure bool, userAgent string)`. The `LoginWithAgent` function will be removed the version after that.
-func Login(toURL string, toUser string, toPasswd string, insecure bool, userAgent string) (*Session, error) {
+func Login(toURL string, toUser string, toPasswd string, insecure bool) (*Session, error) {
 	return LoginWithAgent(toURL, toUser, toPasswd, insecure, "traffic-ops-client") // TODO add version
 }
 

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -40,6 +40,8 @@ import (
 	influx "github.com/influxdata/influxdb/client/v2"
 )
 
+const UserAgent = "traffic-stats"
+
 const (
 	// FATAL will exit after printing error
 	FATAL = iota
@@ -412,7 +414,7 @@ func queryDB(con influx.Client, cmd string, database string) (res []influx.Resul
 }
 
 func writeSummaryStats(config StartupConfig, statsSummary traffic_ops.StatsSummary) {
-	to, err := traffic_ops.Login(config.ToURL, config.ToUser, config.ToPasswd, true)
+	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent)
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
 		log.Error(newErr)
@@ -426,7 +428,7 @@ func writeSummaryStats(config StartupConfig, statsSummary traffic_ops.StatsSumma
 
 func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 	var runningConfig RunningConfig
-	to, err := traffic_ops.Login(config.ToURL, config.ToUser, config.ToPasswd, true)
+	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent)
 	if err != nil {
 		msg := fmt.Sprintf("Error logging in to %v: %v", config.ToURL, err)
 		if init {

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -414,7 +414,7 @@ func queryDB(con influx.Client, cmd string, database string) (res []influx.Resul
 }
 
 func writeSummaryStats(config StartupConfig, statsSummary traffic_ops.StatsSummary) {
-	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent)
+	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false)
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
 		log.Error(newErr)
@@ -428,7 +428,7 @@ func writeSummaryStats(config StartupConfig, statsSummary traffic_ops.StatsSumma
 
 func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 	var runningConfig RunningConfig
-	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent)
+	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false)
 	if err != nil {
 		msg := fmt.Sprintf("Error logging in to %v: %v", config.ToURL, err)
 		if init {

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -41,6 +41,7 @@ import (
 )
 
 const UserAgent = "traffic-stats"
+const TrafficOpsRequestTimeout = time.Second * time.Duration(10)
 
 const (
 	// FATAL will exit after printing error
@@ -414,7 +415,7 @@ func queryDB(con influx.Client, cmd string, database string) (res []influx.Resul
 }
 
 func writeSummaryStats(config StartupConfig, statsSummary traffic_ops.StatsSummary) {
-	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false)
+	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
 		log.Error(newErr)
@@ -428,7 +429,7 @@ func writeSummaryStats(config StartupConfig, statsSummary traffic_ops.StatsSumma
 
 func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 	var runningConfig RunningConfig
-	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false)
+	to, err := traffic_ops.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
 	if err != nil {
 		msg := fmt.Sprintf("Error logging in to %v: %v", config.ToURL, err)
 		if init {


### PR DESCRIPTION
* Fixes Traffic Ops client login signature
* Adds Traffic Stats UserAgent
* Fixes Traffic Monitor 2.0 to overwrite live monitoring.json data with CRConfig snapshotted data
* Fixes Traffic Ops request cache
* Changes Traffic Ops requests to be threadsafe
* Changes Traffic Monitor 2.0 DisabledLocations to cachegroups
* Fixes Traffic Monitor 2.0 to remove caches deleted in Traffic Ops from its CrStates endpoint