### PR TITLE
Reverse schema gaps

### DIFF
--- a/traffic_ops/app/lib/Schema/Result/Deliveryservice.pm
+++ b/traffic_ops/app/lib/Schema/Result/Deliveryservice.pm
@@ -278,6 +278,11 @@ __PACKAGE__->table("deliveryservice");
   default_value: false
   is_nullable: 1
 
+=head2 multi_site_origin_algorithm
+
+  data_type: 'smallint'
+  is_nullable: 1
+
 =head2 geolimit_redirect_url
 
   data_type: 'text'
@@ -390,6 +395,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "logs_enabled",
   { data_type => "boolean", default_value => \"false", is_nullable => 1 },
+  "multi_site_origin_algorithm",
+  { data_type => "smallint", is_nullable => 1 },
   "geolimit_redirect_url",
   { data_type => "text", is_nullable => 1 },
 );
@@ -410,7 +417,7 @@ __PACKAGE__->set_primary_key("id", "type");
 
 =head1 UNIQUE CONSTRAINTS
 
-=head2 C<idx_101208_ds_id_unique>
+=head2 C<idx_89502_ds_id_unique>
 
 =over 4
 
@@ -420,9 +427,9 @@ __PACKAGE__->set_primary_key("id", "type");
 
 =cut
 
-__PACKAGE__->add_unique_constraint("idx_101208_ds_id_unique", ["id"]);
+__PACKAGE__->add_unique_constraint("idx_89502_ds_id_unique", ["id"]);
 
-=head2 C<idx_101208_ds_name_unique>
+=head2 C<idx_89502_ds_name_unique>
 
 =over 4
 
@@ -432,7 +439,7 @@ __PACKAGE__->add_unique_constraint("idx_101208_ds_id_unique", ["id"]);
 
 =cut
 
-__PACKAGE__->add_unique_constraint("idx_101208_ds_name_unique", ["xml_id"]);
+__PACKAGE__->add_unique_constraint("idx_89502_ds_name_unique", ["xml_id"]);
 
 =head1 RELATIONS
 
@@ -607,8 +614,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07046 @ 2017-01-02 16:07:07
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qCU9AxWN09+5k2ETT6tqSQ
+# Created by DBIx::Class::Schema::Loader v0.07046 @ 2017-03-16 16:59:01
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:w/FF9Gbxaf+TQm5Vv/k5ng
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 #

--- a/traffic_ops/app/lib/Schema/Result/GooseDbVersion.pm
+++ b/traffic_ops/app/lib/Schema/Result/GooseDbVersion.pm
@@ -25,25 +25,24 @@ __PACKAGE__->table("goose_db_version");
 
 =head2 id
 
-  data_type: 'bigint'
+  data_type: 'integer'
   is_auto_increment: 1
   is_nullable: 0
   sequence: 'goose_db_version_id_seq'
 
 =head2 version_id
 
-  data_type: 'numeric'
+  data_type: 'bigint'
   is_nullable: 0
 
 =head2 is_applied
 
   data_type: 'boolean'
-  default_value: false
   is_nullable: 0
 
 =head2 tstamp
 
-  data_type: 'timestamp with time zone'
+  data_type: 'timestamp'
   default_value: current_timestamp
   is_nullable: 1
   original: {default_value => \"now()"}
@@ -53,18 +52,18 @@ __PACKAGE__->table("goose_db_version");
 __PACKAGE__->add_columns(
   "id",
   {
-    data_type         => "bigint",
+    data_type         => "integer",
     is_auto_increment => 1,
     is_nullable       => 0,
     sequence          => "goose_db_version_id_seq",
   },
   "version_id",
-  { data_type => "numeric", is_nullable => 0 },
+  { data_type => "bigint", is_nullable => 0 },
   "is_applied",
-  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  { data_type => "boolean", is_nullable => 0 },
   "tstamp",
   {
-    data_type     => "timestamp with time zone",
+    data_type     => "timestamp",
     default_value => \"current_timestamp",
     is_nullable   => 1,
     original      => { default_value => \"now()" },
@@ -84,8 +83,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("id");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2016-11-15 09:35:47
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:kNbDG4yXcgqGB2dRrmtF6A
+# Created by DBIx::Class::Schema::Loader v0.07046 @ 2017-03-16 16:59:01
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:2Wz488ewfMFOofpvcO6l7g
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/traffic_ops/app/lib/Schema/Result/Type.pm
+++ b/traffic_ops/app/lib/Schema/Result/Type.pm
@@ -89,20 +89,6 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->set_primary_key("id");
 
-=head1 UNIQUE CONSTRAINTS
-
-=head2 C<idx_54562_name_unique>
-
-=over 4
-
-=item * L</name>
-
-=back
-
-=cut
-
-__PACKAGE__->add_unique_constraint("idx_54562_name_unique", ["name"]);
-
 =head1 RELATIONS
 
 =head2 cachegroups
@@ -211,8 +197,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07046 @ 2016-11-18 22:45:19
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:JIvzUMeCc2ZVQpQLxITmHQ
+# Created by DBIx::Class::Schema::Loader v0.07046 @ 2017-03-16 16:59:01
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:bVZ5hEoIxEeHxgJ3AO9ndw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration


### PR DESCRIPTION
While working on the multi-tenancy project, I noticed the "reverse_schema" db admin command further change files I have not touched. It seems that these files should have been updated along some previous submit.
This PR comes to close the gap.
