### PR TITLE
[TC-251] Fixed an issue where Traffic Ops was not correctly refreshing DNSSEC keys

### DIFF
--- a/traffic_ops/app/lib/MojoPlugins/Daemonize.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Daemonize.pm
@@ -17,66 +17,36 @@ package MojoPlugins::Daemonize;
 #
 
 use Mojo::Base 'Mojolicious::Plugin';
-use POSIX qw(close setsid);
+use POSIX qw(:sys_wait_h close setsid);
 
 sub register {
 	my ( $self, $app, $conf ) = @_;
 
 	$app->renderer->add_helper(
-		# Note: Calling fork_and_daemonize() returns twice: Once for the parent and the other for the daemon (=child).
-		# Caller should check return value: 
-		#  <0 means an error occured
-		#  0 means you are the daemon (=child)
-		#  1 means you are the parent (= original process)
 		fork_and_daemonize => sub {
 			my $self = shift;
+			my $method = shift;
+
+			# reap any finished child processes
+			my $kid;
+			do {
+				$kid = waitpid(-1, WNOHANG);
+				$self->app->log->debug("Reaping PID $kid");
+			} while $kid > 0;
+
 			my $pid  = fork();
 
 			if ( !defined($pid) ) {
-				$self->app->log->fatal("fork_and_daemonize(): Parent unable to fork: $!");
-				return -1;
+				$self->app->log->fatal("Unable to fork: $!");
+				return (-1);
 			}
 
 			if ( $pid == 0 ) {
-				# This is the first child
 				$self->inactivity_timeout(0);
 				POSIX::setsid();
-				open( STDIN, "< /dev/null" )
-					|| confess("Can't read /dev/null: $!");
-				open( STDOUT, "> /dev/null" )
-					|| confess("Can't write to /dev/null: $!");
-				open( STDERR, "> /dev/null" )
-					|| confess("Can't write to /dev/null: $!");
-				# First child forks daemon and exits with a value that signals the parent how the fork went
-    			my $pid  = fork();
-
-	    		if ( !defined($pid) ) {
-					$self->app->log->fatal("fork_and_daemonize(): Child unable to fork: $!");
-					# Exit with -1 to let parent know that the fork failed
-					exit(-1);
-				}
-				if ($pid > 0) {
-					# First child: Fork was OK, exit with 0 
-					exit(0);
-				}
-				# This is the daemon, return 0 to caller
-				return 0;
 			}
 
-			# This is the parent. Wait for first child to exit
-			my $rc = waitpid($pid, 0);
-			if ($rc != $pid) {
-				$self->app->log->fatal("fork_and_daemonize(): Parent waitpid($pid) returned $rc, expecting $pid. $!");
-				return -1;
-			}
-			$rc = ${^CHILD_ERROR_NATIVE};
-			if ($rc) {
-				$self->app->log->fatal("fork_and_daemonize(): First child exited with $rc. $!");
-				return -1;
-			}
-
-            # Parent: Do not return $pid as this is the pid of the first child, which is not interesting
-			return 0;
+			return $pid;
 		}
 	);
 

--- a/traffic_ops/app/lib/MojoPlugins/Server.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Server.pm
@@ -44,9 +44,6 @@ sub register {
 			my $helper_class       = shift || confess("Supply a Helper 'class'");
 			my $method_function    = shift || confess("Supply a Helper class 'method'");
 			my $schema_result_file = shift || confess("Supply a schema result file, ie: 'InfluxDBHostsOnline'");
-
-			$self->app->log->debug("\n\n" . $schema_result_file . "\n\n");
-
 			my $response;
 			my $active_server = $active_server_for{$schema_result_file};
 			my @rs = randomize_online_servers( $self, $schema_result_file );


### PR DESCRIPTION
I had to fix fork_and_daemonize() so that it would do what we needed.  We want that method to fork off a child and return while the child does its thing in the backgroup (without waiting for the child).  This functionality was changed in 2.0 because the previous implementation was causing issues with processes that use waitpid(), see [TC-158](https://issues.apache.org/jira/browse/TC-158).  The new method is similar to the pre 2.0 method except it does not set a the SIGCHILD handler to IGNORE and it cleans up completed child processes each time it is called.  This hopefully satisfies the requirements of running asynchronously while also not leaving zombie processes and using up all of the traffic_ops workers.