### PR TITLE
Fix Traffic Monitor 2.0 GUI non-reported cache states

### DIFF
--- a/traffic_monitor_golang/traffic_monitor/datareq/datareq.go
+++ b/traffic_monitor_golang/traffic_monitor/datareq/datareq.go
@@ -111,7 +111,7 @@ func MakeDispatchMap(
 			return srvAPITrafficOpsURI(opsConfig)
 		}, ContentTypeJSON)),
 		"/api/cache-statuses": wrap(WrapErr(errorCount, func() ([]byte, error) {
-			return srvAPICacheStates(toData, statInfoHistory, statResultHistory, healthHistory, lastHealthDurations, localStates, lastStats, localCacheStatus, statMaxKbpses)
+			return srvAPICacheStates(toData, statInfoHistory, statResultHistory, healthHistory, lastHealthDurations, localStates, lastStats, localCacheStatus, statMaxKbpses, monitorConfig)
 		}, ContentTypeJSON)),
 		"/api/bandwidth-kbps": wrap(WrapBytes(func() []byte {
 			return srvAPIBandwidthKbps(toData, lastStats)

--- a/traffic_monitor_golang/traffic_monitor/static/index.html
+++ b/traffic_monitor_golang/traffic_monitor/static/index.html
@@ -252,10 +252,11 @@ under the License.
 			 ajax("/api/cache-statuses", function(r) {
 				 var jdata = JSON.parse(r);
 				 var servers = Object.keys(jdata); //debug
+				 var table = document.getElementById("cache-states");
 				 for (i = 0; i < servers.length; i++) {
 					 var server = servers[i];
 					 if (!document.getElementById("cache-states-" + server)) {
-						 var row = document.getElementById("cache-states").insertRow(1); //document.createElement("tr");
+						 var row = table.insertRow(1); //document.createElement("tr");
 						 row.classList.add("stripes");
 						 row.id = "cache-states-" + server
 						 row.insertCell(0).id = row.id + "-server";
@@ -288,11 +289,11 @@ under the License.
 					 if (jdata[server].hasOwnProperty("status")) {
 						 document.getElementById("cache-states-" + server + "-status").textContent = jdata[server].status;
 						 var row = document.getElementById("cache-states-" + server);
-						 if (jdata[server].status.indexOf("ADMIN_DOWN") != -1) {
+						 if (jdata[server].status.indexOf("ADMIN_DOWN") != -1 || jdata[server].status.indexOf("OFFLINE") != -1) {
 							 row.classList.add("warning");
 							 row.classList.remove("error");
 							 row.classList.remove("stripes");
-						 } else if (jdata[server].status.indexOf(" available") == -1) {
+						 } else if (jdata[server].status.indexOf(" available") == -1 && jdata[server].status.indexOf("ONLINE") != 0) {
 							 row.classList.add("error");
 							 row.classList.remove("warning");
 							 row.classList.remove("stripes");
@@ -333,6 +334,14 @@ under the License.
 						 document.getElementById("cache-states-" + server + "-connection-count").textContent = "N/A";
 					 }
 				 }
+
+				 for (var i = 0, row; row = table.rows[i]; i++) {
+					 var server = row.id.replace(/^cache-states-/, '');
+					 if(!(server in jdata)) {
+						 table.deleteRow(i);
+					 }
+				 }
+
 			 })
 		 }
 


### PR DESCRIPTION
Fixes TM2 web GUI to properly display `ONLINE` and `OFFLINE` caches, and to remove caches which existed in a previous CRConfig, but not the latest.