### PR TITLE
Add global build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ misc/traffic-control-cdn/downloads/*.rpm
 traffic_router/*/*.log
 traffic_router/*.log
 .dbInfo
+/dist

--- a/BUILD.md
+++ b/BUILD.md
@@ -7,7 +7,10 @@ are automatically loaded into the image used to build each component.
 
 ### Requirements
 - `docker` (https://docs.docker.com/engine/installation/)
-- `docker-compose` (https://docs.docker.com/compose/install/)
+- `docker-compose` (https://docs.docker.com/compose/install/) (optional, but recommended)
+
+If `docker-compose` is not available, the `pkg` script will automatically download
+and run it in a container. This is noticeably slower than running it natively.
 
 ### Steps
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -15,22 +15,22 @@ From the top level of the incubator-trafficcontrol directory.  The source in
 the current directory is used for the process.   One or more components (with
 \_build suffix added) can be added on the command line.
 
-Clean up any previously-built docker containers:
-> $ docker-compose -f infrastructure/docker/build/docker-compose.yml down -v
+This is all run automatically by the `pkg` script at the root of the repository.
 
-And images:
-> $ docker images | awk '/traffic\_.*\_build/ { print $3 }' | xargs docker rmi -f
+    $ ./pkg -?
+    Usage: ./pkg [options] [projects]
+        -q      Quiet mode. Supresses output.
+        -v      Verbose mode. Lists all build output.
+        -l      List available projects.
 
-Create and run new build containers:
-> $ docker-compose -f infrastructure/docker/build/docker-compose.yml up [ container name ...] 
-
-Container names can be one or more of these:
-* `source`  (builds only the source tarball)
-* `traffic_monitor_build`
-* `traffic_ops_build`
-* `traffic_portal_build`
-* `traffic_router_build`
-* `traffic_stats_build`
+        If no projects are listed, all projects will be packaged.
+        Valid projects:
+                - traffic_portal_build
+                - traffic_router_build
+                - traffic_monitor_build
+                - source
+                - traffic_ops_build
+                - traffic_stats_build
 
 If no component names are provided on the command line, all components will be built.
 

--- a/infrastructure/docker/build/Dockerfile-traffic_monitor
+++ b/infrastructure/docker/build/Dockerfile-traffic_monitor
@@ -48,10 +48,7 @@ RUN alternatives --install /usr/bin/java java /opt/java/bin/java 2 && \
     alternatives --set javac /opt/java/bin/javac && \
     alternatives --install /usr/bin/mvn mvn /opt/maven/bin/mvn 1
 
-CMD set -x; cp -a /trafficcontrol /tmp/. && \
-	cd /tmp/trafficcontrol && rm -rf dist && mkdir -p dist && \
-	./build/build.sh traffic_monitor 2>&1 | tee ./dist/build-traffic_monitor.log && \
-	mkdir -p /trafficcontrol/dist && \
-	cp dist/*traffic_monitor* /trafficcontrol/dist
+ADD infrastructure/docker/build/clean_build.sh /
+CMD /clean_build.sh traffic_monitor
 
 # vi:syntax=Dockerfile

--- a/infrastructure/docker/build/Dockerfile-traffic_monitor_golang
+++ b/infrastructure/docker/build/Dockerfile-traffic_monitor_golang
@@ -35,11 +35,7 @@ RUN	yum -y install \
 	yum -y clean all
 ###
 
-CMD set -x; cp -a /trafficcontrol /tmp/. && \
-	cd /tmp/trafficcontrol && rm -rf dist && mkdir -p dist && \
-	./build/build.sh traffic_monitor_golang 2>&1 | tee ./dist/build-traffic_monitor_golang.log && \
-	mkdir -p /trafficcontrol/dist && \
-	cp dist/*traffic_monitor_golang* /trafficcontrol/dist
-
+ADD infrastructure/docker/build/clean_build.sh /
+CMD /clean_build.sh traffic_monitor_golang
 
 # vi:syntax=Dockerfile

--- a/infrastructure/docker/build/Dockerfile-traffic_ops
+++ b/infrastructure/docker/build/Dockerfile-traffic_ops
@@ -41,10 +41,7 @@ RUN	yum -y install \
 		tar && \
 	yum -y clean all
 
-CMD set -x; cp -a /trafficcontrol /tmp/. && \
-	cd /tmp/trafficcontrol && rm -rf dist && mkdir -p dist && \
-	./build/build.sh traffic_ops 2>&1 | tee ./dist/build-traffic_ops.log && \
-	mkdir -p /trafficcontrol/dist && \
-	cp dist/*traffic_ops* /trafficcontrol/dist
+ADD infrastructure/docker/build/clean_build.sh /
+CMD /clean_build.sh traffic_ops
 
 # vi:syntax=Dockerfile

--- a/infrastructure/docker/build/Dockerfile-traffic_portal
+++ b/infrastructure/docker/build/Dockerfile-traffic_portal
@@ -47,11 +47,8 @@ RUN	echo '{ "allow_root": true }' > /root/.bowerrc
 
 ###
 
-CMD set -x; cp -a /trafficcontrol /tmp/. && \
-	cd /tmp/trafficcontrol && rm -rf dist && mkdir -p dist && \
-	./build/build.sh traffic_portal 2>&1 | tee ./dist/build-traffic_portal.log && \
-	mkdir -p /trafficcontrol/dist && \
-	cp dist/*traffic_portal* /trafficcontrol/dist
+ADD infrastructure/docker/build/clean_build.sh /
+CMD /clean_build.sh traffic_portal
 
 
 # vi:syntax=Dockerfile

--- a/infrastructure/docker/build/Dockerfile-traffic_router
+++ b/infrastructure/docker/build/Dockerfile-traffic_router
@@ -47,10 +47,7 @@ RUN alternatives --install /usr/bin/java java /opt/java/bin/java 2 && \
     alternatives --install /usr/bin/mvn mvn /opt/maven/bin/mvn 1
 ###
 
-CMD set -x; cp -a /trafficcontrol /tmp/. && \
-	cd /tmp/trafficcontrol && rm -rf dist && mkdir -p dist && \
-	./build/build.sh traffic_router 2>&1 | tee ./dist/build-traffic_router.log && \
-	mkdir -p /trafficcontrol/dist && \
-	cp dist/*traffic_router* /trafficcontrol/dist
+ADD infrastructure/docker/build/clean_build.sh /
+CMD /clean_build.sh traffic_router
 
 # vi:syntax=Dockerfile

--- a/infrastructure/docker/build/Dockerfile-traffic_stats
+++ b/infrastructure/docker/build/Dockerfile-traffic_stats
@@ -35,11 +35,8 @@ RUN	yum -y install \
 	yum -y clean all
 ###
 
-CMD set -x; cp -a /trafficcontrol /tmp/. && \
-	cd /tmp/trafficcontrol && rm -rf dist && mkdir -p dist && \
-	./build/build.sh traffic_stats 2>&1 | tee ./dist/build-traffic_stats.log && \
-	mkdir -p /trafficcontrol/dist && \
-	cp dist/*traffic_stats* /trafficcontrol/dist
+ADD infrastructure/docker/build/clean_build.sh /
+CMD /clean_build.sh traffic_stats
 
 
 # vi:syntax=Dockerfile

--- a/infrastructure/docker/build/clean_build.sh
+++ b/infrastructure/docker/build/clean_build.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env sh
 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -x
 cp -a /trafficcontrol /tmp/. && \
 	cd /tmp/trafficcontrol && \

--- a/infrastructure/docker/build/clean_build.sh
+++ b/infrastructure/docker/build/clean_build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+set -x
+cp -a /trafficcontrol /tmp/. && \
+	cd /tmp/trafficcontrol && \
+	rm -rf dist && \
+	ln -fs /trafficcontrol/dist dist &&
+	((((./build/build.sh $1 2>&1; echo $? >&3) | tee ./dist/build-$1.log >&4) 3>&1) | (read x; exit $x)) 4>&1

--- a/pkg
+++ b/pkg
@@ -6,16 +6,76 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 COMPOSE_FILE=./infrastructure/docker/build/docker-compose.yml
 
 # Check for dependencies
-if ! which docker-compose >/dev/null 2>&1; then
-	echo "Error: docker-compose is required for a docker build." >&2
+if ! which docker >/dev/null 2>&1; then
+	echo "Error: docker is required for a docker build." >&2
 	exit 1
+fi
+
+# If the user defined COMPOSE, use that as the path for docker-compose.
+if [ ! -z "$COMPOSE" ]; then
+	COMPOSECMD=( "$COMPOSE" )
+else
+	COMPOSECMD=()
+fi
+
+# Check to see if docker-compose is already installed and use it directly, if possible.
+if [ ${#COMPOSECMD[@]} -eq 0 ]; then
+	if which docker-compose >/dev/null 2>&1; then
+		COMPOSECMD=( docker-compose )
+	fi
+fi
+
+# If it's unavailable, go get the image and run docker-compose inside a container.
+# This is considerably slower, but allows for building on hosts without docker-compose.
+if [ ${#COMPOSECMD[@]} -eq 0 ]; then
+	# Pin the version of docker-compose.
+	IMAGE="docker/compose:1.11.2"
+
+	# We need to either mount the docker socket or export the docker host into the container.
+	# This allows the container to manage "sibling" containers via docker.
+	if [ -z "$DOCKER_HOST" ]; then
+			DOCKER_HOST="/var/run/docker.sock"
+	fi
+
+	if [ -S "$DOCKER_HOST" ]; then
+			DOCKER_ADDR=(-v "$DOCKER_HOST:$DOCKER_HOST" -e DOCKER_HOST)
+	else
+			DOCKER_ADDR=(-e DOCKER_HOST -e DOCKER_TLS_VERIFY -e DOCKER_CERT_PATH)
+	fi
+
+	# We mount the current directory (the base of the repository) into the same location
+	# inside the container. There are many places for which this won't work, but "/" is
+	# a major one.
+	#
+	# You're going to want to avoid keeping your repository in a folder named "/usr/bin",
+	# "/home", "/var" or any other standard paths that will be needed by the docker container.
+	#
+	# This is very unlikely to cause trouble for anyone in practice.
+	if [ "$(pwd)" == "/" ]; then
+		echo "Error: Cannot compile directly at filesystem root." >&2
+		exit 1
+	fi
+
+	# Mount the working directory, and the home directory. Mounting $HOME provides container
+	# access to config files that are kept there.
+	VOLUMES=(-v "$(pwd):$(pwd)" -v "$HOME:$HOME" -v "$HOME:/root")
+
+	# Prepull the image, to avoid spitting out pull progress during other commands.
+	if ! docker inspect $IMAGE >/dev/null 2>&1; then
+		docker pull $IMAGE >/dev/null 2>&1
+	fi
+
+	# COMPOSECMD is kept as an array to significantly simplify handling paths that contain
+	# spaces and other special characters.
+	COMPOSECMD=(docker run --rm "${DOCKER_ADDR[@]}" $COMPOSE_OPTIONS "${VOLUMES[@]}" -w "$(pwd)" $IMAGE)
 fi
 
 # Parse command line arguments
 verbose=0
-while getopts lvq? opt; do
+while getopts :lvq? opt; do
 	case $opt in
 		\?)
+			PROJECTS=`$SELF -l | sed "s/^/		- /"`
 			echo "Usage: $SELF [options] [projects]"
 			echo "	-q	Quiet mode. Supresses output."
 			echo "	-v	Verbose mode. Lists all build output."
@@ -23,7 +83,7 @@ while getopts lvq? opt; do
 			echo
 			echo "	If no projects are listed, all projects will be packaged."
 			echo "	Valid projects:"
-			$SELF -l | sed "s/^/		- /"
+			cat <<< "$PROJECTS"
 			exit 0
 			;;
 		q)
@@ -33,7 +93,7 @@ while getopts lvq? opt; do
 			verbose=1
 			;;
 		l)
-			docker-compose -f $COMPOSE_FILE config --services
+			"${COMPOSECMD[@]}" -f $COMPOSE_FILE config --services
 			exit $?
 			;;
 	esac
@@ -55,8 +115,8 @@ while (( "$#" )); do
 		if (( "$verbose" == 0 )); then
 			exec >/dev/null 2>&1
 		fi
-		docker-compose -f $COMPOSE_FILE build $1 || exit 1
-		docker-compose -f $COMPOSE_FILE run --rm $1 || exit 1
+		"${COMPOSECMD[@]}" -f $COMPOSE_FILE build $1 || exit 1
+		"${COMPOSECMD[@]}" -f $COMPOSE_FILE run --rm $1 || exit 1
 	) || {
 		# Don't totally bail out, but make note of the failures.
 		failure=1

--- a/pkg
+++ b/pkg
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Files are relative to this script directory.
 SELF="${BASH_SOURCE[0]}"
 cd "$( dirname "${BASH_SOURCE[0]}" )"

--- a/pkg
+++ b/pkg
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Files are relative to this script directory.
+SELF="${BASH_SOURCE[0]}"
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+COMPOSE_FILE=./infrastructure/docker/build/docker-compose.yml
+
+# Check for dependencies
+if ! which docker-compose >/dev/null 2>&1; then
+	echo "Error: docker-compose is required for a docker build." >&2
+	exit 1
+fi
+
+# Parse command line arguments
+verbose=0
+while getopts lvq? opt; do
+	case $opt in
+		\?)
+			echo "Usage: $SELF [options] [projects]"
+			echo "	-q	Quiet mode. Supresses output."
+			echo "	-v	Verbose mode. Lists all build output."
+			echo "	-l	List available projects."
+			echo
+			echo "	If no projects are listed, all projects will be packaged."
+			echo "	Valid projects:"
+			$SELF -l | sed "s/^/		- /"
+			exit 0
+			;;
+		q)
+			exec >/dev/null 2>&1
+			;;
+		v)
+			verbose=1
+			;;
+		l)
+			docker-compose -f $COMPOSE_FILE config --services
+			exit $?
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+
+# If no specific packages are listed, run them all.
+if (( ! "$#" )); then
+	set -- `$SELF -l`
+fi
+
+# Build each project in turn.
+failure=0
+badproj=""
+while (( "$#" )); do
+	echo Building $1.
+	(
+		if (( "$verbose" == 0 )); then
+			exec >/dev/null 2>&1
+		fi
+		docker-compose -f $COMPOSE_FILE build $1 || exit 1
+		docker-compose -f $COMPOSE_FILE run --rm $1 || exit 1
+	) || {
+		# Don't totally bail out, but make note of the failures.
+		failure=1
+		badproj="$badproj $1"
+	}
+	shift
+done
+
+if (( $failure )); then
+	echo "Failed to build$badproj."
+fi
+
+exit $failure


### PR DESCRIPTION
This splits out the somewhat messy docker build command into its own script and adds a global build script.
There’s still work to be done to clean up docker build scripts, but this provides a basic way to build top to bottom
In a single, simple command.

This is a step toward addressing TC-180, but falls short of cleaning up everything that requires cleaning up.