### PR TITLE
move server scope files to cdn scope for cacheability and adjust ORT to support change

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -154,11 +154,9 @@ sub get_server_config {
 
 	#generate the config file using the appropriate function
 	my $file_contents;
-	if ( $filename eq "12M_facts" ) { $file_contents = $self->facts( $server_obj, $filename ); }
-	elsif ( $filename =~ /to_ext_.*\.config/ ) { $file_contents = $self->to_ext_dot_config( $server_obj, $filename ); }
+	if ( $filename =~ /to_ext_.*\.config/ ) { $file_contents = $self->to_ext_dot_config( $server_obj, $filename ); }
 	elsif ( $filename eq "ip_allow.config" ) { $file_contents = $self->ip_allow_dot_config( $server_obj, $filename ); }
 	elsif ( $filename eq "parent.config" ) { $file_contents = $self->parent_dot_config( $server_obj, $filename ); }
-	elsif ( $filename eq "records.config" ) { $file_contents = $self->generic_server_config( $server_obj, $filename ); }
 	elsif ( $filename eq "remap.config" ) { $file_contents = $self->remap_dot_config( $server_obj, $filename ); }
 	elsif ( $filename eq "hosting.config" ) { $file_contents = $self->hosting_dot_config( $server_obj, $filename ); }
 	elsif ( $filename eq "cache.config" ) { $file_contents = $self->cache_dot_config( $server_obj, $filename ); }
@@ -254,10 +252,12 @@ sub get_profile_config {
 	#generate the config file using the appropriate function
 	my $file_contents;
 	if ( $filename eq "50-ats.rules" ) { $file_contents = $self->ats_dot_rules( $profile_obj, $filename ); }
+	elsif ( $filename eq "12M_facts" ) { $file_contents = $self->facts( $profile_obj, $filename ); }
 	elsif ( $filename eq "astats.config" ) { $file_contents = $self->generic_profile_config( $profile_obj, $filename ); }
 	elsif ( $filename eq "drop_qstring.config" ) { $file_contents = $self->drop_qstring_dot_config( $profile_obj, $filename ); }
 	elsif ( $filename eq "logs_xml.config" ) { $file_contents = $self->logs_xml_dot_config( $profile_obj, $filename ); }
 	elsif ( $filename eq "plugin.config" ) { $file_contents = $self->generic_profile_config( $profile_obj, $filename ); }
+	elsif ( $filename eq "records.config" ) { $file_contents = $self->generic_profile_config( $profile_obj, $filename ); }
 	elsif ( $filename eq "storage.config" ) { $file_contents = $self->storage_dot_config( $profile_obj, $filename ); }
 	elsif ( $filename eq "sysctl.conf" ) { $file_contents = $self->generic_profile_config( $profile_obj, $filename ); }
 	elsif ( $filename =~ /url_sig_.*\.config/ ) { $file_contents = $self->url_sig_dot_config( $profile_obj, $filename ); }
@@ -292,16 +292,16 @@ sub get_scope {
 	my $fname = shift;
 	my $scope;
 
-	if    ( $fname eq "12M_facts" )               { $scope = 'server' }
-	elsif ( $fname eq "ip_allow.config" )         { $scope = 'server' }
+	if ( $fname eq "ip_allow.config" )            { $scope = 'server' }
 	elsif ( $fname eq "parent.config" )           { $scope = 'server' }
-	elsif ( $fname eq "records.config" )          { $scope = 'server' }
+	elsif ( $fname eq "records.config" )          { $scope = 'profile' }
 	elsif ( $fname eq "remap.config" )            { $scope = 'server' }
 	elsif ( $fname =~ /to_ext_.*\.config/ )       { $scope = 'server' }
 	elsif ( $fname eq "hosting.config" )          { $scope = 'server' }
 	elsif ( $fname eq "cache.config" )            { $scope = 'server' }
 	elsif ( $fname eq "packages" )                { $scope = 'server' }
 	elsif ( $fname eq "chkconfig" )               { $scope = 'server' }
+	elsif ( $fname eq "12M_facts" )               { $scope = 'profile' }
 	elsif ( $fname eq "50-ats.rules" )            { $scope = 'profile' }
 	elsif ( $fname eq "astats.config" )           { $scope = 'profile' }
 	elsif ( $fname eq "drop_qstring.config" )     { $scope = 'profile' }
@@ -717,10 +717,10 @@ sub ds_data {
 #generates the 12m_facts file
 sub facts {
 	my $self       = shift;
-	my $server_obj = shift;
+	my $profile_obj = shift;
 	my $filename   = shift;
-	my $text       = $self->header_comment( $server_obj->host_name );
-	$text .= "profile:" . $server_obj->profile->name . "\n";
+	my $text       = $self->header_comment( $profile_obj->name );
+	$text .= "profile:" . $profile_obj->name . "\n";
 
 	return $text;
 }

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -70,6 +70,7 @@ sub get_config_metadata {
 	if ($server) {
 
 		$data_obj->{'info'}->{'server_name'}	= $server_obj->host_name;
+		$data_obj->{'info'}->{'server_ipv4'}	= $server_obj->ip_address;
 		$data_obj->{'info'}->{'server_id'}		= $server_obj->id;
 		$data_obj->{'info'}->{'profile_name'}	= $server->profile->name;
 		$data_obj->{'info'}->{'profile_id'}		= $server->profile->id;
@@ -146,7 +147,6 @@ sub get_server_config {
 	my $file_contents;
 	if ( $filename eq "12M_facts" ) { $file_contents = $self->facts( $server_obj, $filename ); }
 	elsif ( $filename =~ /to_ext_.*\.config/ ) { $file_contents = $self->to_ext_dot_config( $server_obj, $filename ); }
-	elsif ( $filename =~ /hdr_rw_.*\.config/ ) { $file_contents = $self->header_rewrite_dot_config( $server_obj, $filename ); }
 	elsif ( $filename eq "ip_allow.config" ) { $file_contents = $self->ip_allow_dot_config( $server_obj, $filename ); }
 	elsif ( $filename eq "parent.config" ) { $file_contents = $self->parent_dot_config( $server_obj, $filename ); }
 	elsif ( $filename eq "records.config" ) { $file_contents = $self->generic_server_config( $server_obj, $filename ); }
@@ -205,6 +205,7 @@ sub get_cdn_config {
 	my $file_contents;
 	if ( $filename eq "bg_fetch.config" ) { $file_contents = $self->bg_fetch_dot_config( $cdn_obj, $filename ); }
 	elsif ( $filename =~ /cacheurl.*\.config/ ) { $file_contents = $self->cacheurl_dot_config( $cdn_obj, $filename ); }
+	elsif ( $filename =~ /hdr_rw_.*\.config/ ) { $file_contents = $self->header_rewrite_dot_config( $cdn_obj, $filename ); }
 	elsif ( $filename =~ /regex_remap_.*\.config/ ) { $file_contents = $self->regex_remap_dot_config( $cdn_obj, $filename ); }
 	elsif ( $filename eq "regex_revalidate.config" ) { $file_contents = $self->regex_revalidate_dot_config( $cdn_obj, $filename ); }
 	elsif ( $filename =~ /set_dscp_.*\.config/ ) { $file_contents = $self->set_dscp_dot_config( $cdn_obj, $filename ); }
@@ -288,7 +289,6 @@ sub get_scope {
 	elsif ( $fname eq "records.config" )          { $scope = 'server' }
 	elsif ( $fname eq "remap.config" )            { $scope = 'server' }
 	elsif ( $fname =~ /to_ext_.*\.config/ )       { $scope = 'server' }
-	elsif ( $fname =~ /hdr_rw_.*\.config/ )       { $scope = 'server' }
 	elsif ( $fname eq "hosting.config" )          { $scope = 'server' }
 	elsif ( $fname eq "cache.config" )            { $scope = 'server' }
 	elsif ( $fname eq "packages" )                { $scope = 'server' }
@@ -304,6 +304,7 @@ sub get_scope {
 	elsif ( $fname eq "volume.config" )           { $scope = 'profile' }
 	elsif ( $fname eq "bg_fetch.config" )         { $scope = 'cdn' }
 	elsif ( $fname =~ /cacheurl.*\.config/ )      { $scope = 'cdn' }
+	elsif ( $fname =~ /hdr_rw_.*\.config/ )       { $scope = 'cdn' }
 	elsif ( $fname =~ /regex_remap_.*\.config/ )  { $scope = 'cdn' }
 	elsif ( $fname eq "regex_revalidate.config" ) { $scope = 'cdn' }
 	elsif ( $fname =~ /set_dscp_.*\.config/ )     { $scope = 'cdn' }
@@ -995,10 +996,10 @@ sub bg_fetch_dot_config {
 
 sub header_rewrite_dot_config {
 	my $self     = shift;
-	my $server_obj  = shift;
+	my $cdn_obj  = shift;
 	my $filename = shift;
 
-	my $text      = $self->header_comment( $server_obj->host_name );
+	my $text      = $self->header_comment( $cdn_obj->name );
 	my $ds_xml_id = undef;
 	if ( $filename =~ /^hdr_rw_mid_(.*)\.config$/ ) {
 		$ds_xml_id = $1;
@@ -1014,8 +1015,10 @@ sub header_rewrite_dot_config {
 	}
 
 	$text =~ s/\s*__RETURN__\s*/\n/g;
-	my $ipv4 = $server_obj->ip_address;
-	$text =~ s/__CACHE_IPV4__/$ipv4/g;
+
+	#do the following text replacement at the ORT level for cacheability
+	# my $ipv4 = $server_obj->ip_address;
+	# $text =~ s/__CACHE_IPV4__/$ipv4/g;
 
 	return $text;
 }

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1736,6 +1736,8 @@ sub get_cfg_file_list {
 	}
 
 	my $ort_ref = decode_json($result);
+	my @cf = $ort_ref->{'config_files'};
+	
 	
 	if ($api_in_use == 1) {
 		$to_url = $ort_ref->{'info'}->{'to_url'};
@@ -1763,29 +1765,29 @@ sub get_cfg_file_list {
 		( $log_level >> $INFO ) && printf("INFO Found CDN_name from Traffic Ops: $cdn_name\n");
 	}
 	if ( $script_mode == $REVALIDATE ) {
-		foreach my $cfg_file ( keys %{ $ort_ref->{'config_files'} } ) {
-			if ( $cfg_file eq "regex_revalidate.config" ) {
-				my $fname_on_disk = &get_filename_on_disk($cfg_file);
+		foreach my $cfg_file ( @cf ) {
+			if ( $cfg_file->{'name'} eq "regex_revalidate.config" ) {
+				my $fname_on_disk = &get_filename_on_disk( $cfg_file->{'name'} );
 				( $log_level >> $INFO )
-					&& printf( "INFO Found config file (on disk: %-41s): %-41s with location: %-50s\n", $fname_on_disk, $cfg_file, $ort_ref->{'config_files'}->{$cfg_file}->{'location'} );
-				$cfg_files->{$fname_on_disk}->{'location'} = $ort_ref->{'config_files'}->{$cfg_file}->{'location'};
+					&& printf( "INFO Found config file (on disk: %-41s): %-41s with location: %-50s\n", $fname_on_disk, $cfg_file->{'name'}, $cfg_file->{'location'} );
+				$cfg_files->{$fname_on_disk}->{'location'} = $cfg_file->{'location'};
 				if ($api_in_use == 1) {
-					$cfg_files->{$fname_on_disk}->{'API_URI'} = $ort_ref->{'config_files'}->{$cfg_file}->{'API_URI'};
+					$cfg_files->{$fname_on_disk}->{'API_URI'} = $cfg_file->{'API_URI'};
 				}
-				$cfg_files->{$fname_on_disk}->{'fname-in-TO'} = $cfg_file;
+				$cfg_files->{$fname_on_disk}->{'fname-in-TO'} = $cfg_file->{'name'};
 			}
 		}
 	}
 	else {
-		foreach my $cfg_file ( keys %{ $ort_ref->{'config_files'} } ) {
-			my $fname_on_disk = &get_filename_on_disk($cfg_file);
+		foreach my $cfg_file ( @cf ) {
+			my $fname_on_disk = &get_filename_on_disk( $cfg_file->{'name'} );
 			( $log_level >> $INFO )
-				&& printf( "INFO Found config file (on disk: %-41s): %-41s with location: %-50s\n", $fname_on_disk, $cfg_file, $ort_ref->{'config_files'}->{$cfg_file}->{'location'} );
-			$cfg_files->{$fname_on_disk}->{'location'} = $ort_ref->{'config_files'}->{$cfg_file}->{'location'};
+				&& printf( "INFO Found config file (on disk: %-41s): %-41s with location: %-50s\n", $fname_on_disk, $cfg_file->{'name'}, $cfg_file->{'location'} );
+			$cfg_files->{$fname_on_disk}->{'location'} = $cfg_file->{'location'};
 			if ($api_in_use == 1) {
-				$cfg_files->{$fname_on_disk}->{'API_URI'} = $ort_ref->{'config_files'}->{$cfg_file}->{'API_URI'};
+				$cfg_files->{$fname_on_disk}->{'API_URI'} = $cfg_file->{'API_URI'};
 			}
-			$cfg_files->{$fname_on_disk}->{'fname-in-TO'} = $cfg_file;
+			$cfg_files->{$fname_on_disk}->{'fname-in-TO'} = $cfg_file->{'name'};
 		}
 	}
 	return ( $profile_name, $cfg_files, $cdn_name );


### PR DESCRIPTION
This moves the header rewrite files from server scope to cdn scope, making them cacheable.  This should cut down significantly on the number of requests per server.