### PR TITLE
[TC-240] updates db dump to custom format with compression and adds api

### DIFF
--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -474,6 +474,9 @@ sub api_routes {
 	$r->get("/api/$version/servers/#id/configfiles/ats/#filename")->over( authenticated => 1 )->to ( 'ApacheTrafficServer#get_server_config', namespace => 'API::Configs' );
 	$r->get("/api/$version/cdns/#id/configfiles/ats/#filename")->over( authenticated => 1 )->to ( 'ApacheTrafficServer#get_cdn_config', namespace => 'API::Configs' );
 
+	# -- DB DUMP
+	$r->get("/api/$version/dbdump")->over( authenticated => 1 )->to( 'Database#dbdump', namespace => $namespace );
+
 	# -- DELIVERYSERVICES
 	# -- DELIVERYSERVICES: CRUD
 	$r->get("/api/$version/deliveryservices")->over( authenticated => 1 )->to( 'Deliveryservice#index', namespace => $namespace );

--- a/traffic_ops/app/lib/UI/Tools.pm
+++ b/traffic_ops/app/lib/UI/Tools.pm
@@ -153,7 +153,7 @@ sub db_dump {
     my $host = `hostname`;
     chomp($host);
 
-    my $extension = ".psql";
+    my $extension = ".dump.gz";
     my $filename = "to-backup-" . $host . "-" . $year . $month . $day . $hour . $min . $sec . $extension;
     $self->stash( filename => $filename );
     &stash_role($self);


### PR DESCRIPTION
This commit changes the UI db dump output format to custom and then compresses the dump file using gzip.  It also adds the API route api/$version/dbdump which returns a compressed gzip dump file whose filename contains the hostname and timestamp.