### PR TITLE
Added license verifier tool.

### DIFF
--- a/.dependency_license
+++ b/.dependency_license
@@ -1,0 +1,109 @@
+# Documentation - These files are never code.
+README(\..*)?$, Docs
+NOTICE$, Docs
+VERSION$, Docs
+BUILD$, Docs
+DISCLAIMER, Docs
+\.md$, Docs
+\.txt$, Docs
+\.placeholder$, Empty
+
+# Uncommentable files
+#
+# These files cannot contain comments, so no header can be added.
+# They are nevertheless covered by the Apache license.
+\.gitignore$, Apache
+\.gitattributes$, Apache
+\.classpath$, Apache
+\.pmd$, Apache
+\.project$, Apache
+^\.rat-excludes$, Apache
+RobotoSlab-Bold\.ttf$, Apache
+RobotoSlab-Regular\.ttf$, Apache
+\.cfg$, Apache
+\.json$, Apache
+\.csv$, Apache
+\.conf$, Apache
+\.prop$, Apache
+\.test$, Apache
+\.config\.example$, Apache
+/\.bowerrc$, Apache
+/\.jshintrc$, Apache
+\.traffic_ops$, Apache # JSON with a specific format.
+\.dist$, Apache # JSON with a specific format.
+traffic_monitor_config\.js$, Apache # Actually JSON with a specific format.
+CrStates$, Apache # JSON with a specific format.
+^docs/.*\.(png|jpe?g|ico|gif)$, Apache
+^traffic_ops/app/public/.*\.(png|jpe?g|ico|gif)$, Apache
+^traffic_monitor/src/main/webapp/.*\.(png|jpe?g|ico|gif)$, Apache
+/images/.*\.(png|jpe?g|ico|gif)$, Apache
+favicon.ico$, Apache
+^traffic_ops/goto/testFiles/, Apache
+cron\.d/[^/]*$, Apache
+
+# Demo certificates
+ssl\.(crt|key)$, Apache
+/keystore, Apache
+COMODO.*\.crt$, Apache
+
+# Uncommentable files
+#
+# These files cannot contain comments, but are covered by separate
+# licenses. These licenses must be documented in the root LICENSE file.
+Inconsolata\.ttf$, SIL OFL 1.1
+Inconsolata-Bold\.ttf$, SIL OFL 1.1
+[Ff]ont[Aa]wesome[^\.]*\.([ot]tf|eot|woff2?)$, SIL OFL 1.1
+Lato-Bold\.ttf$, SIL OFL 1.1
+Lato-Regular\.ttf$, SIL OFL 1.1
+ssl-bundle\.crt$, MPL
+
+# Code dependencies
+#
+# These files could bear headers, but are part of dependent code and
+# so we present them for the most part unmodified. These licenses must
+# be documented in the root LICENSE file.
+[Ff]ont[Aa]wesome[^\.]*\.css, MIT
+select2.css, Apache
+select2.css, GPL/LGPL
+j[Mm]enu.*\.(css|js), MIT
+sphinx_rtd_theme/.*\.(html|css|css\.map|js|py)$, MIT
+bootstrap-theme\.css\.map, MIT
+datatables\.min, MIT
+GeoLite2-City.mmdb.gz, CC-A-SA
+jquery\.tree\.min\.css$, MIT
+jquery\.dataTables\.min\.(css|js)$, MIT
+
+# Ignored - Do not report.
+\.DS_Store, Ignore # Created automatically OSX.
+^\.rat-excludes$, Ignore # False positives for basically everything.
+^\.dependency_license, Ignore # False positives in this file.
+
+# This file is created dynamically by the testing script itself, it is
+# not distributed, but if it were, it would be Apache, and the source
+# would be right with it.
+^infrastructure/test/license/license, Apache
+
+# Don't object to licenses in the license file itself.
+^LICENSE$, !GoBSD
+^LICENSE$, !MIT
+^LICENSE$, !BSD
+^LICENSE$, !X11
+^LICENSE$, !ISC
+
+# ... or in the documentation about the licenses.
+^infrastructure/test/license/README.md$, !BSD
+^infrastructure/test/license/README.md$, !GPL/LGPL
+^infrastructure/test/license/README.md$, !MIT
+^infrastructure/test/license/README.md$, !WTFPL
+^infrastructure/test/license/README.md$, !X11
+
+# License files are licensed under their own terms, don't attempt to detect them.
+^licenses/.*, Ignore
+
+# False positives
+licenseList\.go$, !GoBSD
+licenseList\.go$, !MIT
+licenseList\.go$, !BSD
+licenseList\.go$, !X11
+^traffic_ops/app/t_integration/extensions\.t$, !X11
+GeoLite2-City.mmdb.gz, !MIT

--- a/infrastructure/test/license/README.md
+++ b/infrastructure/test/license/README.md
@@ -1,0 +1,122 @@
+Verifying Licenses
+==================
+
+**tl;dr** Run `check_license`. Output indicates problems.
+
+This is an automatic license checker aimed at ensuring compliance with
+the Apache Software Foundation processes. It does not ensure compliance,
+but it catches many common errors automatically.
+
+`check_license`
+---------------
+
+This script will automatically build and run the license check on the
+current directory. The exit code will be non-zero on error. There will
+be no output on success.
+
+`license`
+---------
+
+This is the binary with all the logic in it. `license` will list every
+file in every subdirectory, starting from the current directory, and
+determine the most likely license for that file. It errs on the side of
+false positives, since the consequences of a false negative are
+considerably more serious.
+
+Run `license -q` to suppress the printing of non-problematic files.
+
+`LICENSE`
+---------
+
+The `LICENSE` file is at the root of the project (from whence you ought
+to run `license`). This must comply with the requirements of the Apache
+Software Foundation and is intended for human consumption.
+
+Nevertheless, with a bit of careful writing, it's possible to have
+`license` help verify that everything gets covered.
+
+Lines that begin with an `@`-symbol are interpreted as a path
+specification that describes a set of files covered by the license.
+`license` does not validate that `@` files are actually licensed
+correctly, merely that they are mentioned. This covers the most common
+case, which is adding a (even potentially correctly licensed!) file and
+forgetting to mention it in the `LICENSE` file.
+
+Likewise, it's impermissible to use an `@`-line that describes no files.
+This usually happens when a dependency is removed and the `LICENSE` file
+does not get updated properly.
+
+`@`-lines are interpreted by
+[path.Match](https://golang.org/pkg/path/#Match), the syntax for which
+is:
+
+    pattern:
+        { term }
+    term:
+        '*'         matches any sequence of non-/ characters
+        '?'         matches any single non-/ character
+        '[' [ '^' ] { character-range } ']'
+                    character class (must be non-empty)
+        c           matches character c (c != '*', '?', '\\', '[')
+        '\\' c      matches character c
+
+    character-range:
+        c           matches character c (c != '\\', '-', ']')
+        '\\' c      matches character c
+        lo '-' hi   matches character c for lo <= c <= hi
+
+`.dependency_license`
+---------------------
+
+Sometimes, there's no reasonable way to automatically detect the
+appropriate license for a file, especially files that don't support
+comments or are binary. `.dependency_license` allows you to document the
+exceptions so that new files show up clearly.
+
+The `.dependency_license` must appear in the root of the project.
+
+Each line should either be empty, a comment (prepended by an octothorp),
+or a license exception line. A license exception line is a regular
+expression, a comma, then the name of a license, then optionally an
+octothorp followed by a comment (which may not contain a comma!).
+
+    license-exception:
+        regex ',' license-name [ '#' { commentable-char } ]       Associates the license with the file.        
+        regex ',' '!' license-name [ '#' { commentable-char } ]   Disassociates the license from the file.
+
+    regex: A regular expression accepted by golang regexps, described here: https://golang.org/s/re2syntax
+
+    license-name:
+        'Apache'    Apache License
+        'BSD'       Berkeley Software Distribution License
+        'MIT'       Massachusetts Institute of Technology License
+        'GoBSD'     BSD-style license used by the GoLang team
+        'ISC'       Internet Systems Consortium
+        'X11'       MIT License, by an older name.
+        'WTFPL'     Do What the Fuck You Want to Public License
+        'GPL/LGPL'  Either the GNU General Public License or the GNU Lesser General Public License
+        'Docs'      A documentation file
+        'Empty'     An empty file
+        'Ignored'   A file that ought not be analyzed for compliance
+
+    commentable-char: Any character other than a ','
+
+Best Practices
+--------------
+
+License management can be tricky at the best of times. The goal of this
+tool is to automate as much of that as possible. Here are some best
+practices:
+
+-   **`check_license` before you commit.** If it prints anything, you
+    probably need to add license headers.
+-   **Do not `Ignore` files.** If it's reasonable to quiet `license`
+    about a false positive or negative in another way, do that instead.
+-   **If an unrecognized file has a header, update `license`, not
+    `.dependency_license`.** It's relatively straightforward to add
+    license recognition to `licenseList.go`. Doing it that way benefits
+    future files as well.
+-   **Run `check_license` as part of Continuous Integration.** Issues
+    are not usually difficult to fix, but automatic running allows them
+    to be fixed promptly.
+

--- a/infrastructure/test/license/check_license
+++ b/infrastructure/test/license/check_license
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+SCRIPTDIR=$(pwd)
+
+if [ ! -f license ]; then
+  go build .
+fi
+
+if [ ! -f license ]; then
+  echo "Failed to build license utility." >&2
+  exit 1
+fi
+
+cd ../../..
+if ! $SCRIPTDIR/license -q; then
+  echo "There are problematic licenses." >&2
+  exit 1
+fi
+
+exit 0

--- a/infrastructure/test/license/documented.go
+++ b/infrastructure/test/license/documented.go
@@ -1,0 +1,93 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package main
+
+import (
+	"bufio"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type Documented []string
+
+var documented Documented
+
+func init() {
+	f, err := os.Open(`LICENSE`)
+	if err != nil {
+		panic(err)
+	}
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if len(line) != 0 && line[0] == '@' {
+			documented = append(documented, line[1:])
+		}
+	}
+}
+
+func (d Documented) Documents(name string) bool {
+	for _, re := range d {
+		if ok, err := path.Match(re, name); ok && err == nil {
+			return true
+		}
+	}
+	dir := path.Dir(name)
+	if dir != `` && dir != name {
+		return d.Documents(dir)
+	}
+	return false
+}
+
+func (d Documented) Extra() []string {
+	extra := make(map[string]struct{})
+	for _, s := range d {
+		extra[s] = struct{}{}
+	}
+
+	filepath.Walk(`.`, func(name string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if filepath.Base(name) == `.git` {
+			return filepath.SkipDir
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		for re := range extra {
+			if ok, err := path.Match(re, name); ok && err == nil {
+				delete(extra, re)
+			}
+		}
+		return nil
+	})
+
+	var extraDoc []string
+	for re := range extra {
+		extraDoc = append(extraDoc, re)
+	}
+	return extraDoc
+}

--- a/infrastructure/test/license/filekind.go
+++ b/infrastructure/test/license/filekind.go
@@ -1,0 +1,49 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package main
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func filekind(name string) string {
+	b, err := exec.Command(`file`, `-b`, name).CombinedOutput()
+	if err != nil {
+		return ``
+	}
+	if bytes.Contains(b, []byte("script")) || bytes.Contains(b, []byte("document")) {
+		parts := bytes.Split(b, []byte{' '})
+		kind := string(parts[0])
+		if kind == `a` && len(parts) > 1 {
+			kind = string(parts[1])
+		}
+		return `Unknown-` + kind + `!`
+	}
+
+	if bytes.Contains(b, []byte("text")) {
+		return `Unknown-Text!`
+	}
+
+	if bytes.Contains(b, []byte("executable")) {
+		return `Unknown-Executable!`
+	}
+
+	return ``
+}

--- a/infrastructure/test/license/license.go
+++ b/infrastructure/test/license/license.go
@@ -1,0 +1,208 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+func main() {
+	quiet := false
+	for _, arg := range os.Args[1:] {
+		if arg == `-q` {
+			quiet = true
+		}
+	}
+
+	files := make(map[string][]License)
+	var wg sync.WaitGroup
+	var filesLock sync.Mutex
+	err := filepath.Walk(`.`, func(name string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if filepath.Base(name) == `.git` {
+			return filepath.SkipDir
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if (info.Mode() & os.ModeSymlink) != 0 {
+			return nil
+		}
+
+		if info.Size() == 0 {
+			filesLock.Lock()
+			defer filesLock.Unlock()
+			files[name] = append(files[name], License("Empty"))
+			return nil
+		}
+
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			licenses, err := fileLicenses(name)
+			if err != nil {
+				licenses = []License{License("Error: " + err.Error() + "!")}
+			}
+
+			filesLock.Lock()
+			defer filesLock.Unlock()
+			files[name] = append(files[name], override[name]...)
+			files[name] = append(files[name], licenses...)
+			files[name] = Collide(Uniq(files[name]))
+		}(name)
+		return nil
+	})
+	wg.Wait()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+forUnknownFiles:
+	for name, licenses := range files {
+		if len(licenses) == 0 {
+			parts := strings.Split(name, `/`)
+			for i := len(parts) - 1; i > 0; i-- {
+				for _, licName := range []string{`LICENSE`, `LICENCE`, `LICENSE.md`, `LICENCE.md`, `LICENSE.txt`, `LICENCE.txt`} {
+					licPath := strings.Join(parts[:i], `/`) + `/` + licName
+					if len(files[licPath]) != 0 {
+						for _, license := range files[licPath] {
+							if license != License(`Docs`) {
+								files[name] = append(files[name], License(string(license)+"~"))
+							}
+						}
+						continue forUnknownFiles
+					}
+				}
+			}
+		}
+	}
+
+	for name, licenses := range files {
+		if len(licenses) != 0 {
+			if len(licenses) > 1 || (licenses[0] != License(`Apache`) && licenses[0] != License(`Docs`) && licenses[0] != License(`Empty`) && licenses[0] != License(`Ignore`)) {
+				if !documented.Documents(name) {
+					for i, lic := range licenses {
+						if lic != License(`Apache`) && lic != License(`Docs`) && lic != License(`Empty`) && lic != License(`Ignore`) {
+							licenses[i] = License(string(licenses[i]) + `!`)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for name, licenses := range files {
+		if len(licenses) == 0 {
+			kind := filekind(name)
+			if kind != `` {
+				files[name] = []License{License(kind)}
+			}
+		}
+	}
+
+	var filenames []string
+	for filename := range files {
+		filenames = append(filenames, filename)
+	}
+	sort.Strings(filenames)
+
+	failed := false
+	for _, filename := range filenames {
+		lics := files[filename]
+		ignore := false
+		undoc := false
+		var licStr string
+		if len(lics) == 0 {
+			licStr = "Unknown!"
+			undoc = true
+		} else {
+			licStr = fmt.Sprint(lics[0])
+			ignore = (licStr == `Ignore`)
+			if len(licStr) > 0 && licStr[len(licStr)-1] == '!' {
+				undoc = true
+			}
+			for _, lic := range lics[1:] {
+				if string(lic) == `Ignore` {
+					ignore = true
+				}
+				licStr = licStr + `, ` + fmt.Sprint(lic)
+			}
+		}
+		if !ignore {
+			errStr := ""
+			if undoc {
+				errStr = "Error"
+				failed = true
+			}
+			if undoc || !quiet {
+				fmt.Printf("%-6s%40s %s\n", errStr, licStr, filename)
+			}
+		}
+	}
+	for _, extra := range documented.Extra() {
+		fmt.Printf("%-6s%40s %s\n", "Error", "Extra-License!", extra)
+		failed = true
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func fileLicenses(name string) ([]License, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return identifyLicenses(f)
+}
+
+func identifyLicenses(in io.Reader) ([]License, error) {
+
+	ch := make(chan string, 32)
+	go func() {
+		s := bufio.NewScanner(in)
+		s.Split(bufio.ScanWords)
+		for s.Scan() {
+			s := strings.ToLower(stripPunc(s.Text()))
+			if len(s) > 0 {
+				ch <- s
+			}
+		}
+		close(ch)
+	}()
+
+	licenses := newMultiMatcher(ch)
+	return licenses, nil
+}

--- a/infrastructure/test/license/licenseList.go
+++ b/infrastructure/test/license/licenseList.go
@@ -1,0 +1,262 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package main
+
+import (
+	"bytes"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type License string
+
+type Licenses []License
+
+func (lics Licenses) Len() int {
+	return len(lics)
+}
+func (lics Licenses) Swap(i, j int) {
+	lics[i], lics[j] = lics[j], lics[i]
+}
+func (lics Licenses) Less(i, j int) bool {
+	return lics[i] < lics[j]
+}
+
+func Uniq(lics []License) []License {
+	if len(lics) == 0 {
+		return nil
+	}
+	sortLics := make(Licenses, len(lics))
+	copy(sortLics, lics)
+	sort.Sort(sortLics)
+	var uniqLics []License
+	for _, lic := range sortLics {
+		if len(uniqLics) == 0 || lic != uniqLics[len(uniqLics)-1] {
+			uniqLics = append(uniqLics, lic)
+		}
+	}
+	return uniqLics
+}
+
+func Remove(lics []License, rmLic License) []License {
+	var rmLics []License
+	for _, lic := range lics {
+		if lic != rmLic {
+			rmLics = append(rmLics, lic)
+		}
+	}
+	return rmLics
+}
+
+func Has(lics []License, lic License) bool {
+	for _, l := range lics {
+		if l == lic {
+			return true
+		}
+	}
+	return false
+}
+
+func Collide(lics []License) []License {
+	var toRm []License
+	for _, lic := range lics {
+		if string(lic)[0] == '!' {
+			toRm = append(toRm, lic)
+			toRm = append(toRm, License(string(lic)[1:]))
+		}
+	}
+	newLics := lics
+	for _, rm := range toRm {
+		newLics = Remove(newLics, rm)
+	}
+
+	if Has(newLics, License("GoBSD")) {
+		newLics = Remove(newLics, "BSD")
+	}
+
+	if len(newLics) > 1 {
+		newLics = Remove(newLics, "Docs")
+	}
+	if len(newLics) > 1 {
+		newLics = Remove(newLics, "Generated")
+	}
+	return newLics
+}
+
+func getGID() uint64 {
+	b := make([]byte, 64)
+	b = b[:runtime.Stack(b, false)]
+	b = bytes.TrimPrefix(b, []byte("goroutine "))
+	b = b[:bytes.IndexByte(b, ' ')]
+	n, _ := strconv.ParseUint(string(b), 10, 64)
+	return n
+}
+
+func wordMatcher(words []string) func(out *bool) (in chan<- string, done <-chan struct{}) {
+	return func(out *bool) (in chan<- string, done <-chan struct{}) {
+		ch := make(chan string, 32)
+		doneCh := make(chan struct{})
+		go func() {
+			defer func() { close(doneCh) }()
+			defer func() {
+				for _ = range ch {
+				}
+			}()
+			if len(words) == 0 {
+				*out = true
+				return
+			}
+
+			i := 0
+			for word := range ch {
+				//				fmt.Println(getGID(), "Comparing "+words[i]+" to "+word)
+				if words[i] == word {
+					i++
+				} else {
+					i = 0
+				}
+
+				if i == len(words) {
+					*out = true
+					return
+				}
+			}
+		}()
+		return ch, doneCh
+	}
+}
+
+type multiMatcher []struct {
+	ch      chan<- string
+	done    <-chan struct{}
+	value   *bool
+	license License
+}
+
+func newMultiMatcher(in <-chan string) []License {
+	var mm multiMatcher
+	mmAppend := func(words []string, license License) {
+		value := new(bool)
+		ch, done := wordMatcher(words)(value)
+		mm = append(mm, struct {
+			ch      chan<- string
+			done    <-chan struct{}
+			value   *bool
+			license License
+		}{
+			ch:      ch,
+			done:    done,
+			value:   value,
+			license: license,
+		})
+	}
+
+	mmAppend(wordsApache, License("Apache"))
+	mmAppend(wordsApache2, License("Apache"))
+	mmAppend(wordsBSD, License("BSD"))
+	mmAppend(wordsBSD2, License("BSD"))
+	mmAppend(wordsMIT, License("MIT"))
+	mmAppend(wordsMIT2, License("MIT"))
+	mmAppend(wordsGoBSD, License("GoBSD"))
+	mmAppend(wordsISC, License("ISC"))
+	mmAppend(wordsGen, License("Generated"))
+	mmAppend(wordsX11, License("X11"))
+	mmAppend(wordsWTFPL, License("WTFPL"))
+	mmAppend(wordsGPL, License("GPL/LGPL"))
+	mmAppend(wordsGPL2, License("GPL/LGPL"))
+	mmAppend(wordsGPL3, License("GPL/LGPL"))
+	mmAppend(wordsGPL4, License("GPL/LGPL"))
+	mmAppend(wordsLGPL, License("GPL/LGPL"))
+	mmAppend(wordsLGPL2, License("GPL/LGPL"))
+	mmAppend(wordsLGPL3, License("GPL/LGPL"))
+	mmAppend(wordsLGPL4, License("GPL/LGPL"))
+
+	for word := range in {
+		for _, m := range mm {
+			m.ch <- word
+		}
+	}
+	for _, m := range mm {
+		close(m.ch)
+	}
+	for _, m := range mm {
+		<-m.done
+	}
+
+	var licenses []License
+doMatcher:
+	for _, m := range mm {
+		if *m.value {
+			for _, lic := range licenses {
+				if lic == m.license {
+					continue doMatcher
+				}
+			}
+			licenses = append(licenses, m.license)
+		}
+	}
+	return licenses
+}
+
+func stripPunc(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) {
+			return r
+		}
+		if unicode.IsSpace(r) {
+			return r
+		}
+		if unicode.IsDigit(r) {
+			return r
+		}
+		return -1
+	}, s)
+}
+
+func makeWords(s string) []string {
+	s = strings.ToLower(s)
+	s = strings.Replace(s, "\n", ` `, -1)
+	s = stripPunc(s)
+	return strings.Split(s, ` `)
+}
+
+var (
+	wordsApache  = makeWords(`Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.`)
+	wordsApache2 = makeWords(`Licensed under the Apache License`)
+	wordsBSD     = makeWords(`Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:`)
+	wordsBSD2    = makeWords(`BSD`)
+	wordsMIT     = makeWords(`Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files`)
+	wordsMIT2    = makeWords(`MIT`)
+	wordsGoBSD   = makeWords(`The Go Authors. All rights reserved.`)
+	wordsISC     = makeWords(`Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies`)
+	wordsGen     = makeWords(`DO NOT MODIFY THE FIRST PART OF THIS FILE`)
+	wordsX11     = makeWords(`X11`)
+	wordsWTFPL   = makeWords(`WTFPL`)
+	wordsGPL     = makeWords(`GNU General Public License`)
+	wordsGPL2    = makeWords(`GPL`)
+	wordsGPL3    = makeWords(`GPLv2`)
+	wordsGPL4    = makeWords(`GPLv3`)
+	wordsLGPL    = makeWords(`GNU Lesser General Public License`)
+	wordsLGPL2   = makeWords(`LGPL`)
+	wordsLGPL3   = makeWords(`LGPLv2`)
+	wordsLGPL4   = makeWords(`LGPLv3`)
+)

--- a/infrastructure/test/license/override.go
+++ b/infrastructure/test/license/override.go
@@ -1,0 +1,94 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var override = make(map[string][]License)
+
+func init() {
+	if _, err := os.Stat(`.dependency_license`); err != nil {
+		return
+	}
+
+	f, err := os.Open(`.dependency_license`)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	type licenseFilter struct {
+		License License
+		Regexp  *regexp.Regexp
+	}
+
+	var regexps []licenseFilter
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := s.Text()
+		line = strings.TrimSpace(line)
+		if line == `` || line[0] == '#' {
+			continue
+		}
+
+		parts := strings.Split(line, ",")
+		if len(parts) < 2 {
+			panic("Malformed line in .dependency_license: " + line)
+		}
+
+		strRe, lic := strings.Join(parts[:len(parts)-1], `,`), parts[len(parts)-1]
+		licParts := strings.SplitN(lic, `#`, 2)
+		if len(licParts) > 1 {
+			lic = licParts[0]
+		}
+		lic = strings.TrimSpace(lic)
+
+		re, cmpErr := regexp.Compile(strRe)
+		if cmpErr != nil {
+			panic("Malformed regexp: " + strRe + "\n" + cmpErr.Error())
+		}
+
+		regexps = append(regexps, licenseFilter{License(lic), re})
+	}
+
+	err = filepath.Walk(`.`, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		for _, filter := range regexps {
+			if filter.Regexp.MatchString(path) {
+				override[path] = append(override[path], filter.License)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		panic(`Failed when enumerating working directory: ` + err.Error())
+	}
+}


### PR DESCRIPTION
This is the tool I've been using to grep through the files and categorize them. It's pretty specific to the ASF goals, so it's not a really general purpose tool. It tends significantly toward false positives, which is rather annoying, but reasonably easy to fix. False negatives are simply never caught and can produce considerably more risk.

Most of the details are documented in the `README.md` The basic idea is this: Run the tool. For every file to which it objects, either add the appropriate license header, add an appropriate license to the `LICENSE` file, or update the `.dependency_license` file.

This routine has nothing to do with Traffic Control and wouldn't really belong in the repo... but it would be very useful to have Continuous Integration run it automatically and for people to be able to run it before summitting PRs. It can find common issues far more quickly than people can manually, which should save contributors' time. I'm definitely open to conversation on this front, including ideas for alternatives.