### PR TITLE
Adds Traffic Ops client Server(), Fixes tests, Fixes broken Users() and Types()

### DIFF
--- a/traffic_ops/app/lib/API/Server.pm
+++ b/traffic_ops/app/lib/API/Server.pm
@@ -633,9 +633,8 @@ sub details_v11 {
 	my $isadmin   = &is_admin($self);
 	my $host_name = $self->param('name');
 	my $rs_data   = $self->db->resultset('Server')->search( { host_name => $host_name },
-		{ prefetch => [ 'cachegroup', 'type', 'profile', 'status', 'phys_location', 'hwinfos', { 'deliveryservice_servers' => 'deliveryservice' } ], } );
+																											 { prefetch => [ 'cdn', 'cachegroup', 'type', 'profile', 'status', 'phys_location', 'hwinfos', { 'deliveryservice_servers' => 'deliveryservice' } ], } );
 	while ( my $row = $rs_data->next ) {
-
 		my $serv = {
 			"id"             => $row->id,
 			"hostName"       => $row->host_name,
@@ -670,6 +669,7 @@ sub details_v11 {
 			"iloPassword"    => $isadmin ? $row->ilo_password : "********",
 			"routerHostName" => $row->router_host_name,
 			"routerPortName" => $row->router_port_name,
+			"cdnName"        => $row->cdn->name,
 		};
 		my $hw_rs = $row->hwinfos;
 		while ( my $hwinfo_row = $hw_rs->next ) {

--- a/traffic_ops/app/lib/API/Server.pm
+++ b/traffic_ops/app/lib/API/Server.pm
@@ -633,7 +633,7 @@ sub details_v11 {
 	my $isadmin   = &is_admin($self);
 	my $host_name = $self->param('name');
 	my $rs_data   = $self->db->resultset('Server')->search( { host_name => $host_name },
-																											 { prefetch => [ 'cdn', 'cachegroup', 'type', 'profile', 'status', 'phys_location', 'hwinfos', { 'deliveryservice_servers' => 'deliveryservice' } ], } );
+		{ prefetch => [ 'cdn', 'cachegroup', 'type', 'profile', 'status', 'phys_location', 'hwinfos', { 'deliveryservice_servers' => 'deliveryservice' } ], } );
 	while ( my $row = $rs_data->next ) {
 		my $serv = {
 			"id"             => $row->id,

--- a/traffic_ops/client/fixtures/server.go
+++ b/traffic_ops/client/fixtures/server.go
@@ -149,3 +149,42 @@ func LogstashServers() *client.ServerResponse {
 		},
 	}
 }
+
+// Server returns a default ServerResponse to be used for testing.
+func Server() *client.ServerDetailResponse {
+	return &client.ServerDetailResponse{
+		Response: client.Server{
+			ID:             001,
+			HostName:       "edge-alb-01",
+			DomainName:     "albuquerque.nm.albuq.kabletown.com",
+			CDNName:        "CDN-1",
+			Type:           "EDGE",
+			Profile:        "EDGE1_CDN_520",
+			TCPPort:        80,
+			Rack:           "F-4/35",
+			PhysLocation:   "Albuquerque",
+			Cachegroup:     "albuquerque",
+			IP6Address:     "2001:558:fe18:7::2/64",
+			IP6Gateway:     "2001:558:fe18:7::1",
+			IPAddress:      "10.10.10.10",
+			IPGateway:      "10.10.10.10",
+			IPNetmask:      "255.255.255.252",
+			MgmtIPAddress:  "",
+			MgmtIPNetmask:  "",
+			MgmtIPGateway:  "",
+			Status:         "REPORTED",
+			XMPPID:         "edge-alb-01",
+			XMPPPasswd:     "**********",
+			IloIPAddress:   "10.10.10.10",
+			IloUsername:    "vssilo",
+			IloPassword:    "password",
+			IloIPGateway:   "10.10.10.10",
+			IloIPNetmask:   "255.255.255.192",
+			InterfaceName:  "bond0",
+			InterfaceMtu:   9000,
+			RouterPortName: "TenGigE0/3/0/10\t|\tBundle-Ether1000\t|\tPHY|10G|AGG-MEMBER|dtype:IPCDN-EDGE|rhost:edge-alb-01|rport:eth1|lagg:1000",
+			RouterHostName: "ar01.albuquerque.nm.albuq.kabletown.com",
+			LastUpdated:    "2015-03-27 17:00:30",
+		},
+	}
+}

--- a/traffic_ops/client/fixtures/traffic_monitor_config.go
+++ b/traffic_ops/client/fixtures/traffic_monitor_config.go
@@ -8,9 +8,9 @@ package fixtures
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,7 +18,6 @@ package fixtures
  * specific language governing permissions and limitations
  * under the License.
  */
-
 
 import "github.com/apache/incubator-trafficcontrol/traffic_ops/client"
 
@@ -101,13 +100,24 @@ func TrafficMonitorConfig() *client.TMConfigResponse {
 					Name: "tm-123",
 					Type: "TR",
 					Parameters: client.TMParameters{
-						HealthConnectionTimeout:                 2000,
-						HealthPollingURL:                        "http://${hostname}/_astats?application=&inf.name=${interface_name}",
-						HealthThresholdQueryTime:                1000,
-						HistoryCount:                            30,
-						HealthThresholdAvailableBandwidthInKbps: ">1750000",
-						HealthThresholdLoadAvg:                  25.0,
-						MinFreeKbps:                             11500000,
+						HealthConnectionTimeout: 2000,
+						HealthPollingURL:        "http://${hostname}/_astats?application=&inf.name=${interface_name}",
+						HistoryCount:            30,
+						MinFreeKbps:             11500000,
+						Thresholds: map[string]client.HealthThreshold{
+							"queryTime": client.HealthThreshold{
+								Val:        1000,
+								Comparator: "<",
+							},
+							"availableBandwidthInKbps": client.HealthThreshold{
+								Val:        1750000,
+								Comparator: "<",
+							},
+							"loadavg": client.HealthThreshold{
+								Val:        25.0,
+								Comparator: "<",
+							},
+						},
 					},
 				},
 			},

--- a/traffic_ops/client/server.go
+++ b/traffic_ops/client/server.go
@@ -22,6 +22,11 @@ import (
 	"strings"
 )
 
+// ServerDetailResponse is the JSON object returned for a single server
+type ServerDetailResponse struct {
+	Response Server `json:"response"`
+}
+
 // ServerResponse ...
 type ServerResponse struct {
 	Response []Server `json:"response"`
@@ -79,6 +84,23 @@ func (to *Session) Servers() ([]Server, error) {
 	}
 
 	return data.Response, nil
+}
+
+// Server gets a server by hostname
+func (to *Session) Server(name string) (*Server, error) {
+	url := fmt.Sprintf("/api/1.2/servers/hostname/%s/details", name)
+	resp, err := to.request("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data := ServerDetailResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	return &data.Response, nil
 }
 
 // ServersByType gets an array of serves of a specified type.

--- a/traffic_ops/client/tests/cachegroup_test.go
+++ b/traffic_ops/client/tests/cachegroup_test.go
@@ -29,11 +29,7 @@ func TestCacheGroup(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for CacheGroups")
 
@@ -81,11 +77,7 @@ func TestCacheGroupsUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for CacheGroups")
 

--- a/traffic_ops/client/tests/cdn_test.go
+++ b/traffic_ops/client/tests/cdn_test.go
@@ -29,11 +29,7 @@ func TestCDNs(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for CDNs")
 
@@ -68,11 +64,7 @@ func TestCDNsUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for CDNs")
 
@@ -89,11 +81,7 @@ func TestCDNName(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	cdn := "CDN-1"
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for CDN: \"%s\"", cdn)
@@ -124,11 +112,7 @@ func TestCDNNameUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	cdn := "CDN-1"
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for CDN: \"%s\"", cdn)

--- a/traffic_ops/client/tests/delivery_service_test.go
+++ b/traffic_ops/client/tests/delivery_service_test.go
@@ -29,11 +29,7 @@ func TestDeliveryServices(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for DeliveryServices")
 
@@ -69,11 +65,7 @@ func TestDeliveryServicesUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for DeliveryServices")
 
@@ -90,11 +82,7 @@ func TestDeliveryService(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for a DeliveryService")
 
@@ -122,11 +110,7 @@ func TestDeliveryServiceUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for a DeliveryService")
 
@@ -143,11 +127,7 @@ func TestCreateDeliveryService(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request to create a DeliveryService")
 
@@ -170,11 +150,7 @@ func TestCreateDeliveryServiceUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request to create a DeliveryService")
 
@@ -191,11 +167,7 @@ func TestUpdateDeliveryService(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request to update a DeliveryService")
 
@@ -218,11 +190,7 @@ func TestUpdateDeliveryServiceUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request to update a DeliveryService")
 
@@ -239,11 +207,7 @@ func TestDeleteDeliveryService(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request to delete a DeliveryService")
 
@@ -266,11 +230,7 @@ func TestDeleteDeliveryServiceUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request to delete a DeliveryService")
 
@@ -287,11 +247,7 @@ func TestDeliveryServiceState(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for a DeliveryServiceState")
 
@@ -319,11 +275,7 @@ func TestDeliveryServiceStateUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for a DeliveryServiceState")
 
@@ -340,11 +292,7 @@ func TestDeliveryServiceHealth(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for a DeliveryServiceHealth")
 
@@ -378,11 +326,7 @@ func TestDeliveryServiceHealthUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for a DeliveryServiceHealth")
 
@@ -399,11 +343,7 @@ func TestDeliveryServiceCapacity(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for a DeliveryServiceCapacity")
 
@@ -437,11 +377,7 @@ func TestDeliveryServiceCapacityUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for a DeliveryServiceCapacity")
 
@@ -458,11 +394,7 @@ func TestDeliveryServiceRouting(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for a DeliveryServiceRouting")
 
@@ -484,11 +416,7 @@ func TestDeliveryServiceRoutingUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for a DeliveryServiceRouting")
 
@@ -505,11 +433,7 @@ func TestDeliveryServiceServer(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for a DeliveryServiceServer")
 
@@ -543,11 +467,7 @@ func TestDeliveryServiceServerUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for a DeliveryServiceServer")
 
@@ -564,11 +484,7 @@ func TestDeliveryServiceSSLKeysByID(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for a DeliveryServiceSSLKeysByID")
 
@@ -596,11 +512,7 @@ func TestDeliveryServiceSSLKeysByIDUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for a DeliveryServiceSSLKeysByID")
 
@@ -617,11 +529,7 @@ func TestDeliveryServiceSSLKeysByHostname(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for a DeliveryServiceSSLKeysByHostname")
 
@@ -649,11 +557,7 @@ func TestDeliveryServiceSSLKeysByHostnameUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for a DeliveryServiceSSLKeysByHostname")
 

--- a/traffic_ops/client/tests/hardware_test.go
+++ b/traffic_ops/client/tests/hardware_test.go
@@ -30,11 +30,7 @@ func TestHardware(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for Hardware")
 
@@ -76,11 +72,7 @@ func TestHardwareUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for Hardware")
 

--- a/traffic_ops/client/tests/integration/integration_helper.go
+++ b/traffic_ops/client/tests/integration/integration_helper.go
@@ -118,7 +118,7 @@ func Request(to traffic_ops.Session, method, path string, body []byte) (*http.Re
 		}
 	}
 
-	resp, err := to.UserAgent.Do(req)
+	resp, err := to.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/traffic_ops/client/tests/parameter_test.go
+++ b/traffic_ops/client/tests/parameter_test.go
@@ -29,11 +29,7 @@ func TestParameters(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for Parameters")
 
@@ -75,11 +71,7 @@ func TestParametersUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for Parameters")
 

--- a/traffic_ops/client/tests/profile_test.go
+++ b/traffic_ops/client/tests/profile_test.go
@@ -29,11 +29,7 @@ func TestProfile(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for Profiles")
 
@@ -75,11 +71,7 @@ func TestProfilesUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for Profiles")
 

--- a/traffic_ops/client/tests/server_test.go
+++ b/traffic_ops/client/tests/server_test.go
@@ -25,16 +25,12 @@ import (
 	"github.com/jheitz200/test_helper"
 )
 
-func TestServer(t *testing.T) {
+func TestServers(t *testing.T) {
 	resp := fixtures.Servers()
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for Servers")
 
@@ -74,11 +70,7 @@ func TestServersUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for Servers")
 
@@ -95,11 +87,7 @@ func TestServerFQDN(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	shortName := "edge-alb-01"
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for the FQDN of Server: \"%s\"", shortName)
@@ -123,11 +111,7 @@ func TestServerFQDNError(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	shortName := "edge-alb-01"
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for the FQDN of Server: \"%s\"", shortName)
@@ -144,11 +128,7 @@ func TestServerFQDNUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	shortName := "edge-alb-01"
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for the FQDN of Server: \"%s\"", shortName)
@@ -166,11 +146,7 @@ func TestServerShortName(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	pattern := "edge"
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for servers that match Short Name: \"%s\"", pattern)
@@ -200,11 +176,7 @@ func TestServerShortNameError(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	pattern := "edge"
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for servers that match Short Name: \"%s\"", pattern)
@@ -221,11 +193,7 @@ func TestServerShortNameUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	pattern := "edge"
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for servers that match Short Name: \"%s\"", pattern)
@@ -243,11 +211,7 @@ func TestServerByType(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for \"Logstash\" Servers")
 
@@ -290,11 +254,7 @@ func TestServerByTypeUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for \"Logstash\" servers")
 
@@ -306,5 +266,46 @@ func TestServerByTypeUnauthorized(t *testing.T) {
 		testHelper.Error(t, "Should not be able to make a request to Traffic Ops")
 	} else {
 		testHelper.Success(t, "Should not be able to make a request to Traffic Ops")
+	}
+}
+
+func TestServer(t *testing.T) {
+	resp := fixtures.Server()
+	server := testHelper.ValidHTTPServer(resp)
+	defer server.Close()
+
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
+
+	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for Servers")
+
+	toserver, err := to.Server(resp.Response.HostName)
+	if err != nil {
+		testHelper.Error(t, "Should be able to make a request to Traffic Ops")
+	} else {
+		testHelper.Success(t, "Should be able to make a request to Traffic Ops")
+	}
+
+	if toserver.HostName != "edge-alb-01" {
+		testHelper.Error(t, "Should get \"edge-alb-01\" for \"HostName\", got: %s", toserver.HostName)
+	} else {
+		testHelper.Success(t, "Should get \"edge-alb-01\" for \"HostName\"")
+	}
+
+	if toserver.DomainName != "albuquerque.nm.albuq.kabletown.com" {
+		testHelper.Error(t, "Should get \"albuquerque.nm.albuq.kabletown.com\" for \"DomainName\", got: %s", toserver.DomainName)
+	} else {
+		testHelper.Success(t, "Should get \"albuquerque.nm.albuq.kabletown.com\" for \"DomainName\"")
+	}
+
+	if toserver.Type != "EDGE" {
+		testHelper.Error(t, "Should get \"EDGE\" for \"Type\", got: %s", toserver.Type)
+	} else {
+		testHelper.Success(t, "Should get \"EDGE\" for \"Type\"")
+	}
+
+	if toserver.CDNName != "CDN-1" {
+		testHelper.Error(t, "Should get \"CDN-1\" for \"CDNName\", got: %s", toserver.CDNName)
+	} else {
+		testHelper.Success(t, "Should get \"CDN-1\" for \"CDNName\"")
 	}
 }

--- a/traffic_ops/client/tests/stats_summary_test.go
+++ b/traffic_ops/client/tests/stats_summary_test.go
@@ -29,11 +29,7 @@ func TestStatsSummary(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for Stats Summary")
 
@@ -81,11 +77,7 @@ func TestStatsSummaryUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for Stats Summary")
 

--- a/traffic_ops/client/tests/traffic_monitor_config_test.go
+++ b/traffic_ops/client/tests/traffic_monitor_config_test.go
@@ -29,11 +29,7 @@ func TestTMConfig(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for TM Config")
 

--- a/traffic_ops/client/tests/traffic_router_config_test.go
+++ b/traffic_ops/client/tests/traffic_router_config_test.go
@@ -29,11 +29,7 @@ func TestTRConfig(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for TR Config")
 

--- a/traffic_ops/client/tests/type_test.go
+++ b/traffic_ops/client/tests/type_test.go
@@ -29,11 +29,7 @@ func TestTypes(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for Types")
 
@@ -75,11 +71,7 @@ func TestTypesUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for Types")
 

--- a/traffic_ops/client/tests/user_test.go
+++ b/traffic_ops/client/tests/user_test.go
@@ -29,11 +29,7 @@ func TestUsers(t *testing.T) {
 	server := testHelper.ValidHTTPServer(resp)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a successful Traffic Ops request for Users")
 
@@ -81,11 +77,7 @@ func TestUsersUnauthorized(t *testing.T) {
 	server := testHelper.InvalidHTTPServer(http.StatusUnauthorized)
 	defer server.Close()
 
-	var httpClient http.Client
-	to := client.Session{
-		URL:       server.URL,
-		UserAgent: &httpClient,
-	}
+	to := client.NewSession("", "", server.URL, "", &http.Client{}, false)
 
 	testHelper.Context(t, "Given the need to test a failed Traffic Ops request for Users")
 

--- a/traffic_ops/client/type.go
+++ b/traffic_ops/client/type.go
@@ -46,7 +46,7 @@ func (to *Session) Types(useInTable ...string) ([]Type, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 
 	var data TypeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -45,7 +45,7 @@ func (to *Session) Users() ([]User, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 
 	var data UserResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {


### PR DESCRIPTION
This is needed by Traffic Monitor, to get its own CDN efficiently, instead of having to query all servers.