### PR TITLE
[TC-255] and [TC-256] -- Fixes issues with removed method and inability to add a DS w/o a profile

### DIFF
--- a/traffic_ops/app/lib/MojoPlugins/DnssecKeys.pm
+++ b/traffic_ops/app/lib/MojoPlugins/DnssecKeys.pm
@@ -92,8 +92,7 @@ sub register {
 
 			#then get deliveryservices
 			my %search = ( profile => $profile_id );
-			my @ds_rs
-				= $self->db->resultset('Deliveryservice')->search( \%search );
+			my @ds_rs = $self->db->resultset('Deliveryservice')->search( \%search , { prefetch => [ { 'cdn' => undef }]});
 			foreach my $ds (@ds_rs) {
 				if (   $ds->type->name !~ m/^HTTP/
 					&& $ds->type->name !~ m/^DNS/ )
@@ -104,8 +103,7 @@ sub register {
 				my $ds_id  = $ds->id;
 
 				#create the ds domain name for dnssec keys
-				my $domain_name
-					= UI::DeliveryService::get_cdn_domain( $self, $ds_id );
+				my $domain_name = $ds->cdn->domain_name;
 				my $ds_regexes
 					= UI::DeliveryService::get_regexp_set( $self, $ds_id );
 				my $rs_ds = $self->db->resultset('Deliveryservice')->search(

--- a/traffic_ops/app/lib/UI/DeliveryService.pm
+++ b/traffic_ops/app/lib/UI/DeliveryService.pm
@@ -1021,7 +1021,7 @@ sub create {
 				ccr_dns_ttl                 => $self->paramAsScalar('ds.ccr_dns_ttl'),
 				type                        => $self->paramAsScalar('ds.type'),
 				cdn_id                      => $cdn_id,
-				profile                     => $self->paramAsScalar('ds.profile'),
+				profile                     => ($self->paramAsScalar('ds.profile') == -1) ? undef : $self->paramAsScalar('ds.profile'),
 				global_max_mbps             => $self->hr_string_to_mbps( $self->paramAsScalar( 'ds.global_max_mbps', 0 ) ),
 				global_max_tps              => $self->paramAsScalar( 'ds.global_max_tps', 0 ),
 				miss_lat                    => $self->paramAsScalar('ds.miss_lat'),

--- a/traffic_ops/app/lib/UI/DnssecKeys.pm
+++ b/traffic_ops/app/lib/UI/DnssecKeys.pm
@@ -239,7 +239,7 @@ sub create {
 		}
 
 		#create keys
-		my $profile = $self->db->resultset('Profile')->search( { id => $profile_id }, { prefetch => ['cdn'] } )->single();
+		my $profile = $self->db->resultset('Profile')->search( { 'me.id' => $profile_id }, { prefetch => ['cdn'] } )->single();
 		my $domain_name = $profile->cdn->domain_name;
 
 		my $response_container = $self->riak_ping();

--- a/traffic_ops/app/lib/UI/SslKeys.pm
+++ b/traffic_ops/app/lib/UI/SslKeys.pm
@@ -80,7 +80,7 @@ sub get_hostname {
 	my $ds_id = shift;
 	my $data = shift;
 
-	my $domain_name     = UI::DeliveryService::get_cdn_domain( $self, $ds_id );
+	my $domain_name = $data->cdn->domain_name;
 	my $ds_regexes      = UI::DeliveryService::get_regexp_set( $self, $ds_id );
 	my @example_urls    = UI::DeliveryService::get_example_urls( $self, $ds_id, $ds_regexes, $data, $domain_name, $data->protocol );
 


### PR DESCRIPTION
This fixes the following issues: 
[TC-255](https://issues.apache.org/jira/browse/TC-255) - Cannot manage SSL certs for DSs that don't already have certs.
[TC-256](https://issues.apache.org/jira/browse/TC-256) - Connot add a DS without a profile.