### PR TITLE
Adds external file download functionality for scripts

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -227,7 +227,6 @@ sub get_cdn_config {
 	elsif ( $filename eq "regex_revalidate.config" ) { $file_contents = $self->regex_revalidate_dot_config( $cdn_obj, $filename ); }
 	elsif ( $filename =~ /set_dscp_.*\.config/ ) { $file_contents = $self->set_dscp_dot_config( $cdn_obj, $filename ); }
 	elsif ( $filename eq "ssl_multicert.config" ) { $file_contents = $self->ssl_multicert_dot_config( $cdn_obj, $filename ); }
-	elsif ( $filename eq "download" && defined($ext_url) ) { $file_contents = $self->download_file( $ext_url ) }
 	else { return $self->not_found(); }
 
 	if ( !defined($file_contents) ) {
@@ -333,7 +332,6 @@ sub get_scope {
 	elsif ( $fname eq "volume.config" )                        { $scope = 'profiles' }
 	elsif ( $fname eq "bg_fetch.config" )                      { $scope = 'cdns' }
 	elsif ( $fname =~ /cacheurl.*\.config/ )                   { $scope = 'cdns' }
-	elsif ( $fname eq "download" )                             { $scope = 'cdns' }
 	elsif ( $fname =~ /hdr_rw_.*\.config/ )                    { $scope = 'cdns' }
 	elsif ( $fname =~ /regex_remap_.*\.config/ )               { $scope = 'cdns' }
 	elsif ( $fname eq "regex_revalidate.config" )              { $scope = 'cdns' }
@@ -1001,18 +999,6 @@ sub facts {
 	return $text;
 }
 
-#downloads a file from an external source and returns it.
-sub download_file {
-	my $self = shift;
-	my $url  = shift;
-
-	my $ua = Mojo::UserAgent->new;
-	$ua     = $ua->max_redirects(3);
-	$ua         = $ua->request_timeout(5);
-	my $download = $ua->get($url)->res;
-	if ( $download->code == '200' ) { return $download->body; }
-	else { return; }
-}
 
 #generates a generic config file based on a server and parameters which match the supplied filename.
 sub take_and_bake_server {

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -18,7 +18,6 @@ package API::Configs::ApacheTrafficServer;
 #
 use UI::Utils;
 use Mojo::Base 'Mojolicious::Controller';
-use Mojo::UserAgent;
 use Date::Manip;
 use NetAddr::IP;
 use Data::Dumper;
@@ -119,9 +118,8 @@ sub get_config_metadata {
 			$scope_id = $server_obj->host_name;
 		}
 		if (defined ( $config_file_obj->{$config_file}->{'url'} ) ) {
-			$config_file_obj->{$config_file}->{'apiUri'} = "/api/1.2/" . $scope . "/" . $scope_id . "/configfiles/ats/download?url=" . $config_file_obj->{$config_file}->{'url'};
 			#delete the url element so we don't see it in the metadata:
-			delete $config_file_obj->{$config_file}->{'url'};
+			delete $config_file_obj->{$config_file}->{'apiUri'};
 		}
 		else {
 			$config_file_obj->{$config_file}->{'apiUri'} = "/api/1.2/" . $scope . "/" . $scope_id . "/configfiles/ats/" . $config_file;


### PR DESCRIPTION
This adds simple file download functionality for files not contained within traffic ops, such as lua scripts.  These files will be cached using the CDN scope, as they are expected to be static within the update period.  Any result other than an http 200 will result in an error return.

An example URI added to the metadata would be:

"/api/1.2/cdns/title-vi/configfiles/ats/download?https://Example.com/file

Traffic ops will then attempt to download the file at the supplied URL and pass it back.