### PR TITLE
Changes to the astats_over_http rpm spec file.

### DIFF
--- a/traffic_server/plugins/astats_over_http/astats_over_http.spec
+++ b/traffic_server/plugins/astats_over_http/astats_over_http.spec
@@ -17,25 +17,36 @@
 # under the License.
 
 %global install_prefix "/opt"
+%global commit %(git blame --incremental astats_over_http.c | head -1 | awk '{print substr($1,0,7)}' )
+%global no_commits %(git log astats_over_http.c | grep '^commit' | wc -l)
+%global _find_debuginfo_dwz_opts %{nil}
 
 Name:		astats_over_http
-Version:	1.2
-Release:	1%{?dist}
+Version:	1.3.0
+Release:	%{no_commits}.%{commit}%{?dist}
+Epoch:    434
 Summary:	Apache Traffic Server %{name} plugin
 Vendor:		Comcast
 Group:		Applications/Communications
 License:	Apache License, Version 2.0
 URL:		https://github.com/apache/incubator-trafficcontrol/tree/master/traffic_server/plugins/astats_over_http
-Source0:	%{name}.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-Requires:	trafficserver = 5.2.0
-BuildRequires:	trafficserver = 5.2.0
+Requires:	trafficserver >= 6011
+BuildRequires:	trafficserver >= 6011
 
 %description
 Apache Traffic Server plugin
 
 %prep
-%setup -q -n %{name}
+rm -rf %{name}
+git clone https://git-wip-us.apache.org/repos/asf/incubator-trafficcontrol.git
+cd incubator-trafficcontrol
+git checkout master
+git checkout %{commit} .
+cd ..
+mv incubator-trafficcontrol/traffic_server/plugins/astats_over_http %{name}
+rm -rf incubator-trafficcontrol
+%setup -D -n %{name} -T
 
 %build
 %{install_prefix}/trafficserver/bin/tsxs -v -c %{name}.c -o %{name}.so


### PR DESCRIPTION
Modified the astats spec file so that when an rpm is built, the
build source is pulled from the current master branch at
https://git-wip-us.apache.org/repos/asf/incubator-trafficcontrol.git.
The commit hash used in the rpm name is from the last commit on
astats_over_http.c