### PR TITLE
[TC-272] Remove ccr and steering certificates from ssl_multicert

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1934,17 +1934,12 @@ sub parent_dot_config {
 		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server_obj->profile->id },
 		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
 	my $ats_major_version = substr( $ats_ver, 0, 1 );
-	$time = localtime;
-	print STDERR "Time after ATS ver:\n";
-	print STDERR Dumper($time);
 	my $parent_info;
 	my $text = $self->header_comment( $server_obj->host_name );
 	if ( !defined($data) ) {
 		$data = $self->ds_data($server_obj);
 	}
 	$time = localtime;
-        print STDERR "Time after DS Data:\n";
-        print STDERR Dumper($time);
 	if ( $server_type =~ m/^MID/ ) {
 		my @unique_origins;
 		foreach my $ds ( @{ $data->{dslist} } ) {
@@ -2033,8 +2028,6 @@ sub parent_dot_config {
 
 		#$text .= "dest_domain=. go_direct=true\n"; # this is implicit.
 		#$self->app->log->debug( "MID PARENT.CONFIG:\n" . $text . "\n" );
-		print STDERR "Time after complete:\n";
-                print STDERR Dumper($time);
 		return $text;
 	}
 	else {    #"True" Parent - we are genning a EDGE config that points to a parent proxy.

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1922,9 +1922,6 @@ sub format_parent_info {
 sub parent_dot_config {
 	my $self       = shift;
 	my $server_obj = shift;
-	print STDERR "Start time:\n";
-	my $time = localtime;
-	print STDERR Dumper($time);
 	my $data;
 
 	my $server_type = $server_obj->type->name;
@@ -1939,7 +1936,6 @@ sub parent_dot_config {
 	if ( !defined($data) ) {
 		$data = $self->ds_data($server_obj);
 	}
-	$time = localtime;
 	if ( $server_type =~ m/^MID/ ) {
 		my @unique_origins;
 		foreach my $ds ( @{ $data->{dslist} } ) {
@@ -2124,9 +2120,6 @@ sub parent_dot_config {
 		}
 
 		$text .= "\n";
-		$time = localtime;
-        	print STDERR "Time after complete:\n";
-        	print STDERR Dumper($time);
 		return $text;
 	}
 }

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1473,11 +1473,11 @@ sub ssl_multicert_dot_config {
 
 		#first one is the one we want
 		my $hostname = $example_urls[0];
-		if ( $hostname =~ /ccr/ ) {
-				next;    # Steering delivery service SSLs should not be on the edges.
-		}
 		$hostname =~ /(https?:\/\/)(.*)/;
 		my $new_host = $2;
+		if ( $new_host =~ /^ccr/ || $new_host =~ /^tr/ ) {
+			next;    # Steering delivery service SSLs should not be on the edges.
+		}
 		my $key_name = "$new_host.key";
 		$new_host =~ tr/./_/;
 		my $cer_name = $new_host . "_cert.cer";


### PR DESCRIPTION
Removes the ccr certs and steering services from the ssl_multicert file.  This was causing issues with edges downloading ccr certificates they should not have been.