### PR TITLE
if primary parent list is empty use secondary

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2019,6 +2019,10 @@ sub parent_dot_config {
 						push @secondary_parent_info, $ptxt;
 					}
 				}
+				if ( scalar @parent_info == 0  ) {
+					@parent_info = @secondary_parent_info;
+					@secondary_parent_info = ();
+				}
 				my %seen;
 				@parent_info = grep { !$seen{$_}++ } @parent_info;
 				my $parents = 'parent="' . join( '', @parent_info ) . '"';

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -1226,6 +1226,10 @@ sub parent_dot_config {
 						push @secondary_parent_info, $ptxt;
 					}
 				}
+				if ( scalar @parent_info == 0  ) {
+					@parent_info = @secondary_parent_info;
+					@secondary_parent_info = ();
+				}
 				my %seen;
 				@parent_info = grep { !$seen{$_}++ } @parent_info;
 				my $parents = 'parent="' . join( '', @parent_info ) . '"';


### PR DESCRIPTION
This moves the contents of the secondary parent list to the primary parent list and empties the secondary list if the primary cachegroup is empty - no servers or servers are offline.  This prevents an empty parent='' situation from happening. 