### PR TITLE
Fix TM2 to remove OFFLINEd peers, timeout peers

### DIFF
--- a/traffic_monitor_golang/traffic_monitor/datareq/peerstate.go
+++ b/traffic_monitor_golang/traffic_monitor/datareq/peerstate.go
@@ -49,17 +49,20 @@ func srvPeerStates(params url.Values, errorCount threadsafe.Uint, path string, t
 		HandleErr(errorCount, path, err)
 		return []byte(err.Error()), http.StatusBadRequest
 	}
-	bytes, err := json.Marshal(createAPIPeerStates(peerStates.GetCrstates(), filter, params))
+	bytes, err := json.Marshal(createAPIPeerStates(peerStates.GetCrstates(), peerStates.GetPeersOnline(), filter, params))
 	return WrapErrCode(errorCount, path, bytes, err)
 }
 
-func createAPIPeerStates(peerStates map[enum.TrafficMonitorName]peer.Crstates, filter *PeerStateFilter, params url.Values) APIPeerStates {
+func createAPIPeerStates(peerStates map[enum.TrafficMonitorName]peer.Crstates, peersOnline map[enum.TrafficMonitorName]bool, filter *PeerStateFilter, params url.Values) APIPeerStates {
 	apiPeerStates := APIPeerStates{
 		CommonAPIData: srvhttp.GetCommonAPIData(params, time.Now()),
 		Peers:         map[enum.TrafficMonitorName]map[enum.CacheName][]CacheState{},
 	}
 
 	for peer, state := range peerStates {
+		if !peersOnline[peer] {
+			continue
+		}
 		if !filter.UsePeer(peer) {
 			continue
 		}

--- a/traffic_monitor_golang/traffic_monitor/datareq/stat.go
+++ b/traffic_monitor_golang/traffic_monitor/datareq/stat.go
@@ -99,7 +99,7 @@ func getStats(staticAppData config.StaticAppData, pollingInterval time.Duration,
 	s.MemTotalBytes = memStats.TotalAlloc
 	s.MemSysBytes = memStats.Sys
 
-	oldestPolledPeer, oldestPolledPeerTime := oldestPeerPollTime(peerStates.GetQueryTimes()) // map[enum.TrafficMonitorName]time.Time)
+	oldestPolledPeer, oldestPolledPeerTime := oldestPeerPollTime(peerStates.GetQueryTimes(), peerStates.GetPeersOnline())
 	s.OldestPolledPeer = string(oldestPolledPeer)
 	s.OldestPolledPeerMs = time.Now().Sub((oldestPolledPeerTime)).Nanoseconds() / util.MillisecondsPerNanosecond
 
@@ -145,11 +145,14 @@ func getCacheTimePercentile(lastHealthTimes map[enum.CacheName]time.Duration, pe
 	return times[n]
 }
 
-func oldestPeerPollTime(peerTimes map[enum.TrafficMonitorName]time.Time) (enum.TrafficMonitorName, time.Time) {
+func oldestPeerPollTime(peerTimes map[enum.TrafficMonitorName]time.Time, peerOnline map[enum.TrafficMonitorName]bool) (enum.TrafficMonitorName, time.Time) {
 	now := time.Now()
 	oldestTime := now
 	oldestPeer := enum.TrafficMonitorName("")
 	for p, t := range peerTimes {
+		if !peerOnline[p] {
+			continue
+		}
 		if oldestTime.After(t) {
 			oldestTime = t
 			oldestPeer = p

--- a/traffic_monitor_golang/traffic_monitor/manager/manager.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/manager.go
@@ -75,10 +75,12 @@ func Start(opsConfigFile string, cfg config.Config, staticAppData config.StaticA
 	events := health.NewThreadsafeEvents(cfg.MaxEvents)
 
 	cachesChanged := make(chan struct{})
+	peerStates := peer.NewCRStatesPeersThreadsafe() // each peer's last state is saved in this map
 
 	monitorConfig := StartMonitorConfigManager(
 		monitorConfigPoller.ConfigChannel,
 		localStates,
+		peerStates,
 		cacheStatPoller.ConfigChannel,
 		cacheHealthPoller.ConfigChannel,
 		peerPoller.ConfigChannel,
@@ -87,7 +89,6 @@ func Start(opsConfigFile string, cfg config.Config, staticAppData config.StaticA
 		staticAppData,
 	)
 
-	peerStates := peer.NewCRStatesPeersThreadsafe() // each peer's last state is saved in this map
 	combinedStates, combineStateFunc := StartStateCombiner(events, peerStates, localStates, toData)
 
 	StartPeerManager(

--- a/traffic_monitor_golang/traffic_monitor/version.go
+++ b/traffic_monitor_golang/traffic_monitor/version.go
@@ -20,4 +20,4 @@ package main
  */
 
 // Version is the current version of the app, in string form.
-var Version = "2.0.8"
+var Version = "2.0.9"


### PR DESCRIPTION
Fixes Traffic Monitor 2.0 to remove peers which have been marked
OFFLINE in Traffic Ops from its endpoints. OFFLINEd peers are removed
from `PeerStates`, and their availability is removed from `CrStates`.

Fixes to timeout peers which don't respond. Peers which haven't
responded in (pollInterval+httpTimeout)*2 are removed from CrStates.

Fixes TC-175