### PR TITLE
[TC-352] upgrade jdk download for tm/tr build

### DIFF
--- a/infrastructure/docker/build/Dockerfile-traffic_monitor
+++ b/infrastructure/docker/build/Dockerfile-traffic_monitor
@@ -36,7 +36,7 @@ RUN	yum -y install \
 	yum -y clean all
 
 WORKDIR /opt
-RUN curl -L -b "oraclelicense=a" http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz | tar xzf - && \
+RUN curl -L -b "oraclelicense=a" http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz | tar xzf - && \
     curl -L http://mirror.nexcess.net/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | tar xzf -
 RUN ln -s jdk* java && ln -s apache-maven* maven
 

--- a/infrastructure/docker/build/Dockerfile-traffic_router
+++ b/infrastructure/docker/build/Dockerfile-traffic_router
@@ -34,7 +34,7 @@ RUN	yum -y install \
 		which
 
 WORKDIR /opt
-RUN curl -L -b "oraclelicense=a" http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-linux-x64.tar.gz | tar xzf - && \
+RUN curl -L -b "oraclelicense=a" http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz | tar xzf - && \
     curl -L http://mirror.nexcess.net/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | tar xzf -
 RUN ln -s jdk* java && ln -s apache-maven* maven
 


### PR DESCRIPTION
previous version disappeared from oracle web site.  Updated to a newer version,  but we need to find a better solution.