### PR TITLE
Add Traffic Monitor 2.0 /publish/Stats 95th percentile cache poll time

### DIFF
--- a/traffic_monitor_golang/traffic_monitor/manager/datarequest.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/datarequest.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1092,30 +1093,31 @@ type JSONStats struct {
 
 // Stats contains statistics data about this running app. Designed to be returned via an API endpoint.
 type Stats struct {
-	MaxMemoryMB         uint64 `json:"Max Memory (MB),string"`
-	GitRevision         string `json:"git-revision"`
-	ErrorCount          uint64 `json:"Error Count,string"`
-	Uptime              uint64 `json:"uptime,string"`
-	FreeMemoryMB        uint64 `json:"Free Memory (MB),string"`
-	TotalMemoryMB       uint64 `json:"Total Memory (MB),string"`
-	Version             string `json:"version"`
-	DeployDir           string `json:"deploy-dir"`
-	FetchCount          uint64 `json:"Fetch Count,string"`
-	QueryIntervalDelta  int    `json:"Query Interval Delta,string"`
-	IterationCount      uint64 `json:"Iteration Count,string"`
-	Name                string `json:"name"`
-	BuildTimestamp      string `json:"buildTimestamp"`
-	QueryIntervalTarget int    `json:"Query Interval Target,string"`
-	QueryIntervalActual int    `json:"Query Interval Actual,string"`
-	SlowestCache        string `json:"Slowest Cache"`
-	LastQueryInterval   int    `json:"Last Query Interval,string"`
-	Microthreads        int    `json:"Goroutines"`
-	LastGC              string `json:"Last Garbage Collection"`
-	MemAllocBytes       uint64 `json:"Memory Bytes Allocated"`
-	MemTotalBytes       uint64 `json:"Total Bytes Allocated"`
-	MemSysBytes         uint64 `json:"System Bytes Allocated"`
-	OldestPolledPeer    string `json:"Oldest Polled Peer"`
-	OldestPolledPeerMs  int64  `json:"Oldest Polled Peer Time (ms)"`
+	MaxMemoryMB                 uint64 `json:"Max Memory (MB),string"`
+	GitRevision                 string `json:"git-revision"`
+	ErrorCount                  uint64 `json:"Error Count,string"`
+	Uptime                      uint64 `json:"uptime,string"`
+	FreeMemoryMB                uint64 `json:"Free Memory (MB),string"`
+	TotalMemoryMB               uint64 `json:"Total Memory (MB),string"`
+	Version                     string `json:"version"`
+	DeployDir                   string `json:"deploy-dir"`
+	FetchCount                  uint64 `json:"Fetch Count,string"`
+	QueryIntervalDelta          int    `json:"Query Interval Delta,string"`
+	IterationCount              uint64 `json:"Iteration Count,string"`
+	Name                        string `json:"name"`
+	BuildTimestamp              string `json:"buildTimestamp"`
+	QueryIntervalTarget         int    `json:"Query Interval Target,string"`
+	QueryIntervalActual         int    `json:"Query Interval Actual,string"`
+	SlowestCache                string `json:"Slowest Cache"`
+	LastQueryInterval           int    `json:"Last Query Interval,string"`
+	Microthreads                int    `json:"Goroutines"`
+	LastGC                      string `json:"Last Garbage Collection"`
+	MemAllocBytes               uint64 `json:"Memory Bytes Allocated"`
+	MemTotalBytes               uint64 `json:"Total Bytes Allocated"`
+	MemSysBytes                 uint64 `json:"System Bytes Allocated"`
+	OldestPolledPeer            string `json:"Oldest Polled Peer"`
+	OldestPolledPeerMs          int64  `json:"Oldest Polled Peer Time (ms)"`
+	QueryInterval95thPercentile int64  `json:"Query Interval 95th Percentile (ms)"`
 }
 
 func getLongestPoll(lastHealthTimes map[enum.CacheName]time.Duration) (enum.CacheName, time.Duration) {
@@ -1147,6 +1149,31 @@ func oldestPeerPollTime(peerTimes map[enum.TrafficMonitorName]time.Time) (enum.T
 }
 
 const MillisecondsPerNanosecond = int64(1000000)
+
+type Durations []time.Duration
+
+func (s Durations) Len() int {
+	return len(s)
+}
+func (s Durations) Less(i, j int) bool {
+	return s[i] < s[j]
+}
+func (s Durations) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// getCacheTimePercentile returns the given percentile of cache result times. The `percentile` should be a decimal percent, for example, for the 95th percentile pass 0.95
+func getCacheTimePercentile(lastHealthTimes map[enum.CacheName]time.Duration, percentile float64) time.Duration {
+	times := make([]time.Duration, 0, len(lastHealthTimes))
+	for _, t := range lastHealthTimes {
+		times = append(times, t)
+	}
+	sort.Sort(Durations(times))
+
+	n := int(float64(len(lastHealthTimes)) * percentile)
+
+	return times[n]
+}
 
 func getStats(staticAppData StaticAppData, pollingInterval time.Duration, lastHealthTimes map[enum.CacheName]time.Duration, fetchCount uint64, healthIteration uint64, errorCount uint64, peerStates peer.CRStatesPeersThreadsafe) ([]byte, error) {
 	longestPollCache, longestPollTime := getLongestPoll(lastHealthTimes)
@@ -1180,6 +1207,8 @@ func getStats(staticAppData StaticAppData, pollingInterval time.Duration, lastHe
 	oldestPolledPeer, oldestPolledPeerTime := oldestPeerPollTime(peerStates.GetQueryTimes()) // map[enum.TrafficMonitorName]time.Time)
 	s.OldestPolledPeer = string(oldestPolledPeer)
 	s.OldestPolledPeerMs = time.Now().Sub((oldestPolledPeerTime)).Nanoseconds() / MillisecondsPerNanosecond
+
+	s.QueryInterval95thPercentile = getCacheTimePercentile(lastHealthTimes, 0.95).Nanoseconds() / MillisecondsPerNanosecond
 
 	return json.Marshal(JSONStats{Stats: s})
 }

--- a/traffic_monitor_golang/traffic_monitor/manager/monitorconfig.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/monitorconfig.go
@@ -140,6 +140,9 @@ func trafficOpsHealthPollIntervalToDuration(t int) time.Duration {
 
 var healthPollCount int
 
+// PollIntervalRatio is the ratio of the configuration interval to poll. The configured intervals are 'target' times, so we actually poll at some small fraction less, in attempt to make the actual poll marginally less than the target.
+const PollIntervalRatio = float64(0.97) // TODO make config?
+
 // getPollIntervals reads the Traffic Ops Client monitorConfig structure, and parses and returns the health, peer, and stat poll intervals
 func getHealthPeerStatPollIntervals(monitorConfig to.TrafficMonitorConfigMap, cfg config.Config) (time.Duration, time.Duration, time.Duration, error) {
 	peerPollIntervalI, peerPollIntervalExists := monitorConfig.Config["peers.polling.interval"]
@@ -176,6 +179,9 @@ func getHealthPeerStatPollIntervals(monitorConfig to.TrafficMonitorConfigMap, cf
 	}
 	healthPollInterval := trafficOpsHealthPollIntervalToDuration(int(healthPollIntervalInt))
 
+	healthPollInterval = time.Duration(float64(healthPollInterval) * PollIntervalRatio)
+	peerPollInterval = time.Duration(float64(peerPollInterval) * PollIntervalRatio)
+	statPollInterval = time.Duration(float64(statPollInterval) * PollIntervalRatio)
 	return healthPollInterval, peerPollInterval, statPollInterval, nil
 }
 

--- a/traffic_monitor_golang/traffic_monitor/peer/crstates.go
+++ b/traffic_monitor_golang/traffic_monitor/peer/crstates.go
@@ -229,7 +229,7 @@ func (t *CRStatesPeersThreadsafe) GetPeerAvailability(peer enum.TrafficMonitorNa
 	return availability
 }
 
-// GetPeerAvailability returns the state of the given peer
+// GetQueryTimes returns the last query time of all peers
 func (t *CRStatesPeersThreadsafe) GetQueryTimes() map[enum.TrafficMonitorName]time.Time {
 	t.m.RLock()
 	defer t.m.RUnlock()

--- a/traffic_monitor_golang/traffic_monitor/version.go
+++ b/traffic_monitor_golang/traffic_monitor/version.go
@@ -20,4 +20,4 @@ package main
  */
 
 // Version is the current version of the app, in string form.
-var Version = "2.0.7"
+var Version = "2.0.8"

--- a/traffic_monitor_golang/traffic_monitor/version.go
+++ b/traffic_monitor_golang/traffic_monitor/version.go
@@ -20,4 +20,4 @@ package main
  */
 
 // Version is the current version of the app, in string form.
-var Version = "2.0.6"
+var Version = "2.0.7"


### PR DESCRIPTION
Also changes polling to be slightly under the target time, and fixes a global variable potential threadsafety issue.