### PR TITLE
Add a Mutex to the free_handler continuation as required by the ATS 6…

### DIFF
--- a/traffic_server/plugins/astats_over_http/astats_over_http.c
+++ b/traffic_server/plugins/astats_over_http/astats_over_http.c
@@ -802,7 +802,7 @@ static void load_config_file(config_holder_t *config_holder) {
 		oldconfig = __sync_lock_test_and_set(confp, newconfig);
 		if (oldconfig) {
 			TSDebug(PLUGIN_TAG, "scheduling free: %p (%p)", oldconfig, newconfig);
-			free_cont = TSContCreate(free_handler, NULL);
+			free_cont = TSContCreate(free_handler, TSMutexCreate());
 			TSContDataSet(free_cont, (void *) oldconfig);
 			TSContSchedule(free_cont, FREE_TMOUT, TS_THREAD_POOL_TASK);
 		}


### PR DESCRIPTION
Traffic Server 6.2.1 API changes require that a continuation that is Scheduled to run, must have a continuation Mutex.