### PR TITLE
[TC-167] fix old test; not sure how it ever worked.

### DIFF
--- a/traffic_ops/app/t/api/1.1/cachegroupparameter.t
+++ b/traffic_ops/app/t/api/1.1/cachegroupparameter.t
@@ -43,10 +43,10 @@ ok $t->post_ok( '/login', => form => { u => 'portal', p => Test::TestHelper::ADM
   ->or( sub { diag $t->tx->res->content->asset->{content}; } );
 
 $t->get_ok("/api/1.1/cachegroupparameters.json")->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
-  ->json_is( '/response/cachegroupParameters/0/cachegroup', 'mid-northeast-group' )->json_is( '/response/cachegroupParameters/0/parameter', "61" )
-  ->json_is( '/response/cachegroupParameters/1/cachegroup', 'mid-northeast-group' )->json_is( '/response/cachegroupParameters/1/parameter', "60" )
-  ->json_is( '/response/cachegroupParameters/2/cachegroup', 'mid-northwest-group' )->json_is( '/response/cachegroupParameters/2/parameter', "61" )
-  ->json_is( '/response/cachegroupParameters/3/cachegroup', 'mid-northwest-group' )->json_is( '/response/cachegroupParameters/3/parameter', "60" );
+  ->json_is( '/response/cachegroupParameters/0/cachegroup', 'mid-northeast-group' )->json_like( '/response/cachegroupParameters/0/parameter', qr/\d+/ )
+  ->json_is( '/response/cachegroupParameters/1/cachegroup', 'mid-northeast-group' )->json_like( '/response/cachegroupParameters/1/parameter', qr/\d+/ )
+  ->json_is( '/response/cachegroupParameters/2/cachegroup', 'mid-northwest-group' )->json_like( '/response/cachegroupParameters/2/parameter', qr/\d+/ )
+  ->json_is( '/response/cachegroupParameters/3/cachegroup', 'mid-northwest-group' )->json_like( '/response/cachegroupParameters/3/parameter', qr/\d+/ );
 
 ok $t->get_ok('/logout')->status_is(302)->or( sub { diag $t->tx->res->content->asset->{content}; } );
 $dbh->disconnect();

--- a/traffic_ops/app/t/api/1.1/cachegroupparameter.t
+++ b/traffic_ops/app/t/api/1.1/cachegroupparameter.t
@@ -43,10 +43,10 @@ ok $t->post_ok( '/login', => form => { u => 'portal', p => Test::TestHelper::ADM
   ->or( sub { diag $t->tx->res->content->asset->{content}; } );
 
 $t->get_ok("/api/1.1/cachegroupparameters.json")->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
-  ->json_is( '/response/cachegroupParameters/0/cachegroup', 'mid-northeast-group' )->json_is( '/response/cachegroupParameters/0/parameter', "60" )
-  ->json_is( '/response/cachegroupParameters/1/cachegroup', 'mid-northeast-group' )->json_is( '/response/cachegroupParameters/0/parameter', "60" )
-  ->json_is( '/response/cachegroupParameters/1/cachegroup', 'mid-northeast-group' )->json_is( '/response/cachegroupParameters/1/parameter', "61" )
-  ->json_is( '/response/cachegroupParameters/2/cachegroup', 'mid-northwest-group' )->json_is( '/response/cachegroupParameters/2/parameter', "60" );
+  ->json_is( '/response/cachegroupParameters/0/cachegroup', 'mid-northeast-group' )->json_is( '/response/cachegroupParameters/0/parameter', "61" )
+  ->json_is( '/response/cachegroupParameters/1/cachegroup', 'mid-northeast-group' )->json_is( '/response/cachegroupParameters/1/parameter', "60" )
+  ->json_is( '/response/cachegroupParameters/2/cachegroup', 'mid-northwest-group' )->json_is( '/response/cachegroupParameters/2/parameter', "61" )
+  ->json_is( '/response/cachegroupParameters/3/cachegroup', 'mid-northwest-group' )->json_is( '/response/cachegroupParameters/3/parameter', "60" );
 
 ok $t->get_ok('/logout')->status_is(302)->or( sub { diag $t->tx->res->content->asset->{content}; } );
 $dbh->disconnect();


### PR DESCRIPTION
All tests pass now: 
```
[jvd@jvd-knutsel-4 app (2.0-test *$)]$ prove -pqr 2>/dev/null
./t/aadata.t ................................ ok
./t/api/1.0/availableds.t ................... ok
./t/api/1.0/data.t .......................... ok
./t/api/1.0/health.t ........................ ok
./t/api/1.0/ort.t ........................... ok
./t/api/1.1/asn.t ........................... ok
./t/api/1.1/cachegroup.t .................... ok
./t/api/1.1/cachegroupparameter.t ........... ok
./t/api/1.1/cdn.t ........................... ok
./t/api/1.1/deliveryservice/keys_url_sig.t .. ok
./t/api/1.1/deliveryservice/ssl_keys.t ...... ok
./t/api/1.1/deliveryserviceserver.t ......... ok
./t/api/1.1/hwinfo.t ........................ ok
./t/api/1.1/job.t ........................... ok
./t/api/1.1/keys.t .......................... ok
./t/api/1.1/log.t ........................... ok
./t/api/1.1/metrics.t ....................... ok
./t/api/1.1/parameter.t ..................... ok
./t/api/1.1/phys_location.t ................. ok
./t/api/1.1/profile.t ....................... ok
./t/api/1.1/region.t ........................ ok
./t/api/1.1/riak_adapter.t .................. ok
./t/api/1.1/roles.t ......................... ok
./t/api/1.1/server.t ........................ ok
./t/api/1.1/staticdns.t ..................... ok
./t/api/1.1/status.t ........................ ok
./t/api/1.1/traffic_monitor.t ............... ok
./t/api/1.1/types.t ......................... ok
./t/api/1.1/user.t .......................... ok
./t/api/1.2/asn.t ........................... ok
./t/api/1.2/cache_stats.t ................... ok
./t/api/1.2/cachegroup.t .................... ok
./t/api/1.2/cdn.t ........................... ok
./t/api/1.2/deliveryservice.t ............... ok
./t/api/1.2/deliveryservice_matches.t ....... ok
./t/api/1.2/deliveryservice_regex.t ......... ok
./t/api/1.2/deliveryservice_server.t ........ ok
./t/api/1.2/deliveryservice_stats.t ......... ok
./t/api/1.2/division.t ...................... ok
./t/api/1.2/federation_external.t ........... ok
./t/api/1.2/federation_internal.t ........... ok
./t/api/1.2/parameter.t ..................... ok
./t/api/1.2/physlocation.t .................. ok
./t/api/1.2/profile.t ....................... ok
./t/api/1.2/profile_parameter.t ............. ok
./t/api/1.2/region.t ........................ ok
./t/api/1.2/server.t ........................ ok
./t/api/1.2/stats_summary.t ................. ok
./t/api/1.2/user.t .......................... ok
./t/asn.t ................................... ok
./t/deliveryservice.t ....................... ok
./t/deliveryserviceserver.t ................. ok
./t/federation.t ............................ ok
./t/health.t ................................ ok
./t/hwinfo.t ................................ ok
./t/influxdb_adapter.t ...................... ok
./t/log.t ................................... ok
./t/modules.t ............................... ok
./t/parameter.t ............................. ok
./t/phys_location.t ......................... ok
./t/profile.t ............................... ok
./t/purge.t ................................. ok
./t/rascal_status.t ......................... ok
./t/server.t ................................ ok
./t/staticdnsentry.t ........................ ok
./t/user.t .................................. ok
./t_integration/000init_database.t .......... ok
./t_integration/configfiles.t ............... ok
./t_integration/configfiles_view.t .......... ok
./t_integration/extensions.t ................ ok
./t_integration/server.t .................... ok
./t_integration/servercheck.t ............... ok
All tests successful.
Files=72, Tests=7916, 554 wallclock secs ( 1.71 usr  0.46 sys + 428.71 cusr 60.82 csys = 491.70 CPU)
Result: PASS
[jvd@jvd-knutsel-4 app (2.0-test *$)]$
```