### PR TITLE
[TC-278] postinstall -defaults option

### DIFF
--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -732,12 +732,12 @@ sub main {
     my $help = 0;
 
     # help string
-    my $usageString = "Usage: postinstall [-a] [-debug] [-defaults] [-r] -cfile=[config_file]\n";
+    my $usageString = "Usage: postinstall [-a] [-debug] [-defaults[=<outfile]] [-r] -cfile=[config_file]\n";
 
     GetOptions(
         "cfile=s"     => \$inputFile,
         "automatic"   => \$automatic,
-        "defaults"    => \$dumpDefaults,
+        "defaults:s"  => \$dumpDefaults,
         "debug"       => \$debug,
         "help"        => \$help
     ) or die($usageString);
@@ -770,8 +770,14 @@ sub main {
         InstallUtils::logger( "Running in automatic mode", "info" );
     }
 
-    if ($dumpDefaults) {
-        InstallUtils::logger( "Writing default configuration file to $outputConfigFile", "info" );
+    if (defined $dumpDefaults) {
+        # -defaults flag provided.
+        if ($dumpDefaults ne "") {
+	    # -defaults=<filename>  -- if -defaults without a file name, use the default.
+	    # dumpDefaults with value -- use that as output file name
+	    $outputConfigFile = $dumpDefaults;
+        }
+        InstallUtils::logger( "Writing default configuration to $outputConfigFile", "info" );
         InstallUtils::writeJson( $outputConfigFile, $defaultInputs );
         return;
     }
@@ -810,7 +816,7 @@ sub main {
     chdir("/opt/traffic_ops/install/bin");
     my $rc = InstallUtils::execCommand( "./download_web_deps", "-i" );
     if ( $rc != 0 ) {
-     errorOut("Failed to install Traffic Ops Web dependencies, check the console output and rerun postinstall once you've resolved the error");
+        errorOut("Failed to install Traffic Ops Web dependencies, check the console output and rerun postinstall once you've resolved the error");
     }
 
     # The generator functions handle checking input/default/automatic mode

--- a/traffic_ops/install/bin/postinstall
+++ b/traffic_ops/install/bin/postinstall
@@ -14,6 +14,22 @@
 # limitations under the License.
 #
 
+for arg in "$@"; do
+	case $arg in
+		-h*) action=bypass
+			;;
+		-defaults*) action=bypass
+			;;
+	esac
+done
+
+# above options don't require any of the extra processing -- just kick off the script with
+# options intact.
+if [[ $action == "bypass" ]]; then
+	/opt/traffic_ops/install/bin/_postinstall "$@"
+	exit
+fi
+
 # make sure installed with proper permissions
 umask 022
 


### PR DESCRIPTION
postinstall -defaults and -h skip all pre-postinstall steps and just pass options to the _postinstall perl script.  Also allow -defaults= to specify output file to write config.
