### PR TITLE
[Backport TC-345] source tarball has invalid link

### DIFF
--- a/build/functions.sh
+++ b/build/functions.sh
@@ -168,7 +168,7 @@ function createTarball() {
         getBuildNumber >"$bndir/BUILD_NUMBER"
 
         # create the tarball only from files in repo and BUILD_NUMBER
-        tar -czf "$tarball" -C "$bndir" BUILD_NUMBER -C "$projDir" --exclude-vcs --transform "flags=S;s@^@$projName-$version/@" $(git ls-files)
+        tar -czf "$tarball" -C "$bndir" BUILD_NUMBER -C "$projDir" --exclude-vcs --transform "s@^@$projName-$version/@S" $(git ls-files)
         rm -r "$bndir"
         echo "$tarball"
 }


### PR DESCRIPTION
(cherry picked from commit ebfae5038a66a3124a329c9f11c51c705b083dd0)