### PR TITLE
fixes UI example delivery URL bug

### DIFF
--- a/traffic_ops/app/lib/UI/DeliveryService.pm
+++ b/traffic_ops/app/lib/UI/DeliveryService.pm
@@ -123,7 +123,7 @@ sub get_example_urls {
 					$url = $scheme . '://' . $re->{pattern};
 					push( @example_urls, $url );
 					if ($scheme2) {
-						$url = $scheme . '://' . $re->{pattern};
+						$url = $scheme2 . '://' . $re->{pattern};
 						push( @example_urls, $url );
 					}
 				}


### PR DESCRIPTION
Example delivery URLS for for http and https delivery services show http for both examples after the first regex.  Corrects that bug.