### PR TITLE
TC-171: ort script should chown ats configuration files.

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1226,6 +1226,7 @@ sub replace_cfg_file {
 			. $cfg_file_tracker->{$cfg_file}->{'location'}
 			. "/$cfg_file\n";
 		system("/bin/cp $cfg_file_tracker->{$cfg_file}->{'backup_from_trops'} $cfg_file_tracker->{$cfg_file}->{'location'}/$cfg_file");
+		chown $ats_uid, $ats_uid, $cfg_file_tracker->{$cfg_file}->{'location'}/$cfg_file";
 		$cfg_file_tracker->{$cfg_file}->{'change_applied'}++;
 		( $log_level >> $TRACE ) && print "TRACE Setting change applied for $cfg_file.\n";
 		$return_code = $CFG_FILE_CHANGED;


### PR DESCRIPTION
See Jira TC-171.  Ort script should chown ats config files to the effective ats process owner.