### PR TITLE
BACKPORT - update CrConfig structs in goTM to work with TO 2.0

### DIFF
--- a/traffic_monitor_golang/traffic_monitor/crconfig/data.go
+++ b/traffic_monitor_golang/traffic_monitor/crconfig/data.go
@@ -168,7 +168,7 @@ type DeliveryService struct {
 	GeoLocationProviderTime time.Time                `json:"-"`
 	MatchSets               []MatchSet               `json:"matchSets,omitempty"`
 	MatchSetsTime           time.Time                `json:"-"`
-	MissLocation            *LatLon                  `json:"missLocation,omitempty"`
+	MissLocation            *LatitudeLongitude       `json:"missLocation,omitempty"`
 	MissLocationTime        time.Time                `json:"-"`
 	Protocol                *DeliveryServiceProtocol `json:"protocol,omitempty"`
 	ProtocolTime            time.Time                `json:"-"`
@@ -180,7 +180,7 @@ type DeliveryService struct {
 	SoaTime                 time.Time                `json:"-"`
 	SSLEnabled              *bool                    `json:"sslEnabled,string,omitempty"`
 	SSLEnabledTime          time.Time                `json:"-"`
-	TTL                     *int                     `json:"ttl,string,omitempty"`
+	TTL                     *int                     `json:"ttl,omitempty"`
 	TTLTime                 time.Time                `json:"-"`
 	TTLs                    *TTL                     `json:"ttls,omitempty"`
 	TTLsTime                time.Time                `json:"-"`
@@ -188,10 +188,6 @@ type DeliveryService struct {
 type Dispersion struct {
 	Limit    int  `json:"limit,omitempty"`
 	Shuffled bool `json:"shuffled,string,omitempty"`
-}
-type LatLon struct {
-	Lat float64 `json:"lat,string"`
-	Lon float64 `json:"lon,string"`
 }
 
 type LatitudeLongitude struct {

--- a/traffic_monitor_golang/traffic_monitor/crconfig/data.go
+++ b/traffic_monitor_golang/traffic_monitor/crconfig/data.go
@@ -108,7 +108,7 @@ type Router struct {
 	APIPortTime   time.Time
 	FQDN          *string `json:"fqdn,omitempty"`
 	FQDNTime      time.Time
-	HTTPSPort     *int `json:"httpsPort,string,omitempty"`
+	HTTPSPort     *int `json:"httpsPort,omitempty"`
 	HTTPSPortTime time.Time
 	IP            *string `json:"ip,omitempty"`
 	IPTime        time.Time
@@ -116,7 +116,7 @@ type Router struct {
 	IP6Time       time.Time
 	Location      *string `json:"location,omitempty"`
 	LocationTime  time.Time
-	Port          *int `json:"port,string,omitempty"`
+	Port          *int `json:"port,omitempty"`
 	PortTime      time.Time
 	Profile       *string `json:"profile,omitempty"`
 	ProfileTime   time.Time
@@ -137,7 +137,7 @@ type Server struct {
 	HashCountTime        time.Time           `json:"-"`
 	HashId               *string             `json:"hashId,omitempty"`
 	HashIdTime           time.Time           `json:"-"`
-	HttpsPort            *int                `json:"httpsPort,string,omitempty"`
+	HttpsPort            *int                `json:"httpsPort,omitempty"`
 	HttpsPortTime        time.Time           `json:"-"`
 	InterfaceName        *string             `json:"interfaceName,omitempty"`
 	InterfaceNameTime    time.Time           `json:"-"`
@@ -147,7 +147,7 @@ type Server struct {
 	Ip6Time              time.Time           `json:"-"`
 	LocationId           *string             `json:"locationId,omitempty"`
 	LocationIdTime       time.Time           `json:"-"`
-	Port                 *int                `json:"port,string,omitempty"`
+	Port                 *int                `json:"port,omitempty"`
 	PortTime             time.Time           `json:"-"`
 	Profile              *string             `json:"profile,omitempty"`
 	ProfileTime          time.Time           `json:"-"`
@@ -207,7 +207,7 @@ type DeliveryServiceProtocol struct {
 type Monitor struct {
 	FQDN          *string   `json:"fqdn,omitempty"`
 	FQDNTime      time.Time `json:"-"`
-	HTTPSPort     *int      `json:"httpsPort,string,omitempty"`
+	HTTPSPort     *int      `json:"httpsPort,omitempty"`
 	HTTPSPortTime time.Time `json:"-"`
 	IP            *string   `json:"ip,omitempty"`
 	IPTime        time.Time `json:"-"`
@@ -215,7 +215,7 @@ type Monitor struct {
 	IP6Time       time.Time `json:"-"`
 	Location      *string   `json:"location,omitempty"`
 	LocationTime  time.Time `json:"-"`
-	Port          *int      `json:"port,string,omitempty"`
+	Port          *int      `json:"port,omitempty"`
 	PortTime      time.Time `json:"-"`
 	Profile       *string   `json:"profile,omitempty"`
 	ProfileTime   time.Time `json:"-"`

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -516,7 +516,7 @@ sub gen_crconfig_json {
         $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'ttls'} = {
             'A'    => "$ds_ttl",
             'AAAA' => "$ds_ttl",
-			 'NS'   => $tld_ttls_ns,
+            'NS'   => $tld_ttls_ns,
             'SOA'  => $tld_ttls_soa
         };
         $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'soa'}->{'minimum'} = $cdn_soa_minimum;

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -512,10 +512,11 @@ sub gen_crconfig_json {
             $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'missLocation'}->{'long'} = $row->miss_long + 0;
         }
 
+        my $ds_ttl = $row->ccr_dns_ttl;
         $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'ttls'} = {
-            'A'    => $row->ccr_dns_ttl,
-            'AAAA' => $row->ccr_dns_ttl,
-            'NS'   => $tld_ttls_ns,
+            'A'    => "$ds_ttl",
+            'AAAA' => "$ds_ttl",
+			 'NS'   => $tld_ttls_ns,
             'SOA'  => $tld_ttls_soa
         };
         $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'soa'}->{'minimum'} = $cdn_soa_minimum;


### PR DESCRIPTION
Some of the fields in the CrConfig were strings in Traffic Ops 1.x and are now ints in Traffic Ops 2.x.
Also fixed [TC-190](https://issues.apache.org/jira/browse/TC-190)