### PR TITLE
Add Traffic Monitor 2.0 Log Location Hot Reloading

### DIFF
--- a/traffic_monitor_golang/common/handler/handler.go
+++ b/traffic_monitor_golang/common/handler/handler.go
@@ -20,11 +20,8 @@ package handler
  */
 
 import (
-	"encoding/json"
 	"io"
 	"time"
-
-	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/common/log"
 )
 
 const (
@@ -32,16 +29,6 @@ const (
 	NOTIFY_CHANGE
 	NOTIFY_ALWAYS
 )
-
-type Handler interface {
-	Handle(string, io.Reader, time.Duration, time.Time, error, uint64, chan<- uint64)
-}
-
-type OpsConfigFileHandler struct {
-	Content          interface{}
-	ResultChannel    chan interface{}
-	OpsConfigChannel chan OpsConfig
-}
 
 type OpsConfig struct {
 	Username     string `json:"username"`
@@ -52,17 +39,6 @@ type OpsConfig struct {
 	HttpListener string `json:"httpListener"`
 }
 
-func (handler OpsConfigFileHandler) Listen() {
-	for {
-		result := <-handler.ResultChannel
-		var toc OpsConfig
-
-		err := json.Unmarshal(result.([]byte), &toc)
-
-		if err != nil {
-			log.Errorf("Could not unmarshal Ops Config JSON: %s\n", err)
-		} else {
-			handler.OpsConfigChannel <- toc
-		}
-	}
+type Handler interface {
+	Handle(string, io.Reader, time.Duration, time.Time, error, uint64, chan<- uint64)
 }

--- a/traffic_monitor_golang/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/opsconfig.go
@@ -20,16 +20,17 @@ package manager
  */
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/common/handler"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/common/log"
-	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/common/poller"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/config"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/datareq"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/health"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/peer"
+	poller "github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/poller"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/srvhttp"
 	"github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/threadsafe"
 	todata "github.com/apache/incubator-trafficcontrol/traffic_monitor_golang/traffic_monitor/trafficopsdata"
@@ -65,110 +66,104 @@ func StartOpsConfigManager(
 	unpolledCaches threadsafe.UnpolledCaches,
 	monitorConfig threadsafe.TrafficMonitorConfigMap,
 	cfg config.Config,
-) threadsafe.OpsConfig {
+) (threadsafe.OpsConfig, error) {
 
-	opsConfigFileChannel := make(chan interface{})
-	opsConfigFilePoller := poller.FilePoller{
-		File:          opsConfigFile,
-		ResultChannel: opsConfigFileChannel,
+	handleErr := func(err error) {
+		errorCount.Inc()
+		log.Errorf("OpsConfigManager: %v\n", err)
 	}
 
-	opsConfigChannel := make(chan handler.OpsConfig)
-	opsConfigFileHandler := handler.OpsConfigFileHandler{
-		ResultChannel:    opsConfigFilePoller.ResultChannel,
-		OpsConfigChannel: opsConfigChannel,
-	}
-
-	go opsConfigFileHandler.Listen()
-	go opsConfigFilePoller.Poll()
-
+	httpServer := srvhttp.Server{}
 	opsConfig := threadsafe.NewOpsConfig()
 
 	// TODO remove change subscribers, give Threadsafes directly to the things that need them. If they only set vars, and don't actually do work on change.
-	go func() {
-		handleErr := func(err error) {
-			errorCount.Inc()
-			log.Errorf("OpsConfigManager: %v\n", err)
+	onChange := func(bytes []byte, err error) {
+		if err != nil {
+			handleErr(err)
+			return
 		}
 
-		httpServer := srvhttp.Server{}
-
-		for newOpsConfig := range opsConfigChannel {
-			// TODO config? parameter?
-			useCache := false
-			trafficOpsRequestTimeout := time.Second * time.Duration(10)
-			realToSession, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
-			if err != nil {
-				handleErr(fmt.Errorf("instantiating Session with traffic_ops: %s\n", err))
-				continue
-			}
-
-			if cdn, err := getMonitorCDN(realToSession, staticAppData.Hostname); err != nil {
-				handleErr(fmt.Errorf("getting CDN name from Traffic Ops, using config CDN '%s': %s\n", newOpsConfig.CdnName, err))
-			} else {
-				if newOpsConfig.CdnName != "" && newOpsConfig.CdnName != cdn {
-					log.Warnf("%s Traffic Ops CDN '%s' doesn't match config CDN '%s' - using Traffic Ops CDN\n", staticAppData.Hostname, cdn, newOpsConfig.CdnName)
-				}
-				newOpsConfig.CdnName = cdn
-			}
-
-			opsConfig.Set(newOpsConfig)
-
-			listenAddress := ":80" // default
-
-			if newOpsConfig.HttpListener != "" {
-				listenAddress = newOpsConfig.HttpListener
-			}
-
-			endpoints := datareq.MakeDispatchMap(
-				opsConfig,
-				toSession,
-				localStates,
-				peerStates,
-				combinedStates,
-				statInfoHistory,
-				statResultHistory,
-				statMaxKbpses,
-				healthHistory,
-				dsStats,
-				events,
-				staticAppData,
-				healthPollInterval,
-				lastHealthDurations,
-				fetchCount,
-				healthIteration,
-				errorCount,
-				toData,
-				localCacheStatus,
-				lastStats,
-				unpolledCaches,
-				monitorConfig,
-			)
-
-			if err := httpServer.Run(endpoints, listenAddress, cfg.ServeReadTimeout, cfg.ServeWriteTimeout, cfg.StaticFileDir); err != nil {
-				handleErr(fmt.Errorf("creating HTTP server: %s\n", err))
-				continue
-			}
-
-			toSession.Set(realToSession)
-
-			if err := toData.Fetch(toSession, newOpsConfig.CdnName); err != nil {
-				handleErr(fmt.Errorf("getting Traffic Ops data: %v\n", err))
-				continue
-			}
-
-			// These must be in a goroutine, because the monitorConfigPoller tick sends to a channel this select listens for. Thus, if we block on sends to the monitorConfigPoller, we have a livelock race condition.
-			// More generically, we're using goroutines as an infinite chan buffer, to avoid potential livelocks
-			for _, subscriber := range opsConfigChangeSubscribers {
-				go func(s chan<- handler.OpsConfig) { s <- newOpsConfig }(subscriber)
-			}
-			for _, subscriber := range toChangeSubscribers {
-				go func(s chan<- towrap.ITrafficOpsSession) { s <- toSession }(subscriber)
-			}
+		newOpsConfig := handler.OpsConfig{}
+		if err = json.Unmarshal(bytes, &newOpsConfig); err != nil {
+			handleErr(fmt.Errorf("Could not unmarshal Ops Config JSON: %s\n", err))
+			return
 		}
-	}()
 
-	return opsConfig
+		opsConfig.Set(newOpsConfig)
+
+		listenAddress := ":80" // default
+
+		if newOpsConfig.HttpListener != "" {
+			listenAddress = newOpsConfig.HttpListener
+		}
+
+		endpoints := datareq.MakeDispatchMap(
+			opsConfig,
+			toSession,
+			localStates,
+			peerStates,
+			combinedStates,
+			statInfoHistory,
+			statResultHistory,
+			statMaxKbpses,
+			healthHistory,
+			dsStats,
+			events,
+			staticAppData,
+			healthPollInterval,
+			lastHealthDurations,
+			fetchCount,
+			healthIteration,
+			errorCount,
+			toData,
+			localCacheStatus,
+			lastStats,
+			unpolledCaches,
+			monitorConfig,
+		)
+		err = httpServer.Run(endpoints, listenAddress, cfg.ServeReadTimeout, cfg.ServeWriteTimeout, cfg.StaticFileDir)
+		if err != nil {
+			handleErr(fmt.Errorf("MonitorConfigPoller: error creating HTTP server: %s\n", err))
+			return
+		}
+
+		// TODO config? parameter?
+		useCache := false
+		trafficOpsRequestTimeout := time.Second * time.Duration(10)
+
+		realToSession, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
+		if err != nil {
+			handleErr(fmt.Errorf("MonitorConfigPoller: error instantiating Session with traffic_ops: %s\n", err))
+			return
+		}
+		toSession.Set(realToSession)
+
+		if cdn, err := getMonitorCDN(realToSession, staticAppData.Hostname); err != nil {
+			handleErr(fmt.Errorf("getting CDN name from Traffic Ops, using config CDN '%s': %s\n", newOpsConfig.CdnName, err))
+		} else {
+			if newOpsConfig.CdnName != "" && newOpsConfig.CdnName != cdn {
+				log.Warnf("%s Traffic Ops CDN '%s' doesn't match config CDN '%s' - using Traffic Ops CDN\n", staticAppData.Hostname, cdn, newOpsConfig.CdnName)
+			}
+			newOpsConfig.CdnName = cdn
+		}
+
+		if err := toData.Fetch(toSession, newOpsConfig.CdnName); err != nil {
+			handleErr(fmt.Errorf("Error getting Traffic Ops data: %v\n", err))
+			return
+		}
+
+		// These must be in a goroutine, because the monitorConfigPoller tick sends to a channel this select listens for. Thus, if we block on sends to the monitorConfigPoller, we have a livelock race condition.
+		// More generically, we're using goroutines as an infinite chan buffer, to avoid potential livelocks
+		for _, subscriber := range opsConfigChangeSubscribers {
+			go func(s chan<- handler.OpsConfig) { s <- newOpsConfig }(subscriber)
+		}
+		for _, subscriber := range toChangeSubscribers {
+			go func(s chan<- towrap.ITrafficOpsSession) { s <- toSession }(subscriber)
+		}
+	}
+
+	_, err := poller.File(opsConfigFile, onChange)
+	return opsConfig, err
 }
 
 // getMonitorCDN returns the CDN of a given Traffic Monitor.

--- a/traffic_monitor_golang/traffic_monitor/poller/file.go
+++ b/traffic_monitor_golang/traffic_monitor/poller/file.go
@@ -1,0 +1,60 @@
+package poller
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"fmt"
+	"gopkg.in/fsnotify.v1"
+	"io/ioutil"
+)
+
+// FilePoller starts a goroutine polling the given file for changes. When changes occur, including an initial read, the result callback is called asynchronously. Returns a kill chan, which will kill the file poller when written to.
+func File(filename string, result func([]byte, error)) (chan<- struct{}, error) {
+	die := make(chan struct{})
+
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("reading file '%v': %v", filename, err)
+	}
+	go result(contents, nil)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		watcher.Add(filename)
+		defer watcher.Close()
+		for {
+			select {
+			case event := <-watcher.Events:
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					go result(ioutil.ReadFile(filename))
+				}
+			case err := <-watcher.Errors:
+				go result(nil, err)
+			case <-die:
+				return
+			}
+		}
+	}()
+
+	return die, nil
+}

--- a/traffic_monitor_golang/traffic_monitor/traffic_monitor.go
+++ b/traffic_monitor_golang/traffic_monitor/traffic_monitor.go
@@ -40,19 +40,19 @@ var GitRevision = "No Git Revision Specified. Please build with '-X main.GitRevi
 // BuildTimestamp is the time the app was built. The app SHOULD always be built with this set via the `-X` flag.
 var BuildTimestamp = "No Build Timestamp Specified. Please build with '-X main.BuildTimestamp=`date +'%Y-%M-%dT%H:%M:%S'`"
 
-func getLogWriter(location string) (io.Writer, error) {
+func getLogWriter(location string) (io.WriteCloser, error) {
 	switch location {
 	case config.LogLocationStdout:
-		return os.Stdout, nil
+		return log.NopCloser(os.Stdout), nil
 	case config.LogLocationStderr:
-		return os.Stderr, nil
+		return log.NopCloser(os.Stderr), nil
 	case config.LogLocationNull:
-		return ioutil.Discard, nil
+		return log.NopCloser(ioutil.Discard), nil
 	default:
 		return os.OpenFile(location, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	}
 }
-func getLogWriters(eventLoc, errLoc, warnLoc, infoLoc, debugLoc string) (io.Writer, io.Writer, io.Writer, io.Writer, io.Writer, error) {
+func getLogWriters(eventLoc, errLoc, warnLoc, infoLoc, debugLoc string) (io.WriteCloser, io.WriteCloser, io.WriteCloser, io.WriteCloser, io.WriteCloser, error) {
 	eventW, err := getLogWriter(eventLoc)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("getting log event writer %v: %v", eventLoc, err)


### PR DESCRIPTION
Adds TM2 reloading log locations when they change in the config file. This allows e.g. changing the debug log location from "null" to a real file, without restarting the service. 

We've hit several state bugs which go away on restart, this will make future state bugs much easier to debug. 