### PR TITLE
[TC-244] Correctly search by cdn name rather than domain name

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -851,10 +851,8 @@ sub ds_data {
 
 	my $rs_dsinfo;
 	if ( $server_obj->type->name =~ m/^MID/ ) {
-
 		# the mids will do all deliveryservices in this CDN
-		my $domain = $self->get_cdn_domain_by_profile_id( $server_obj->profile->id );
-		$rs_dsinfo = $self->db->resultset('DeliveryServiceInfoForDomainList')->search( {}, { bind => [$domain] } );
+		$rs_dsinfo = $self->db->resultset('DeliveryServiceInfoForDomainList')->search( {}, { bind => [ $server_obj->cdn->name ] } );
 	}
 	else {
 		$rs_dsinfo = $self->db->resultset('DeliveryServiceInfoForServerList')->search( {}, { bind => [ $server_obj->id ] } );

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -184,10 +184,8 @@ sub ds_data {
 	my @server_ids = ();
 	my $rs;
 	if ( $server->type->name =~ m/^MID/ ) {
-
 		# the mids will do all deliveryservices in this CDN
-		my $domain = $self->get_cdn_domain_by_profile_id( $server->profile->id );
-		$rs = $self->db->resultset('DeliveryServiceInfoForDomainList')->search( {}, { bind => [$domain] } );
+		$rs = $self->db->resultset('DeliveryServiceInfoForDomainList')->search( {}, { bind => [ $server->cdn->name ] } );
 	}
 	else {
 		$rs = $self->db->resultset('DeliveryServiceInfoForServerList')->search( {}, { bind => [ $server->id ] } );


### PR DESCRIPTION
This corrects parent.config generation for mids.  Previously the results were blank as we were searching by the domain name, not the CDN name.