### PR TITLE
Add Traffic Monitor 2.0 Parameter to disable TCP KeepAlive in Polls

### DIFF
--- a/traffic_monitor_golang/traffic_monitor/tmcheck/tmcheck.go
+++ b/traffic_monitor_golang/traffic_monitor/tmcheck/tmcheck.go
@@ -61,6 +61,7 @@ func GetCDN(uri string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("reading reply from %v: %v\n", uri, err)
 	}
+	defer resp.Body.Close()
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("reading reply from %v: %v\n", uri, err)
@@ -79,6 +80,7 @@ func GetCRStates(uri string) (*peer.Crstates, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading reply from %v: %v\n", uri, err)
 	}
+	defer resp.Body.Close()
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading reply from %v: %v\n", uri, err)
@@ -97,6 +99,7 @@ func GetDSStats(uri string) (*dsdata.StatsOld, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading reply from %v: %v\n", uri, err)
 	}
+	defer resp.Body.Close()
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading reply from %v: %v\n", uri, err)
@@ -115,6 +118,7 @@ func GetStats(uri string) (*datareq.Stats, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading reply from %v: %v\n", uri, err)
 	}
+	defer resp.Body.Close()
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading reply from %v: %v\n", uri, err)


### PR DESCRIPTION
If `peer.polling.keepalive`, `health.polling.keepalive`, or `heartbeat.polling.keepalive` exist and are a string starting with "f" (e.g. "false"), TCP KeepAlive is disabled for that poll. If the parameter doesn't exist, or is any other string, it defaults to KeepAlive (existing behavior).