### PR TITLE
[TC-265] adds secondary psel qstring handling at profile level

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2008,9 +2008,17 @@ sub parent_dot_config {
 				$text .= "dest_domain=" . $org_uri->host . " port=" . $org_uri->port . " go_direct=true\n";
 			}
 			else {
+				# check for delivery service psel.qstring_handling.  If this parameter is assigned to the delivery service profile,
+				# then edges will use the qstring handling value specified in the parameter for all profiles.
 				my $qsh = $ds->{'param'}->{'parent.config'}->{'psel.qstring_handling'};
+				# If there is no defined parameter in the delivery service, then check the server's profile.
+				# If psel.qstring_handling exists in the profile, then we use that value for the specified profile only.
+				# This is used only if not overridden by a delivery service profile qstring handling parameter.
+				if (!defined($qsh)) {
+					$qsh = $self->profile_param_value( $server_obj->profile->id, 'parent.config', 'psel.qstring_handling');
+				}
 				my $parent_qstring = defined($qsh) ? $qsh : "ignore";
-				if ( $ds->{qstring_ignore} == 0 && !defined($qsh) ) {
+				if ( $remap->{qstring_ignore} == 0 && !defined($qsh) ) {
 					$parent_qstring = "consider";
 				}
 

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2018,7 +2018,7 @@ sub parent_dot_config {
 					$qsh = $self->profile_param_value( $server_obj->profile->id, 'parent.config', 'psel.qstring_handling');
 				}
 				my $parent_qstring = defined($qsh) ? $qsh : "ignore";
-				if ( $remap->{qstring_ignore} == 0 && !defined($qsh) ) {
+				if ( $ds->{qstring_ignore} == 0 && !defined($qsh) ) {
 					$parent_qstring = "consider";
 				}
 

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -1207,7 +1207,15 @@ sub parent_dot_config {
 				$text .= "dest_domain=" . $org_uri->host . " port=" . $org_uri->port . " go_direct=true\n";
 			}
 			else {
-				my $qsh = $remap->{'param'}->{'parent.config'}->{'psel.qstring_handling'};
+				# check for delivery service psel.qstring_handling.  If this parameter is assigned to the delivery service profile,
+				# then edges will use the qstring handling value specified in the parameter for all profiles.
+				my $qsh = $ds->{'param'}->{'parent.config'}->{'psel.qstring_handling'};
+				# If there is no defined parameter in the delivery service, then check the server's profile.
+				# If psel.qstring_handling exists in the profile, then we use that value for the specified profile only.
+				# This is used only if not overridden by a delivery service profile qstring handling parameter.
+				if (!defined($qsh)) {
+					$qsh = $self->profile_param_value( $server_obj->profile->id, 'parent.config', 'psel.qstring_handling');
+				}
 				my $parent_qstring = defined($qsh) ? $qsh : "ignore";
 				if ( $remap->{qstring_ignore} == 0 && !defined($qsh) ) {
 					$parent_qstring = "consider";


### PR DESCRIPTION
This allows a psel.qstring_handling parameter to be set to a profile, overriding all qstring handling except when specified by a delivery service profile.  Useful if you have multiple edge tiers but need different qstring values.