### PR TITLE
[TC-184] Tenancy table creation

### DIFF
--- a/docs/source/development/traffic_ops.rst
+++ b/docs/source/development/traffic_ops.rst
@@ -625,6 +625,7 @@ API 1.2 Reference
   traffic_ops_api/v12/static_dns
   traffic_ops_api/v12/status
   traffic_ops_api/v12/system
+  traffic_ops_api/v12/tenant
   traffic_ops_api/v12/to_extension
   traffic_ops_api/v12/type
   traffic_ops_api/v12/user

--- a/docs/source/development/traffic_ops_api/v12/tenant.rst
+++ b/docs/source/development/traffic_ops_api/v12/tenant.rst
@@ -1,0 +1,242 @@
+..
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _to-api-v12-tenant:
+
+Tenants
+=======
+
+.. _to-api-v12-tenant-route:
+
+/api/1.2/tenants
+++++++++++++++++++
+
+**GET /api/1.2/tenants**
+
+  Get all tenants.
+
+  Authentication Required: Yes
+
+  Role(s) Required: None
+
+  **Response Properties**
+
+  +----------------------+--------+-------------------------------------------------+
+  | Parameter            | Type   | Description                                     |
+  +======================+========+=================================================+
+  |``id``                |  int   | Tenant id                                       |
+  +----------------------+--------+-------------------------------------------------+
+  |``name``              | string | Tenant name                                     |
+  +----------------------+--------+-------------------------------------------------+
+  |``active``            |  bool  | Active or inactive                              |
+  +----------------------+--------+-------------------------------------------------+
+  |``parentId``          |  int   | Parent tenant                                   |
+  +----------------------+--------+-------------------------------------------------+
+
+  **Response Example** ::
+
+    {
+     "response": [
+        {
+           "id": 1
+           "name": "root",
+           "active": true,
+           "parentId": null,
+        },
+        {
+           "id": 2
+           "name": "tenant-a",
+           "active": true,
+           "parentId": 1
+        }
+     ]
+    }
+
+|
+
+
+**GET /api/1.2/tenants/:id**
+
+  Get a tenant by ID.
+
+  Authentication Required: Yes
+
+  Role(s) Required: None
+
+  **Response Properties**
+
+  +----------------------+--------+-------------------------------------------------+
+  | Parameter            | Type   | Description                                     |
+  +======================+========+=================================================+
+  |``id``                |  int   | Tenant id                                       |
+  +----------------------+--------+-------------------------------------------------+
+  |``name``              | string | Tenant name                                     |
+  +----------------------+--------+-------------------------------------------------+
+  |``active``            |  bool  | Active or inactive                              |
+  +----------------------+--------+-------------------------------------------------+
+  |``parentId``          |  int   | Parent tenant                                   |
+  +----------------------+--------+-------------------------------------------------+
+
+  **Response Example** ::
+
+    {
+     "response": [
+        {
+           "id": 2
+           "name": "tenant-a",
+           "active": true,
+           "parentId": 1,
+        }
+     ]
+    }
+
+|
+
+
+**PUT /api/1.2/tenants/:id**
+
+  Update a tenant.
+
+  Authentication Required: Yes
+
+  Role(s) Required: admin or oper
+
+  **Request Route Parameters**
+
+  +-------------------+----------+------------------------------------------------+
+  | Name              |   Type   |                 Description                    |
+  +===================+==========+================================================+
+  | ``id``            |   int    | Tenant id                                      |
+  +-------------------+----------+------------------------------------------------+
+
+  **Request Properties**
+
+  +-------------------+----------+--------------------------+
+  | Parameter         | Required | Description              |
+  +===================+==========+==========================+
+  | ``name``          | yes      | The name of the tenant   |
+  +-------------------+----------+--------------------------+
+  | ``active``        | yes      | True or false            |
+  +-------------------+----------+--------------------------+
+  | ``parentId``      | yes      | Parent tenant            |
+  +-------------------+----------+--------------------------+
+
+  **Request Example** ::
+
+    {
+        "name": "my-tenant"
+        "active": true
+        "parentId": 1
+    }
+
+|
+
+  **Response Properties**
+
+  +----------------------+--------+-------------------------------------------------+
+  | Parameter            | Type   | Description                                     |
+  +======================+========+=================================================+
+  |``id``                |  int   | Tenant id                                       |
+  +----------------------+--------+-------------------------------------------------+
+  |``name``              | string | Tenant name                                     |
+  +----------------------+--------+-------------------------------------------------+
+  |``active``            |  bool  | Active or inactive                              |
+  +----------------------+--------+-------------------------------------------------+
+  |``parentId``          |  int   | Parent tenant                                   |
+  +----------------------+--------+-------------------------------------------------+
+
+  **Response Example** ::
+
+	{
+		"response": {
+			"id": 2,
+			"name": "my-tenant",
+			"active": true,
+			"parentId": 1,
+			"lastUpdated": "2014-03-18 08:57:39"
+		},
+		"alerts": [
+			{
+				"level": "success",
+				"text": "Tenant update was successful."
+			}
+		]
+	}
+
+|
+
+
+**POST /api/1.2/tenants**
+
+  Create a tenant.
+
+  Authentication Required: Yes
+
+  Role(s) Required: admin or oper
+
+  **Request Properties**
+
+  +-------------------+----------+--------------------------+
+  | Parameter         | Required | Description              |
+  +===================+==========+==========================+
+  | ``name``          | yes      | The name of the tenant   |
+  +-------------------+----------+--------------------------+
+  | ``active``        | no       | Defaults to false        |
+  +-------------------+----------+--------------------------+
+  | ``parentId``      | yes      | Parent tenant            |
+  +-------------------+----------+--------------------------+
+
+  **Request Example** ::
+
+    {
+        "name": "your-tenant"
+        "parentId": 2
+    }
+
+|
+
+  **Response Properties**
+
+  +----------------------+--------+-------------------------------------------------+
+  | Parameter            | Type   | Description                                     |
+  +======================+========+=================================================+
+  |``id``                |  int   | Tenant id                                       |
+  +----------------------+--------+-------------------------------------------------+
+  |``name``              | string | Tenant name                                     |
+  +----------------------+--------+-------------------------------------------------+
+  |``active``            |  bool  | Active or inactive                              |
+  +----------------------+--------+-------------------------------------------------+
+  |``parentId``          |  int   | Parent tenant                                   |
+  +----------------------+--------+-------------------------------------------------+
+
+  **Response Example** ::
+
+	{
+		"response": {
+			"id": 2,
+			"name": "your-tenant",
+			"active": false,
+			"parentId": 2,
+			"lastUpdated": "2014-03-18 08:57:39"
+		},
+		"alerts": [
+			{
+				"level": "success",
+				"text": "Tenant create was successful."
+			}
+		]
+	}
+
+|

--- a/traffic_ops/app/db/migrations/20170315000000_basic_tenancy.sql
+++ b/traffic_ops/app/db/migrations/20170315000000_basic_tenancy.sql
@@ -1,0 +1,38 @@
+/*
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+
+-- tenant
+CREATE TABLE tenant (
+    id BIGSERIAL primary key NOT NULL,
+    name text UNIQUE NOT NULL,
+    active boolean NOT NULL DEFAULT false,
+    parent_id bigint DEFAULT 1 CHECK (id != parent_id),
+    CONSTRAINT fk_parentid FOREIGN KEY (parent_id) REFERENCES tenant(id),    
+    last_updated timestamp with time zone DEFAULT now()
+); 
+CREATE INDEX idx_k_tenant_parent_tenant_idx ON tenant USING btree (parent_id);
+
+CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON tenant FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated();
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP TRIGGER on_update_current_timestamp ON tenant;
+
+DROP TABLE tenant;

--- a/traffic_ops/app/lib/API/Tenant.pm
+++ b/traffic_ops/app/lib/API/Tenant.pm
@@ -1,0 +1,247 @@
+package API::Tenant;
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+
+use UI::Utils;
+
+use Mojo::Base 'Mojolicious::Controller';
+use Data::Dumper;
+use JSON;
+use MojoPlugins::Response;
+
+my $finfo = __FILE__ . ":";
+
+sub getTenantName {
+	my $self 		= shift;
+	my $tenant_id		= shift;
+	return defined($tenant_id) ? $self->db->resultset('Tenant')->search( { id => $tenant_id } )->get_column('name')->single() : "n/a";
+}
+
+sub isRootTenant {
+	my $self 	= shift;
+	my $tenant_id	= shift;
+	return !defined($self->db->resultset('Tenant')->search( { id => $tenant_id } )->get_column('parent_id')->single());
+}
+
+sub index {
+	my $self 	= shift;
+
+	my @data;
+	my $orderby = $self->param('orderby') || "name";
+	my $rs_data = $self->db->resultset("Tenant")->search( undef, {order_by => 'me.' . $orderby } );
+	while ( my $row = $rs_data->next ) {
+		push(
+			@data, {
+				"id"           => $row->id,
+				"name"         => $row->name,
+				"active"       => \$row->active,
+				"parentId"     => $row->parent_id,
+			}
+		);
+	}
+	$self->success( \@data );
+}
+
+
+sub show {
+	my $self = shift;
+	my $id   = $self->param('id');
+
+	my $rs_data = $self->db->resultset("Tenant")->search( { 'me.id' => $id });
+	my @data = ();
+	while ( my $row = $rs_data->next ) {
+		push(
+			@data, {
+				"id"           => $row->id,
+				"name"         => $row->name,
+				"active"       => \$row->active,
+				"parentId"     => $row->parent_id,
+			}
+		);
+	}
+	$self->success( \@data );
+}
+
+sub update {
+	my $self   = shift;
+	my $id     = $self->param('id');
+	my $params = $self->req->json;
+
+	if ( !&is_oper($self) ) {
+		return $self->forbidden();
+	}
+
+	my $tenant = $self->db->resultset('Tenant')->find( { id => $id } );
+	if ( !defined($tenant) ) {
+		return $self->not_found();
+	}
+
+	if ( !defined($params) ) {
+		return $self->alert("Parameters must be in JSON format.");
+	}
+
+	if ( !defined( $params->{name} ) ) {
+		return $self->alert("Tenant name is required.");
+	}
+	
+	if ( $params->{name} ne $self->getTenantName($id) ) {
+	        my $name = $params->{name};
+		my $existing = $self->db->resultset('Tenant')->search( { name => $name } )->get_column('name')->single();
+		if ($existing) {
+			return $self->alert("A tenant with name \"$name\" already exists.");
+		}	
+	}	
+
+	if ( !defined( $params->{parentId}) && !$self->isRootTenant($id) ) {
+		return $self->alert("Parent Id is required.");
+	}
+	
+	my $is_active = $params->{active};
+	
+	if ( !$params->{active} && $self->isRootTenant($id)) {
+		return $self->alert("Root user cannot be in-active.");
+	}
+	
+
+	if ( !defined($params->{parentId}) && !isRootTenant($id) ) {
+		return $self->alert("Only the \"root\" tenant can have no parent.");
+	}
+	
+	my $values = {
+		name      => $params->{name},
+		active    => $params->{active},
+		parent_id => $params->{parentId}
+	};
+
+	my $rs = $tenant->update($values);
+	if ($rs) {
+		my $response;
+		$response->{id}          = $rs->id;
+		$response->{name}        = $rs->name;
+		$response->{active}      = \$rs->active;
+		$response->{parentId}    = $rs->parent_id;
+		$response->{lastUpdated} = $rs->last_updated;
+		&log( $self, "Updated Tenant name '" . $rs->name . "' for id: " . $rs->id, "APICHANGE" );
+		return $self->success( $response, "Tenant update was successful." );
+	}
+	else {
+		return $self->alert("Tenant update failed.");
+	}
+
+}
+
+
+sub create {
+	my $self   = shift;
+	my $params = $self->req->json;
+
+	if ( !&is_oper($self) ) {
+		return $self->forbidden();
+	}
+
+	my $name = $params->{name};
+	if ( !defined($name) ) {
+		return $self->alert("Tenant name is required.");
+	}
+
+	my $parent_id = $params->{parentId};
+	if ( !defined($parent_id) ) {
+		return $self->alert("Parent Id is required.");
+	}
+
+	my $existing = $self->db->resultset('Tenant')->search( { name => $name } )->get_column('name')->single();
+	if ($existing) {
+		return $self->alert("A tenant with name \"$name\" already exists.");
+	}
+
+	my $is_active = exists($params->{active})? $params->{active} : 0; #optional, if not set use default
+	
+	if ( !$is_active && !defined($parent_id)) {
+		return $self->alert("Root user cannot be in-active.");
+	}
+	
+	my $values = {
+		name 		=> $params->{name} ,
+		active		=> $is_active,
+		parent_id 	=> $params->{parentId}
+	};
+
+	my $insert = $self->db->resultset('Tenant')->create($values);
+	my $rs = $insert->insert();
+	if ($rs) {
+		my $response;
+		$response->{id}          	= $rs->id;
+		$response->{name}        	= $rs->name;
+		$response->{active}        	= \$rs->active;
+		$response->{parentId}           = $rs->parent_id;
+		$response->{lastUpdated} 	= $rs->last_updated;
+
+		&log( $self, "Created Tenant name '" . $rs->name . "' for id: " . $rs->id, "APICHANGE" );
+
+		return $self->success( $response, "Tenant create was successful." );
+	}
+	else {
+		return $self->alert("Tenant create failed.");
+	}
+
+}
+
+
+sub delete {
+	my $self = shift;
+	my $id     = $self->param('id');
+
+	if ( !&is_oper($self) ) {
+		return $self->forbidden();
+	}
+
+	my $tenant = $self->db->resultset('Tenant')->find( { id => $id } );
+	if ( !defined($tenant) ) {
+		return $self->not_found();
+	}	
+	my $name = $self->db->resultset('Tenant')->search( { id => $id } )->get_column('name')->single();
+	
+	my $existing_child = $self->db->resultset('Tenant')->search( { parent_id => $id } )->get_column('name')->first();
+	if ($existing_child) {
+		return $self->alert("Tenant '$name' has children tenant(s): e.g '$existing_child'. Please update these tenants and retry.");
+	}
+
+	#The order of the below tests is intentional - allowing UT to cover all cases - TODO(nirs) remove this comment when a full "tenancy" UT is added, including permissions and such (no use in putting effort into it yet)
+	#TODO(nirs) - add back when making available: my $existing_ds = $self->db->resultset('Deliveryservice')->search( { tenant_id => $id })->get_column('xml_id')->first();
+	#TODO(nirs) - add back when making available: if ($existing_ds) {
+	#TODO(nirs) - add back when making available: 	return $self->alert("Tenant '$name' is assign with delivery-services(s): e.g. '$existing_ds'. Please update/delete these delivery-services and retry.");
+	#TODO(nirs) - add back when making available: }
+
+	#TODO(nirs) - add back when making available: my $existing_cdn = $self->db->resultset('Cdn')->search( { tenant_id => $id })->get_column('name')->first();
+	#TODO(nirs) - add back when making available: if ($existing_cdn) {
+	#TODO(nirs) - add back when making available: 	return $self->alert("Tenant '$name' is assign with CDNs(s): e.g. '$existing_cdn'. Please update/delete these CDNs and retry.");
+	#TODO(nirs) - add back when making available: }
+
+	#TODO(nirs) - add back when making available: my $existing_user = $self->db->resultset('TmUser')->search( { tenant_id => $id })->get_column('username')->first();
+	#TODO(nirs) - add back when making available: if ($existing_user) {
+	#TODO(nirs) - add back when making available: 	return $self->alert("Tenant '$name' is assign with user(s): e.g. '$existing_user'. Please update these users and retry.");
+	#TODO(nirs) - add back when making available: }
+
+	my $rs = $tenant->delete();
+	if ($rs) {
+		return $self->success_message("Tenant deleted.");
+	} else {
+		return $self->alert( "Tenant delete failed." );
+	}
+}
+
+

--- a/traffic_ops/app/lib/API/Tenant.pm
+++ b/traffic_ops/app/lib/API/Tenant.pm
@@ -220,22 +220,6 @@ sub delete {
 		return $self->alert("Tenant '$name' has children tenant(s): e.g '$existing_child'. Please update these tenants and retry.");
 	}
 
-	#The order of the below tests is intentional - allowing UT to cover all cases - TODO(nirs) remove this comment when a full "tenancy" UT is added, including permissions and such (no use in putting effort into it yet)
-	#TODO(nirs) - add back when making available: my $existing_ds = $self->db->resultset('Deliveryservice')->search( { tenant_id => $id })->get_column('xml_id')->first();
-	#TODO(nirs) - add back when making available: if ($existing_ds) {
-	#TODO(nirs) - add back when making available: 	return $self->alert("Tenant '$name' is assign with delivery-services(s): e.g. '$existing_ds'. Please update/delete these delivery-services and retry.");
-	#TODO(nirs) - add back when making available: }
-
-	#TODO(nirs) - add back when making available: my $existing_cdn = $self->db->resultset('Cdn')->search( { tenant_id => $id })->get_column('name')->first();
-	#TODO(nirs) - add back when making available: if ($existing_cdn) {
-	#TODO(nirs) - add back when making available: 	return $self->alert("Tenant '$name' is assign with CDNs(s): e.g. '$existing_cdn'. Please update/delete these CDNs and retry.");
-	#TODO(nirs) - add back when making available: }
-
-	#TODO(nirs) - add back when making available: my $existing_user = $self->db->resultset('TmUser')->search( { tenant_id => $id })->get_column('username')->first();
-	#TODO(nirs) - add back when making available: if ($existing_user) {
-	#TODO(nirs) - add back when making available: 	return $self->alert("Tenant '$name' is assign with user(s): e.g. '$existing_user'. Please update these users and retry.");
-	#TODO(nirs) - add back when making available: }
-
 	my $rs = $tenant->delete();
 	if ($rs) {
 		return $self->success_message("Tenant deleted.");

--- a/traffic_ops/app/lib/API/Tenant.pm
+++ b/traffic_ops/app/lib/API/Tenant.pm
@@ -110,6 +110,10 @@ sub update {
 		return $self->alert("Parent Id is required.");
 	}
 	
+	if ( !defined( $params->{active} ) ) {
+		return $self->alert("Active field is required.");
+	}
+
 	my $is_active = $params->{active};
 	
 	if ( !$params->{active} && $self->isRootTenant($id)) {

--- a/traffic_ops/app/lib/Fixtures/Tenant.pm
+++ b/traffic_ops/app/lib/Fixtures/Tenant.pm
@@ -19,7 +19,6 @@ use namespace::autoclean;
 use Digest::SHA1 qw(sha1_hex);
 
 my %definition_for = (
-	## id => 1
 	root_tenant_name => {
 		new   => 'Tenant',
 		using => {

--- a/traffic_ops/app/lib/Fixtures/Tenant.pm
+++ b/traffic_ops/app/lib/Fixtures/Tenant.pm
@@ -1,0 +1,46 @@
+package Fixtures::Tenant;
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use Moose;
+extends 'DBIx::Class::EasyFixture';
+use namespace::autoclean;
+use Digest::SHA1 qw(sha1_hex);
+
+my %definition_for = (
+	## id => 1
+	root_tenant_name => {
+		new   => 'Tenant',
+		using => {
+			id          => 10**9, #a large number not to confuse the id sequence
+			name        => 'root',
+			active      => 1,
+			parent_id   => undef,
+		},
+	},
+);
+
+sub get_definition {
+	my ( $self, $name ) = @_;
+	return $definition_for{$name};
+}
+
+sub all_fixture_names {
+	# sort by db id to guarantee insert order
+	return (sort { $definition_for{$a}{using}{id} cmp $definition_for{$b}{using}{id} } keys %definition_for);
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/traffic_ops/app/lib/Schema/Result/Tenant.pm
+++ b/traffic_ops/app/lib/Schema/Result/Tenant.pm
@@ -1,0 +1,157 @@
+use utf8;
+package Schema::Result::Tenant;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Schema::Result::Tenant
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 TABLE: C<tenant>
+
+=cut
+
+__PACKAGE__->table("tenant");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'bigint'
+  is_auto_increment: 1
+  is_nullable: 0
+  sequence: 'tenant_id_seq'
+
+=head2 name
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 active
+
+  data_type: 'boolean'
+  default_value: false
+  is_nullable: 0
+
+=head2 parent_id
+
+  data_type: 'bigint'
+  default_value: 1
+  is_foreign_key: 1
+  is_nullable: 1
+
+=head2 last_updated
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 1
+  original: {default_value => \"now()"}
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "bigint",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "tenant_id_seq",
+  },
+  "name",
+  { data_type => "text", is_nullable => 0 },
+  "active",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "parent_id",
+  {
+    data_type      => "bigint",
+    default_value  => 1,
+    is_foreign_key => 1,
+    is_nullable    => 1,
+  },
+  "last_updated",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 1,
+    original      => { default_value => \"now()" },
+  },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<tenant_name_key>
+
+=over 4
+
+=item * L</name>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("tenant_name_key", ["name"]);
+
+=head1 RELATIONS
+
+=head2 parent
+
+Type: belongs_to
+
+Related object: L<Schema::Result::Tenant>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "parent",
+  "Schema::Result::Tenant",
+  { id => "parent_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+=head2 tenants
+
+Type: has_many
+
+Related object: L<Schema::Result::Tenant>
+
+=cut
+
+__PACKAGE__->has_many(
+  "tenants",
+  "Schema::Result::Tenant",
+  { "foreign.parent_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07046 @ 2017-03-13 09:41:00
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:a816RdXB0mjimo2LvnqX/Q
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/traffic_ops/app/lib/Test/TestHelper.pm
+++ b/traffic_ops/app/lib/Test/TestHelper.pm
@@ -37,6 +37,7 @@ use Fixtures::ProfileParameter;
 use Fixtures::Role;
 use Fixtures::Server;
 use Fixtures::Status;
+use Fixtures::Tenant;
 use Fixtures::TmUser;
 use Fixtures::Type;
 use Fixtures::Division;
@@ -103,6 +104,7 @@ sub load_core_data {
 
 	$self->reset_sequence_id();
 
+        $self->load_all_fixtures( Fixtures::Tenant->new($schema_values) );
 	$self->load_all_fixtures( Fixtures::Cdn->new($schema_values) );
 	$self->load_all_fixtures( Fixtures::Role->new($schema_values) );
 	$self->load_all_fixtures( Fixtures::TmUser->new($schema_values) );
@@ -153,6 +155,7 @@ sub unload_core_data {
 	$self->teardown($schema, 'Status');
 	$self->teardown($schema, 'Snapshot');
 	$self->teardown($schema, 'Cdn');
+	$self->teardown($schema, 'Tenant');
 }
 
 sub teardown {

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -557,6 +557,13 @@ sub api_routes {
 	# Supports ?orderby=key
 	$r->get("/api/$version/deliveryserviceserver")->over( authenticated => 1 )->to( 'DeliveryServiceServer#index', namespace => $namespace );
 
+	# -- TENANTS
+	$r->get("/api/$version/tenants")->over( authenticated => 1 )->to( 'Tenant#index', namespace => $namespace );
+	$r->get( "/api/$version/tenants/:id" => [ id => qr/\d+/ ] )->over( authenticated => 1 )->to( 'Tenant#show', namespace => $namespace );
+	$r->put("/api/$version/tenants/:id")->over( authenticated => 1 )->to( 'Tenant#update', namespace => $namespace );
+	$r->post("/api/$version/tenants")->over( authenticated => 1 )->to( 'Tenant#create', namespace => $namespace );
+	$r->delete("/api/$version/tenants/:id")->over( authenticated => 1 )->to( 'Tenant#delete', namespace => $namespace );
+
 	# -- DIVISIONS
 	$r->get("/api/$version/divisions")->over( authenticated => 1 )->to( 'Division#index', namespace => $namespace );
 	$r->get( "/api/$version/divisions/:id" => [ id => qr/\d+/ ] )->over( authenticated => 1 )->to( 'Division#show', namespace => $namespace );

--- a/traffic_ops/app/t/api/1.2/cachegroup.t
+++ b/traffic_ops/app/t/api/1.2/cachegroup.t
@@ -37,6 +37,7 @@ Test::TestHelper->unload_core_data($schema);
 
 # Load the test data up until 'cachegroup', because this test case creates
 # them.
+Test::TestHelper->load_all_fixtures( Fixtures::Tenant->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::Cdn->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::Role->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::TmUser->new($schema_values) );

--- a/traffic_ops/app/t/api/1.2/federation_external.t
+++ b/traffic_ops/app/t/api/1.2/federation_external.t
@@ -39,6 +39,7 @@ my $schema_values = { schema => $schema, no_transactions => 1 };
 
 #unload data for a clean test
 Test::TestHelper->unload_core_data($schema);
+Test::TestHelper->load_all_fixtures( Fixtures::Tenant->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::Cdn->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::Role->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::TmUser->new($schema_values) );

--- a/traffic_ops/app/t/api/1.2/parameter.t
+++ b/traffic_ops/app/t/api/1.2/parameter.t
@@ -38,6 +38,7 @@ Test::TestHelper->unload_core_data($schema);
 
 # Load the test data up until 'cachegroup', because this test case creates
 # them.
+Test::TestHelper->load_all_fixtures( Fixtures::Tenant->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::Cdn->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::Role->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::TmUser->new($schema_values) );

--- a/traffic_ops/app/t/api/1.2/profile_parameter.t
+++ b/traffic_ops/app/t/api/1.2/profile_parameter.t
@@ -35,6 +35,7 @@ my $dbh    = Schema->database_handle;
 my $t      = Test::Mojo->new('TrafficOps');
 
 Test::TestHelper->unload_core_data($schema);
+Test::TestHelper->load_all_fixtures( Fixtures::Tenant->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::Cdn->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::Role->new($schema_values) );
 Test::TestHelper->load_all_fixtures( Fixtures::TmUser->new($schema_values) );

--- a/traffic_ops/app/t/api/1.2/tenant.t
+++ b/traffic_ops/app/t/api/1.2/tenant.t
@@ -1,0 +1,155 @@
+package main;
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use Mojo::Base -strict;
+use Test::More;
+use Test::Mojo;
+use DBI;
+use strict;
+use warnings;
+no warnings 'once';
+use warnings 'all';
+use Test::TestHelper;
+
+#no_transactions=>1 ==> keep fixtures after every execution, beware of duplicate data!
+#no_transactions=>0 ==> delete fixtures after every execution
+
+BEGIN { $ENV{MOJO_MODE} = "test" }
+
+my $schema = Schema->connect_to_database;
+my $dbh    = Schema->database_handle;
+my $t      = Test::Mojo->new('TrafficOps');
+
+Test::TestHelper->unload_core_data($schema);
+Test::TestHelper->load_core_data($schema);
+
+ok $t->post_ok( '/login', => form => { u => Test::TestHelper::ADMIN_USER, p => Test::TestHelper::ADMIN_USER_PASSWORD } )->status_is(302)
+	->or( sub { diag $t->tx->res->content->asset->{content}; } ), 'Should login?';
+
+#verifying the basic cfg
+$t->get_ok("/api/1.2/tenants")->status_is(200)->json_is( "/response/0/name", "root" )->or( sub { diag $t->tx->res->content->asset->{content}; } );;
+
+my $root_tenant_id = &get_tenant_id('root');
+
+#setting with no "active" field which is optional
+ok $t->post_ok('/api/1.2/tenants' => {Accept => 'application/json'} => json => {
+        "name" => "tenantA", "parentId" => $root_tenant_id })->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+	->json_is( "/response/name" => "tenantA" )
+	->json_is( "/response/active" =>  0)
+	->json_is( "/response/parentId" =>  $root_tenant_id)
+            , 'Does the tenant details return?';
+
+#same name - would not accept
+ok $t->post_ok('/api/1.2/tenants' => {Accept => 'application/json'} => json => {
+        "name" => "tenantA", "active" => 1, "parentId" => $root_tenant_id })->status_is(400);
+
+#no name - would not accept
+ok $t->post_ok('/api/1.2/tenants' => {Accept => 'application/json'} => json => {
+        "parentId" => $root_tenant_id })->status_is(400);
+
+#no parent - would not accept
+ok $t->post_ok('/api/1.2/tenants' => {Accept => 'application/json'} => json => {
+        "name" => "tenantB" })->status_is(400);
+
+my $tenantA_id = &get_tenant_id('tenantA');
+#rename, and move to active
+ok $t->put_ok('/api/1.2/tenants/' . $tenantA_id  => {Accept => 'application/json'} => json => {
+			"name" => "tenantA2", "active" => 1, "parentId" => $root_tenant_id 
+		})
+		->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+		->json_is( "/response/name" => "tenantA2" )
+		->json_is( "/response/id" => $tenantA_id )
+		->json_is( "/response/active" => 1 )
+		->json_is( "/response/parentId" => $root_tenant_id )
+		->json_is( "/alerts/0/level" => "success" )
+	, 'Does the tenantA2 details return?';
+
+#change "active"
+ok $t->put_ok('/api/1.2/tenants/' . $tenantA_id  => {Accept => 'application/json'} => json => {
+			"name" => "tenantA2", "active" => 0, "parentId" => $root_tenant_id 
+		})
+		->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+		->json_is( "/response/name" => "tenantA2" )
+		->json_is( "/response/id" => $tenantA_id )
+		->json_is( "/response/active" => 0 )
+		->json_is( "/response/parentId" => $root_tenant_id )
+		->json_is( "/alerts/0/level" => "success" )
+	, 'Did we moved to non active?';
+
+#change "active" back
+ok $t->put_ok('/api/1.2/tenants/' . $tenantA_id  => {Accept => 'application/json'} => json => {
+			"name" => "tenantA2", "active" => 1, "parentId" => $root_tenant_id 
+		})
+		->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+		->json_is( "/response/name" => "tenantA2" )
+		->json_is( "/response/id" => $tenantA_id )
+		->json_is( "/response/active" => 1 )
+		->json_is( "/response/parentId" => $root_tenant_id )
+		->json_is( "/alerts/0/level" => "success" )
+	, 'Did we moved back to active?';
+
+#cannot change tenant parent to undef
+ok $t->put_ok('/api/1.2/tenants/' . $tenantA_id  => {Accept => 'application/json'} => json => {
+			"name" => "tenantC", 
+		})->status_is(400);
+
+#cannot change root-tenant to inactive
+ok $t->put_ok('/api/1.2/tenants/' . $root_tenant_id  => {Accept => 'application/json'} => json => {
+			"name" => "root", "active" => 0, "parentId" => undef  
+		})->status_is(400);
+
+#adding a child tenant
+ok $t->post_ok('/api/1.2/tenants' => {Accept => 'application/json'} => json => {
+        "name" => "tenantD", "active" => 1, "parentId" => $tenantA_id })->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+	->json_is( "/response/name" => "tenantD" )
+	->json_is( "/response/active" => 1 )
+	->json_is( "/response/parentId" =>  $tenantA_id)
+            , 'Does the tenant details return?';
+
+#adding a child inactive tenant
+ok $t->post_ok('/api/1.2/tenants' => {Accept => 'application/json'} => json => {
+        "name" => "tenantE", "active" => 0, "parentId" => $tenantA_id })->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+	->json_is( "/response/name" => "tenantE" )
+	->json_is( "/response/active" => 0 )
+	->json_is( "/response/parentId" =>  $tenantA_id)
+            , 'Does the tenant details return?';
+
+#cannot delete a tenant that have children
+ok $t->delete_ok('/api/1.2/tenants/' . $tenantA_id)->status_is(400)
+	->json_is( "/alerts/0/text" => "Tenant 'tenantA2' has children tenant(s): e.g 'tenantD'. Please update these tenants and retry." )
+	->or( sub { diag $t->tx->res->content->asset->{content}; } );
+
+my $tenantD_id = &get_tenant_id('tenantD');
+my $tenantE_id = &get_tenant_id('tenantE');
+
+ok $t->delete_ok('/api/1.2/tenants/' . $tenantE_id)->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } );
+ok $t->delete_ok('/api/1.2/tenants/' . $tenantD_id)->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } );
+ok $t->delete_ok('/api/1.2/tenants/' . $tenantA_id)->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } );
+
+ok $t->get_ok('/logout')->status_is(302)->or( sub { diag $t->tx->res->content->asset->{content}; } );
+$dbh->disconnect();
+done_testing();
+
+sub get_tenant_id {
+	my $name = shift;
+	my $q    = "select id from tenant where name = \'$name\'";
+	my $get_svr = $dbh->prepare($q);
+	$get_svr->execute();
+	my $p = $get_svr->fetchall_arrayref( {} );
+	$get_svr->finish();
+	my $id = $p->[0]->{id};
+	return $id;
+}
+

--- a/traffic_ops/app/t/api/1.2/tenant.t
+++ b/traffic_ops/app/t/api/1.2/tenant.t
@@ -102,13 +102,27 @@ ok $t->put_ok('/api/1.2/tenants/' . $tenantA_id  => {Accept => 'application/json
 
 #cannot change tenant parent to undef
 ok $t->put_ok('/api/1.2/tenants/' . $tenantA_id  => {Accept => 'application/json'} => json => {
-			"name" => "tenantC", 
-		})->status_is(400);
+			"name" => "tenantC", "active" => 1})
+			->json_is( "/alerts/0/text" => "Parent Id is required.")
+			->status_is(400);
+
+#cannot skip "active" field on "put"
+ok $t->put_ok('/api/1.2/tenants/' . $tenantA_id  => {Accept => 'application/json'} => json => {
+			"name" => "tenantC", "parentId" => $root_tenant_id})
+			->json_is( "/alerts/0/text" => "Active field is required.")
+			->status_is(400);
+
+#cannot skip "name" field on "put"
+ok $t->put_ok('/api/1.2/tenants/' . $tenantA_id  => {Accept => 'application/json'} => json => {
+			"active" => 1, "parentId" => $root_tenant_id})
+			->json_is( "/alerts/0/text" => "Tenant name is required.")
+			->status_is(400);
 
 #cannot change root-tenant to inactive
 ok $t->put_ok('/api/1.2/tenants/' . $root_tenant_id  => {Accept => 'application/json'} => json => {
-			"name" => "root", "active" => 0, "parentId" => undef  
-		})->status_is(400);
+			"name" => "root", "active" => 0, "parentId" => undef})
+			->json_is( "/alerts/0/text" => "Root user cannot be in-active.")
+			->status_is(400);
 
 #adding a child tenant
 ok $t->post_ok('/api/1.2/tenants' => {Accept => 'application/json'} => json => {


### PR DESCRIPTION
This PR is the first step in adding "org tenancy" to TC. It comes to start and replace PR-322
It define the tenants table, including an "active" flag as well as "parent-tenant".
This PR is pre-requisite for adding the tenancy to the Users/CDN/DS tables