### PR TITLE
Will not try to download lua files referenced in remap.config

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1265,7 +1265,7 @@ sub check_plugins {
 					( my @parts ) = split( /\//, $plugin_config_file );
 					$plugin_config_file = $parts[$#parts];
 					$plugin_config_file =~ s/\s+//g;
-					if ( !exists($cfg_file_tracker->{$plugin_config_file}->{'remap_plugin_config_file'}) ) {
+					if ( !exists($cfg_file_tracker->{$plugin_config_file}->{'remap_plugin_config_file'} && $plugin_config_file !~ /.lua$/ ) ) {
 						$cfg_file_tracker->{$plugin_config_file}->{'remap_plugin_config_file'} = 1;
 					}
 				}


### PR DESCRIPTION
This ignores lua files when processing the remap.config, and does not attempt to download them.  They will still be downloaded if added as a take and bake parameter file.