### PR TITLE
[TC-160] remove check for ip6 addr and gateway in same network

### DIFF
--- a/traffic_ops/app/lib/API/Server2.pm
+++ b/traffic_ops/app/lib/API/Server2.pm
@@ -217,9 +217,6 @@ sub check_server_params {
                 $json->{'ip6Gateway'} = $update_base->{'ip6_gateway'};
             }
         }
-        if ( !&in_same_net( $json->{'ip6Address'}, $json->{'ip6Gateway'} ) ) {
-            return ( \%params, $json->{'ip6Address'} . " and " . $json->{'ip6Gateway'} . " are not in same network" );
-        }
     }
 
     my $ipstr1;

--- a/traffic_ops/app/lib/UI/Server.pm
+++ b/traffic_ops/app/lib/UI/Server.pm
@@ -413,9 +413,6 @@ sub check_server_input {
 		if ( !&is_ip6address( $paramHashRef->{'ip6_gateway'} ) ) {
 			$err .= "Gateway " . $paramHashRef->{'ip6_gateway'} . " is not a valid IPv6 address " . $sep;
 		}
-		if ( !&in_same_net( $paramHashRef->{'ip6_address'}, $paramHashRef->{'ip6_gateway'} ) ) {
-			$err .= $paramHashRef->{'ip6_address'} . " and " . $paramHashRef->{'ip6_gateway'} . " are not in same network" . $sep;
-		}
 	}
 
 	$ipstr1 = $paramHashRef->{'ilo_ip_address'} . "/" . $paramHashRef->{'ilo_ip_netmask'};


### PR DESCRIPTION
still allows user to enter,  but does not check that address is in the same network