### PR TITLE
[TC-176] fix minor typo in <version> -- affects only 2.0.x branch

### DIFF
--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>2.0..0</version>
+		<version>2.0.0</version>
 	</parent>
 
 	<scm>


### PR DESCRIPTION
causes traffic_router to fail to build