### PR TITLE
add Ort login dispersion

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -36,12 +36,14 @@ my %supported_el_release = ( "EL6" => 1, "EL7" => 1);
 my $dispersion = 300;
 my $retries = 5;
 my $wait_for_parents = 1;
+my $login_dispersion = 0;
 my $reval_wait_time = 60;
 my $reval_in_use = 0;
 
 GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "retries=i"          => \$retries,
-            "wait_for_parents=i" => \$wait_for_parents );
+            "wait_for_parents=i" => \$wait_for_parents,
+            "login_dispersion=i" => \$login_dispersion );
 
 if ( $#ARGV < 1 ) {
 	&usage();
@@ -317,9 +319,10 @@ sub usage {
 	print "\n";
 	print "\t<Traffic_Ops_Login> => Example: 'username:password' \n";
 	print "\n\t[optional flags]:\n";
-	print "\t\tdispersion=<time>      => wait a random number between 0 and <time> before starting. Default = 300.\n";
-	print "\t\tretries=<number>       => retry connection to Traffic Ops URL <number> times. Default = 3.\n";
-	print "\t\twait_for_parents=<0|1> => do not update if parent_pending = 1 in the update json. Default = 1, wait for parents.\n";
+	print "\t   dispersion=<time>\t=> wait a random number between 0 and <time> before starting. Default = 300.\n";
+	print "\t   login_dispersion=<time>\t=> wait a random number between 0 and <time> before login. Default = 0.\n";
+	print "\t   retries=<number>\t=> retry connection to Traffic Ops URL <number> times. Default = 3.\n";
+	print "\t   wait_for_parents=<0|1>\t=> do not update if parent_pending = 1 in the update json. Default = 1, wait for parents.\n";
 	print "====-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-====\n";
 	exit 1;
 }
@@ -1552,6 +1555,12 @@ sub get_cookie {
 	my $to_login    = shift;
 	my ( $u, $p ) = split( /:/, $to_login );
 	my %headers;
+
+	if ( $login_dispersion > 0 ) {
+		( $log_level >> $WARN ) && print "WARN Login dispersion is enabled.\n";
+		&sleep_rand($login_dispersion);
+	}
+
 	my $url = $to_host . "/login";
 	my $response = $lwp_conn->post( $url, [ 'u' => $u, 'p' => $p ], %headers );
 

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -319,10 +319,10 @@ sub usage {
 	print "\n";
 	print "\t<Traffic_Ops_Login> => Example: 'username:password' \n";
 	print "\n\t[optional flags]:\n";
-	print "\t   dispersion=<time>\t=> wait a random number between 0 and <time> before starting. Default = 300.\n";
-	print "\t   login_dispersion=<time>\t=> wait a random number between 0 and <time> before login. Default = 0.\n";
-	print "\t   retries=<number>\t=> retry connection to Traffic Ops URL <number> times. Default = 3.\n";
-	print "\t   wait_for_parents=<0|1>\t=> do not update if parent_pending = 1 in the update json. Default = 1, wait for parents.\n";
+	print "\t   dispersion=<time>        => wait a random number between 0 and <time> before starting. Default = 300.\n";
+	print "\t   login_dispersion=<time>  => wait a random number between 0 and <time> before login. Default = 0.\n";
+	print "\t   retries=<number>         => retry connection to Traffic Ops URL <number> times. Default = 3.\n";
+	print "\t   wait_for_parents=<0|1>   => do not update if parent_pending = 1 in the update json. Default = 1, wait for parents.\n";
 	print "====-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-====\n";
 	exit 1;
 }
@@ -1014,6 +1014,18 @@ sub check_syncds_state {
 		}
 	}
 	return ($syncds_update);
+}
+
+sub sleep_rand {
+	my $duration = int( rand(shift) );
+
+	( $log_level >> $WARN ) && print "WARN Sleeping for $duration seconds: ";
+
+	for ( my $i = $duration; $i > 0; $i-- ) {
+		( $log_level >> $WARN ) && print ".";
+		sleep 1;
+	}
+	( $log_level >> $WARN ) && print "\n";
 }
 
 sub sleep_timer {


### PR DESCRIPTION
Adds login_dispersion command line option to spread out login requests. Default value is 0, so not using this option will result in the same behavior as in the past.