### PR TITLE
Add a spec file that checks out astats source from git when building an rpm

### DIFF
--- a/traffic_server/plugins/astats_over_http/CHANGELOG
+++ b/traffic_server/plugins/astats_over_http/CHANGELOG
@@ -1,0 +1,3 @@
+
+04-11-2017 - bumped version to 1.3 to account for ats 6.2.1 api changes.
+

--- a/traffic_server/plugins/astats_over_http/README.md
+++ b/traffic_server/plugins/astats_over_http/README.md
@@ -8,3 +8,9 @@ Add to the plugin.conf:
   astats_over_http.so path=${path}
 
 start traffic server and visit http://[ip]:[port]/${path}
+
+Rpm Builds
+
+  Two spec files are provided.  astats_over_http.spec requires a tar ball of this directoy 
+  named astats_over_htt-.tar.gz is copied to the rpmbuild/SOURCES directory.  The second
+  astats-git-build, checks out the source from the git repo and builds the rpm.

--- a/traffic_server/plugins/astats_over_http/astats-git-build.spec
+++ b/traffic_server/plugins/astats_over_http/astats-git-build.spec
@@ -17,25 +17,36 @@
 # under the License.
 
 %global install_prefix "/opt"
+%global commit %(git blame --incremental astats_over_http.c | head -1 | awk '{print substr($1,0,7)}' )
+%global no_commits %(git log astats_over_http.c | grep '^commit' | wc -l)
+%global _find_debuginfo_dwz_opts %{nil}
 
 Name:		astats_over_http
-Version:	1.3
-Release:	1%{?dist}
+Version:	1.3.0
+Release:	%{no_commits}.%{commit}%{?dist}
+Epoch:    434
 Summary:	Apache Traffic Server %{name} plugin
 Vendor:		Comcast
 Group:		Applications/Communications
 License:	Apache License, Version 2.0
 URL:		https://github.com/apache/incubator-trafficcontrol/tree/master/traffic_server/plugins/astats_over_http
-Source0:	%{name}.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-Requires:	trafficserver = 5.2.0
-BuildRequires:	trafficserver = 5.2.0
+Requires:	trafficserver >= 6011
+BuildRequires:	trafficserver >= 6011
 
 %description
 Apache Traffic Server plugin
 
 %prep
-%setup -q -n %{name}
+rm -rf %{name}
+git clone https://git-wip-us.apache.org/repos/asf/incubator-trafficcontrol.git
+cd incubator-trafficcontrol
+git checkout master
+git checkout %{commit} .
+cd ..
+mv incubator-trafficcontrol/traffic_server/plugins/astats_over_http %{name}
+rm -rf incubator-trafficcontrol
+%setup -D -n %{name} -T
 
 %build
 %{install_prefix}/trafficserver/bin/tsxs -v -c %{name}.c -o %{name}.so


### PR DESCRIPTION
Added an astats-git-build spec file for building this plugin from the latest
commit in the git repo.

Updated README.md and added a changelog.  Bumped astats version to 1.3 to account for
ats 6.2.1 change.