### PR TITLE
[Backport] license fixes to be backported to 2.0.x

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -5,6 +5,7 @@ VERSION(?:                           This very short file doesn't support commen
 .*\.css\.map(?:                      debug files for minified css. License borne by source. ){0}
 \..*(?:                              hidden files ought not to be code. These are generally things like projects, ignore files and such. ){0}
 LICEN[SC]E.*(?:                      Licenses do not usually require meta-licenses. ){0}
+^licenses/*(?:                         Licenses do not usually require meta-licenses. ){0}
 .*\.conf(?:ig)?(?:\.?.*)?(?:         Config files aren't code and don't typically require licenses. ){0}
 .*\.cfg(?:                           config file ){0}
 .*\.logrotate(?:                     config file ){0}

--- a/traffic_monitor_golang/common/util/num.go
+++ b/traffic_monitor_golang/common/util/num.go
@@ -1,5 +1,24 @@
 package util
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 // ToNumeric returns a float for any numeric type, and false if the interface does not hold a numeric type.
 // This allows converting unknown numeric types (for example, from JSON) in a single line
 // TODO try to parse string stats as numbers?

--- a/traffic_monitor_golang/traffic_monitor/crconfig/data.go
+++ b/traffic_monitor_golang/traffic_monitor/crconfig/data.go
@@ -1,5 +1,24 @@
 package crconfig
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import (
 	"time"
 )

--- a/traffic_ops/app/db/pg-migration/runwaiter.sh
+++ b/traffic_ops/app/db/pg-migration/runwaiter.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 
 echo "WAITER_HOST: $WAITER_HOST"


### PR DESCRIPTION
(cherry picked from commit 1ddcd73418bf17450a194cd767370c09763ed1fa)