### PR TITLE
Scope ort changes - Requires PR 438

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1739,10 +1739,10 @@ sub get_cfg_file_list {
 	}
 	if ( $script_mode == $REVALIDATE ) {
 		foreach my $cfg_file ( @cf ) {
-			if ( $cfg_file->{'name'} eq "regex_revalidate.config" ) {
-				my $fname_on_disk = &get_filename_on_disk( $cfg_file->{'name'} );
+			if ( $cfg_file->{'fnameOnDisk'} eq "regex_revalidate.config" ) {
+				my $fname_on_disk = &get_filename_on_disk( $cfg_file->{'fnameOnDisk'} );
 				( $log_level >> $INFO )
-					&& printf( "INFO Found config file (on disk: %-41s): %-41s with location: %-50s\n", $fname_on_disk, $cfg_file->{'name'}, $cfg_file->{'location'} );
+					&& printf( "INFO Found config file (on disk: %-41s): %-41s with location: %-50s\n", $fname_on_disk, $cfg_file->{'fnameOnDisk'}, $cfg_file->{'location'} );
 				$cfg_files->{$fname_on_disk}->{'location'} = $cfg_file->{'location'};
 				if ($api_in_use == 1) {
 					$cfg_files->{$fname_on_disk}->{'apiUri'} = $cfg_file->{'apiUri'};
@@ -1758,9 +1758,9 @@ sub get_cfg_file_list {
 			my @cf = $ort_ref->{'configFiles'};
 		}
 		foreach my $cfg_file ( @cf ) {
-			my $fname_on_disk = &get_filename_on_disk( $cfg_file->{'name'} );
+			my $fname_on_disk = &get_filename_on_disk( $cfg_file->{'fnameOnDisk'} );
 			( $log_level >> $INFO )
-				&& printf( "INFO Found config file (on disk: %-41s): %-41s with location: %-50s\n", $fname_on_disk, $cfg_file->{'name'}, $cfg_file->{'location'} );
+				&& printf( "INFO Found config file (on disk: %-41s): %-41s with location: %-50s\n", $fname_on_disk, $cfg_file->{'fnameOnDisk'}, $cfg_file->{'location'} );
 			$cfg_files->{$fname_on_disk}->{'location'} = $cfg_file->{'location'};
 			if ($api_in_use == 1) {
 				$cfg_files->{$fname_on_disk}->{'apiUri'} = $cfg_file->{'apiUri'};


### PR DESCRIPTION
ORT changes required to change scope for multiple configuration files.  Adds support for replacement of __HOSTNAME__, __HOSTNAME_FULL__, __SERVER_TCP_PORT, and __CACHE_IPV4.  Also adds support for configFiles array of objects change.  Also includes minor variable naming changes.

This PR requires https://github.com/apache/incubator-trafficcontrol/pull/438 to be merged at the same time.