### PR TITLE
prevents DB update error when using older syncds versions with reval pending…

### DIFF
--- a/traffic_ops/app/lib/UI/Server.pm
+++ b/traffic_ops/app/lib/UI/Server.pm
@@ -986,7 +986,7 @@ sub postupdate {
 	my $use_reval_pending = $self->db->resultset('Parameter')->search( { -and => [ 'name' => 'use_reval_pending', 'config_file' => 'global' ] } )->get_column('value')->single;
 
 	#Parameters don't have boolean options at this time, so we're going to compare against the default string value of 0.
-	if ( defined($use_reval_pending) && $use_reval_pending ne '0' ) {
+	if ( defined($use_reval_pending) && $use_reval_pending ne '0' && defined($reval_updated) ) {
 		$update_server->update( { upd_pending => $updated } );
 		$update_server->update( { reval_pending => $reval_updated } );
 	}

--- a/traffic_ops/app/lib/UI/Server.pm
+++ b/traffic_ops/app/lib/UI/Server.pm
@@ -987,12 +987,9 @@ sub postupdate {
 
 	#Parameters don't have boolean options at this time, so we're going to compare against the default string value of 0.
 	if ( defined($use_reval_pending) && $use_reval_pending ne '0' && defined($reval_updated) ) {
-		$update_server->update( { upd_pending => $updated } );
 		$update_server->update( { reval_pending => $reval_updated } );
 	}
-	else {
-		$update_server->update( { upd_pending => $updated } );
-	}
+	$update_server->update( { upd_pending => $updated } );
 
 	$self->render( text => "Success", layout=>undef);
 

--- a/traffic_ops/app/lib/UI/Server.pm
+++ b/traffic_ops/app/lib/UI/Server.pm
@@ -987,9 +987,11 @@ sub postupdate {
 
 	#Parameters don't have boolean options at this time, so we're going to compare against the default string value of 0.
 	if ( defined($use_reval_pending) && $use_reval_pending ne '0' && defined($reval_updated) ) {
-		$update_server->update( { reval_pending => $reval_updated } );
+		$update_server->update( { reval_pending => $reval_updated, upd_pending => $updated } );
 	}
-	$update_server->update( { upd_pending => $updated } );
+	else {
+		$update_server->update( { upd_pending => $updated } );
+	}
 
 	$self->render( text => "Success", layout=>undef);
 


### PR DESCRIPTION
When updating the status page with use_reval_pending enabled and an older version of ORT, we are attempting to push a null value to the DB.  This fixes that.