### PR TITLE
[TC-240] Fix Database dump failure

### DIFF
--- a/traffic_ops/app/lib/API/Database.pm
+++ b/traffic_ops/app/lib/API/Database.pm
@@ -33,7 +33,7 @@ sub dbdump {
 	my $db_user = $Schema::user;
 	my $db_pass = $Schema::pass;
 
-	my $ok = open my $fh, '-|', "PGPASSWORD=/\"$db_pass/\" pg_dump -b -Fc --no-owner -h $host -p $port -U $db_user";
+	my $ok = open my $fh, '-|', "PGPASSWORD=\"$db_pass\" pg_dump -b -Fc --no-owner -h $host -p $port -U $db_user -d $db_name";
 	if (! $ok ) {
 		$self->internal_server_error( { Error => "Error dumping database" } );	
 		return;
@@ -42,13 +42,11 @@ sub dbdump {
 	# slurp it in..
 	undef $/;
 	my $data = <$fh>;
-	my $zipdata;
-	gzip \$data => \$zipdata;
 
 
 	$self->res->headers->content_type("application/download");
 	$self->res->headers->content_disposition( "attachment; filename=\"" . $filename . "\"" );
-	$self->render( data => $zipdata );
+	$self->render( data => $data );
 	close $fh;
 }
 
@@ -63,7 +61,7 @@ sub get_filename {
     my $host = `hostname`;
     chomp($host);
 
-    my $extension = ".dump.gz";
+    my $extension = ".dump";
     my $filename = "to-backup-" . $host . "-" . $year . $month . $day . $hour . $min . $sec . $extension;
     return $filename;
 }

--- a/traffic_ops/app/lib/API/Database.pm
+++ b/traffic_ops/app/lib/API/Database.pm
@@ -61,7 +61,7 @@ sub get_filename {
     my $host = `hostname`;
     chomp($host);
 
-    my $extension = ".dump";
+    my $extension = ".pg_dump";
     my $filename = "to-backup-" . $host . "-" . $year . $month . $day . $hour . $min . $sec . $extension;
     return $filename;
 }

--- a/traffic_ops/app/lib/UI/GenDbDump.pm
+++ b/traffic_ops/app/lib/UI/GenDbDump.pm
@@ -33,7 +33,7 @@ sub dbdump {
 	my $db_user = $Schema::user;
 	my $db_pass = $Schema::pass;
 
-	my $ok = open my $fh, '-|', "PGPASSWORD=/\"$db_pass/\" pg_dump -b -Fc --no-owner -h $host -p $port -U $db_user";
+	my $ok = open my $fh, '-|', "PGPASSWORD=\"$db_pass\" pg_dump -b -Fc --no-owner -h $host -p $port -U $db_user -d $db_name";
 	if (! $ok ) {
 		$self->internal_server_error( { Error => "Error dumping database" } );	
 		return;
@@ -42,13 +42,11 @@ sub dbdump {
 	# slurp it in..
 	undef $/;
 	my $data = <$fh>;
-	my $zipdata;
-	gzip \$data => \$zipdata;
 
 
 	$self->res->headers->content_type("application/download");
 	$self->res->headers->content_disposition( "attachment; filename=\"" . $filename . "\"" );
-	$self->render( data => $zipdata );
+	$self->render( data => $data );
 	close $fh;
 }
 

--- a/traffic_ops/app/lib/UI/Tools.pm
+++ b/traffic_ops/app/lib/UI/Tools.pm
@@ -153,7 +153,7 @@ sub db_dump {
     my $host = `hostname`;
     chomp($host);
 
-    my $extension = ".dump";
+    my $extension = ".pg_dump";
     my $filename = "to-backup-" . $host . "-" . $year . $month . $day . $hour . $min . $sec . $extension;
     $self->stash( filename => $filename );
     &stash_role($self);

--- a/traffic_ops/app/lib/UI/Tools.pm
+++ b/traffic_ops/app/lib/UI/Tools.pm
@@ -153,7 +153,7 @@ sub db_dump {
     my $host = `hostname`;
     chomp($host);
 
-    my $extension = ".dump.gz";
+    my $extension = ".dump";
     my $filename = "to-backup-" . $host . "-" . $year . $month . $day . $hour . $min . $sec . $extension;
     $self->stash( filename => $filename );
     &stash_role($self);


### PR DESCRIPTION
Downloads were 0 bytes because the password was being incorrectly passed.  Removed gzip compression because it was causing the browser to suspect a malicious file.