### PR TITLE
[TC-233] adds check for connecting to psql as postgres user

### DIFF
--- a/traffic_ops/install/bin/postinstall
+++ b/traffic_ops/install/bin/postinstall
@@ -22,6 +22,11 @@ for p in git go; do
 	type $p >/dev/null 2>&1 || { echo >&2 "postinstall requires $p but it's not installed.  Aborting."; exit 1; }
 done
 
+if [[ ! $(su - postgres psql -w -c 'show is_superuser' </dev/null 2>/dev/null) =~ 'on' ]]; then
+	echo >&2 "postinstall requires the postgres user to have superuser access to postgresql. Aborting."
+	exit 1
+fi
+
 # install carton first
 cpanm Carton
 


### PR DESCRIPTION
we want to ensure that `postinstall` can run `db/admin.pl` to set up user/db,  so check first if `postgres` user is accessible thru `psql -Upostgres`.   If not,  go no further.