### PR TITLE
Adding an experimental go based rest API for Traffic Ops

### DIFF
--- a/traffic_ops/experimental/go-api/api.go
+++ b/traffic_ops/experimental/go-api/api.go
@@ -1,0 +1,112 @@
+package main
+
+/*
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+This module it provides a server creating a RESTful API towards Traffic-Ops DB.
+It was created in order to POC the concept of API Gateway (added on another PR) between the different modules of Traffic-Ops, specifically old perl Traffic-Ops, and new (go?) one.
+
+At first step, only "tenant" table is covered (CRUD).
+Other tables can be added, by adding modules (see tenant foe example), and seeding their enpoints below.
+To Run this module, call: go run api.go --server --db-config-file 
+e.g. go run api.go --server :8888 --db-config-file ../../app/conf/test/database.conf
+Note that the below go modules are required, so you'll might need to "go get" them:)
+"github.com/gorilla/mux"
+"github.com/lib/pq"
+*/
+
+ 
+import (
+    "database/sql"
+    "encoding/json"
+    "flag"
+    "fmt"
+    "log"
+    "net/http"
+    "os"
+
+    "github.com/gorilla/mux"
+  _ "github.com/lib/pq"
+
+//modules to seed endpoints  
+    "./tenant"
+)
+
+type DbConfig struct {
+    Hostname  string    `json:"hostname"`
+    Port      string    `json:"port"` //String for now, as the conf files are like this
+    User      string    `json:"user"`
+    Password  string    `json:"password"`
+    DbName    string    `json:"dbname"`
+}
+
+func main() {
+
+    server := flag.String("server", "", "IP:port to listen on")
+    dbConfigFileName := flag.String("db-config-file", "", "DB to connect to config file")
+
+    flag.Parse()
+
+    if *server == ""{
+        fmt.Println("Missing server address")
+        os.Exit(1)
+    }
+    
+    if *dbConfigFileName == ""{
+        fmt.Println("Missing DB config file")
+        os.Exit(1)
+    }
+
+    dbConfigFD, err := os.Open(*dbConfigFileName)
+    if err != nil {
+        fmt.Println(err.Error())
+        os.Exit(1)
+    }
+    
+    var dbConfig DbConfig
+    jsonParser := json.NewDecoder(dbConfigFD)
+    if err := jsonParser.Decode(&dbConfig); err != nil {
+        fmt.Println(err.Error())
+        os.Exit(1)
+    }
+    
+    psqlInfo := fmt.Sprintf("host=%s port=%s user=%s "+"password=%s dbname=%s sslmode=disable",dbConfig.Hostname, dbConfig.Port, dbConfig.User, dbConfig.Password, dbConfig.DbName)
+    db, err := sql.Open("postgres", psqlInfo)
+    if err != nil {
+        panic(err)
+    }
+    defer db.Close()
+
+    err= db.Ping()
+    if err != nil {
+      panic(err)
+    }
+
+    fmt.Println("Successfully connected!")
+
+
+    apiPrefix := "/api/2.0"
+    router := mux.NewRouter()
+    
+
+    //list of elements to populat the api
+    tenantEndpoints := tenant.NewEndpointSeeder(db)
+    tenantEndpoints.Seed(router, apiPrefix)
+    
+    log.Fatal(http.ListenAndServe(*server, router))
+}
+
+
+

--- a/traffic_ops/experimental/go-api/tenant/EndPointSeeder.go
+++ b/traffic_ops/experimental/go-api/tenant/EndPointSeeder.go
@@ -1,0 +1,202 @@
+package tenant
+
+/*
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+ 
+import (
+    "database/sql"
+    "encoding/json"
+    "net/http"
+    "fmt"
+    "time"
+
+    "github.com/gorilla/mux"
+  _ "github.com/lib/pq"
+)
+
+
+//TODO(nirs) polymorphisem
+
+/////BASE - COMMON TO ALL SEEDERS (needs to move to another package)
+/// Defintions
+type EndpointSeeder struct{
+    myDb        *sql.DB
+}
+
+/// Interface
+func NewEndpointSeeder(aDb *sql.DB) *EndpointSeeder {
+    endPointSeeder := new(EndpointSeeder)
+    endPointSeeder.myDb = aDb
+    return endPointSeeder
+}
+
+func (aEndpointSeeder *EndpointSeeder) Seed (aRouter *mux.Router, aApiPrefix string) {
+
+    aRouter.HandleFunc(aApiPrefix+"/tenants", aEndpointSeeder.getListEndpoint).Methods("GET")
+    aRouter.HandleFunc(aApiPrefix+"/tenants/{id}", aEndpointSeeder.getEndpoint).Methods("GET")
+    aRouter.HandleFunc(aApiPrefix+"/tenants", aEndpointSeeder.createEndpoint).Methods("POST")
+    aRouter.HandleFunc(aApiPrefix+"/tenants/{id}", aEndpointSeeder.updateEndpoint).Methods("PUT")
+    aRouter.HandleFunc(aApiPrefix+"/tenants/{id}", aEndpointSeeder.deleteEndpoint).Methods("DELETE")
+}
+
+///Common utilities
+func (aEndpointSeeder *EndpointSeeder) checkErr(aError error) {
+    //TODO log
+    if aError != nil {
+        panic(aError)
+    }
+}
+
+
+/////Class specific
+
+type Tenant struct {
+    Id        int       `json:"id"`
+    Name      string    `json:"name"`
+    Active    bool      `json:"active"`
+    ParentId  int       `json:"parentId"`
+}
+
+func (aEndpointSeeder *EndpointSeeder) getEndpoint(aResponseWriter http.ResponseWriter, aRequest *http.Request) {
+    params := mux.Vars(aRequest)
+
+    var id int
+    var name string
+    var active bool
+    var parent_id sql.NullInt64
+    var updated time.Time;
+    
+    err := aEndpointSeeder.myDb.QueryRow("SELECT * FROM tenant WHERE id="+params["id"]).Scan(&id, &name, &active, &parent_id, &updated)
+    if err == sql.ErrNoRows{//TODO make it work
+        aResponseWriter.WriteHeader(http.StatusNotFound)
+        fmt.Fprint(aResponseWriter, params["id"]+" not found")
+        return
+    }
+    aEndpointSeeder.checkErr(err)
+    
+    var parent_id1 int
+    if parent_id.Valid {
+        parent_id1 = int(parent_id.Int64)
+    } else {
+       parent_id1 = 0        
+    }
+
+    json.NewEncoder(aResponseWriter).Encode(Tenant{Id: id, Name: name, Active: active, ParentId: parent_id1})
+    return
+}
+    
+
+ 
+func (aEndpointSeeder *EndpointSeeder) getListEndpoint(aResponseWriter http.ResponseWriter, aRequest *http.Request) {
+    var tenants []Tenant
+    rows, err := aEndpointSeeder.myDb.Query("SELECT * FROM tenant")
+    aEndpointSeeder.checkErr(err)
+    
+    for rows.Next() {
+        var id int
+        var name string
+        var active bool
+        var parent_id sql.NullInt64
+        var updated time.Time;
+            
+        err = rows.Scan(&id, &name, &active, &parent_id, &updated)
+        aEndpointSeeder.checkErr(err)
+
+        var parent_id1 int
+        if parent_id.Valid {
+            parent_id1 = int(parent_id.Int64)
+        } else {
+            parent_id1 = 0        
+        }
+    
+        tenants = append(tenants, Tenant{Id: id, Name: name, Active: active, ParentId: parent_id1})
+    }
+    
+    json.NewEncoder(aResponseWriter).Encode(tenants)
+
+}
+ 
+func (aEndpointSeeder *EndpointSeeder) createEndpoint(aResponseWriter http.ResponseWriter, aRequest *http.Request) {
+    var tenant Tenant
+    _ = json.NewDecoder(aRequest.Body).Decode(&tenant)
+    
+    var tenantParent sql.NullInt64
+    if tenant.ParentId==0{
+        tenantParent.Valid = false
+    }else{
+    	tenantParent.Int64 = int64(tenant.ParentId)
+    	tenantParent.Valid = true
+    }
+    
+
+    var lastInsertId int
+    err := aEndpointSeeder.myDb.QueryRow("INSERT INTO tenant(name, active, parent_id, last_updated) VALUES($1,$2,$3,$4) returning id;", tenant.Name, tenant.Active, tenantParent, "2012-12-09").Scan(&lastInsertId)
+    aEndpointSeeder.checkErr(err)
+    aEndpointSeeder.getListEndpoint(aResponseWriter, aRequest)
+}
+
+
+
+func (aEndpointSeeder *EndpointSeeder) updateEndpoint(aResponseWriter http.ResponseWriter, aRequest *http.Request) {
+    params := mux.Vars(aRequest)
+    
+    var tenant Tenant
+    _ = json.NewDecoder(aRequest.Body).Decode(&tenant)
+
+    var tenantParent sql.NullInt64
+    if tenant.ParentId==0{
+        tenantParent.Valid = false
+    }else{
+    	tenantParent.Int64 = int64(tenant.ParentId)
+    	tenantParent.Valid = true
+    }
+    
+    stmt, err := aEndpointSeeder.myDb.Prepare("update tenant set name=$1, active=$2, parent_id=$3, last_updated=$4 where id="+params["id"])
+    if err == sql.ErrNoRows{//TODO make it work
+        aResponseWriter.WriteHeader(http.StatusNotFound)
+        return
+    }
+    aEndpointSeeder.checkErr(err)
+    
+    res, err := stmt.Exec(tenant.Name, tenant.Active, tenantParent, "2012-12-09")
+    aEndpointSeeder.checkErr(err)
+    
+    _, err = res.RowsAffected()
+    aEndpointSeeder.checkErr(err)
+    
+    aEndpointSeeder.getEndpoint(aResponseWriter, aRequest)
+}
+ 
+func (aEndpointSeeder *EndpointSeeder) deleteEndpoint(aResponseWriter http.ResponseWriter, aRequest *http.Request) {
+    params := mux.Vars(aRequest)
+    
+    stmt, err := aEndpointSeeder.myDb.Prepare("delete from tenant where id="+params["id"])
+    if err == sql.ErrNoRows{//TODO make it work
+        aResponseWriter.WriteHeader(http.StatusNotFound)
+        return
+    }
+    aEndpointSeeder.checkErr(err)
+    
+    res, err := stmt.Exec()
+    aEndpointSeeder.checkErr(err)
+    
+    _, err = res.RowsAffected()
+    aEndpointSeeder.checkErr(err)
+    
+    aEndpointSeeder.getListEndpoint(aResponseWriter, aRequest)
+}
+
+
+


### PR DESCRIPTION
This module it provides a server creating a RESTful API towards Traffic-Ops DB.
It was created in order to POC the concept of API Gateway (added on another PR) between the different modules of Traffic-Ops, specifically old perl Traffic-Ops, and new (go?) one.

At first step, only "tenant" table is covered (CRUD).
Other tables can be added, by adding modules (see tenant foe example), and seeding their enpoints below.
To Run this module, call: go run api.go --server --db-config-file 
e.g. go run api.go --server :8888 --db-config-file ../../app/conf/test/database.conf
Note that the below go modules are required, so you'll might need to "go get" them:)
"github.com/gorilla/mux"
"github.com/lib/pq"
