### PR TITLE
[TC-211] don't add use_reval_pending value by default.

### DIFF
--- a/traffic_ops/app/db/migrations/20170224163900_add_client_steering.sql
+++ b/traffic_ops/app/db/migrations/20170224163900_add_client_steering.sql
@@ -1,8 +1,0 @@
-
--- +goose Up
--- SQL in section 'Up' is executed when this migration is applied
-insert into type (name, description, use_in_table) select 'CLIENT_STEERING', 'Client-Controlled Steering Delivery Service', 'deliveryservice' WHERE NOT EXISTS (select 1 FROM type WHERE name='CLIENT_STEERING');
-
--- +goose Down
--- SQL section 'Down' is executed when this migration is rolled back
-delete from type where name = 'CLIENT_STEERING';

--- a/traffic_ops/app/db/migrations/20170224163900_add_client_steering.sql
+++ b/traffic_ops/app/db/migrations/20170224163900_add_client_steering.sql
@@ -1,8 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-insert into type (name, description, use_in_table) values ('CLIENT_STEERING', 'Client-Controlled Steering Delivery Service', 'deliveryservice');
-
+insert into type (name, description, use_in_table) select 'CLIENT_STEERING', 'Client-Controlled Steering Delivery Service', 'deliveryservice' WHERE NOT EXISTS (select 1 FROM type WHERE name='CLIENT_STEERING');
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/traffic_ops/app/db/migrations/20170226190747_add_reval_pending.sql
+++ b/traffic_ops/app/db/migrations/20170226190747_add_reval_pending.sql
@@ -16,8 +16,6 @@
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
 ALTER TABLE server ADD COLUMN reval_pending boolean NOT NULL DEFAULT false;
-INSERT INTO parameter (name, config_file, value, secure) VALUES ('use_reval_pending', 'global', '0', False);
-insert into profile_parameter (profile, parameter) values ((select id from profile where name = 'GLOBAL'), (select id from parameter where name = 'use_reval_pending'));
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/traffic_ops/app/db/migrations/20170328190847_add_reval_pending.sql
+++ b/traffic_ops/app/db/migrations/20170328190847_add_reval_pending.sql
@@ -15,7 +15,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE server DROP COLUMN IF EXISTS reval_pendings;
+ALTER TABLE server DROP COLUMN IF EXISTS reval_pending;
 delete from profile_parameter where parameter = (select id from parameter where name = 'use_reval_pending');
 delete from parameter where name = 'use_reval_pending';
 ALTER TABLE server ADD COLUMN IF NOT EXISTS reval_pending boolean NOT NULL DEFAULT false;

--- a/traffic_ops/app/db/migrations/20170328190847_add_reval_pending.sql
+++ b/traffic_ops/app/db/migrations/20170328190847_add_reval_pending.sql
@@ -15,10 +15,13 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE server ADD COLUMN reval_pending boolean NOT NULL DEFAULT false;
+ALTER TABLE server DROP COLUMN IF EXISTS reval_pendings;
+delete from profile_parameter where parameter = (select id from parameter where name = 'use_reval_pending');
+delete from parameter where name = 'use_reval_pending';
+ALTER TABLE server ADD COLUMN IF NOT EXISTS reval_pending boolean NOT NULL DEFAULT false;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-ALTER TABLE server DROP COLUMN reval_pending;
+ALTER TABLE server DROP COLUMN IF EXISTS reval_pending;
 delete from profile_parameter where parameter = (select id from parameter where name = 'use_reval_pending');	
 delete from parameter where name = 'use_reval_pending';

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -27,6 +27,7 @@ insert into role (id, name, description, priv_level) values (8, 'steering', 'Rol
 insert into type (name, description, use_in_table) values ('ANY_MAP', 'No Content Routing - arbitrary remap at the edge, no Traffic Router config', 'deliveryservice') ON CONFLICT DO NOTHING;
 insert into type (name, description, use_in_table) values ('ORG_LOC', 'Origin Logical Site', 'cachegroup') ON CONFLICT DO NOTHING;
 insert into type (name, description, use_in_table) values ('STEERING', 'Steering Delivery Service', 'deliveryservice') ON CONFLICT DO NOTHING;
+insert into type (name, description, use_in_table) values ('CLIENT_STEERING', 'Client-Controlled Steering Delivery Service', 'deliveryservice') ON CONFLICT DO NOTHING;
 insert into type (name, description, use_in_table) values ('STEERING_REGEXP', 'Steering target filter regular expression', 'regex') ON CONFLICT DO NOTHING;
 insert into type (name, description, use_in_table) values ('CHECK_EXTENSION_BOOL', 'Extension for checkmark in Server Check', 'to_extension') ON CONFLICT DO NOTHING;
 insert into type (name, description, use_in_table) values ('CHECK_EXTENSION_NUM', 'Extension for int value in Server Check', 'to_extension') ON CONFLICT DO NOTHING;
@@ -41,6 +42,11 @@ insert into type (name, description, use_in_table) values ('TRAFFIC_PORTAL', 'tr
 insert into type (name, description, use_in_table) values ('INFLUXDB', 'influxDb server', 'server') ON CONFLICT DO NOTHING;
 
 -- statuses
+insert into status (name, description) values ('OFFLINE', 'Server is Offline. Not active in any configuration.') ON CONFLICT DO NOTHING;
+insert into status (name, description) values ('ONLINE', 'Server is online.') ON CONFLICT DO NOTHING;
+insert into status (name, description) values ('REPORTED', 'Server is online and reporeted in the health protocol.') ON CONFLICT DO NOTHING;
+insert into status (name, description) values ('ADMIN_DOWN', 'Sever is administrative down and does not receive traffic.') ON CONFLICT DO NOTHING;
+insert into status (name, description) values ('CCR_IGNORE', 'Server is ignored by traffic router.') ON CONFLICT DO NOTHING;
 insert into status (name, description) values ('PRE_PROD', 'Pre Production. Not active in any configuration.') ON CONFLICT DO NOTHING;
 
 -- job agents


### PR DESCRIPTION
Removes the add for the use_reval_pending parameter and assignment to global.  This breaks in some situations, and isn't needed by default.  Parameter only needs to be added if in use.

https://issues.apache.org/jira/browse/TC-211