### PR TITLE
Change Traffic Ops password hashing to scrypt

### DIFF
--- a/traffic_ops/app/cpanfile
+++ b/traffic_ops/app/cpanfile
@@ -270,6 +270,7 @@ requires 'Net::Riak';
 requires 'Crypt::OpenSSL::RSA';
 requires 'Crypt::OpenSSL::Bignum';
 requires 'Crypt::OpenSSL::Random';
+requires 'Crypt::ScryptKDF';
 requires 'Net::DNS::SEC::Private';
 requires 'LWP::Protocol::https';
 requires 'Net::CIDR';

--- a/traffic_ops/app/lib/API/Job.pm
+++ b/traffic_ops/app/lib/API/Job.pm
@@ -22,7 +22,6 @@ use UI::Utils;
 
 use Mojo::Base 'Mojolicious::Controller';
 use UI::Utils;
-use Digest::SHA1 qw(sha1_hex);
 use Mojolicious::Validator;
 use Mojolicious::Validator::Validation;
 use Mojo::JSON;

--- a/traffic_ops/app/lib/API/User.pm
+++ b/traffic_ops/app/lib/API/User.pm
@@ -20,7 +20,7 @@ package API::User;
 use UI::Utils;
 
 use Mojo::Base 'Mojolicious::Controller';
-use Digest::SHA1 qw(sha1_hex);
+use Utils::Helper;
 use Mojolicious::Validator;
 use Mojolicious::Validator::Validation;
 use Data::Dumper;
@@ -184,10 +184,10 @@ sub update {
 	};
 
 	if ( defined( $params->{localPasswd} ) && $params->{localPasswd} ne '' ) {
-		$values->{"local_passwd"} = sha1_hex( $params->{localPasswd} );
+		$values->{"local_passwd"} = Utils::Helper::hash_pass($params->{localPasswd});
 	}
 	if ( defined( $params->{confirmLocalPasswd} ) && $params->{confirmLocalPasswd} ne '' ) {
-		$values->{"confirm_local_passwd"} = sha1_hex( $params->{confirmLocalPasswd} );
+		$values->{"confirm_local_passwd"} = Utils::Helper::hash_pass( $params->{confirmLocalPasswd} );
 	}
 
 	my $rs = $user->update($values);
@@ -460,10 +460,10 @@ sub update_current {
 		# These if "defined" checks allow for partial user updates, otherwise the entire
 		# user would need to be passed through.
 		if ( defined($local_passwd) && $local_passwd ne '' ) {
-			$db_user->{"local_passwd"} = sha1_hex($local_passwd);
+			$db_user->{"local_passwd"} = Utils::Helper::hash_pass( $local_passwd );
 		}
 		if ( defined($confirm_local_passwd) && $confirm_local_passwd ne '' ) {
-			$db_user->{"confirm_local_passwd"} = sha1_hex($confirm_local_passwd);
+			$db_user->{"confirm_local_passwd"} = Utils::Helper::hash_pass( $confirm_local_passwd );
 		}
 		if ( defined( $user->{"id"} ) ) {
 			$db_user->{"id"} = $user->{"id"};

--- a/traffic_ops/app/lib/TrafficOps.pm
+++ b/traffic_ops/app/lib/TrafficOps.pm
@@ -24,7 +24,7 @@ use Mojo::Base 'Mojolicious::Plugin::Config';
 use base 'DBIx::Class::Core';
 use Schema;
 use Data::Dumper;
-use Digest::SHA1 qw(sha1_hex);
+use Utils::Helper;
 use JSON;
 use Cwd;
 
@@ -439,10 +439,7 @@ sub check_local_user {
 	my $db_user = $self->db->resultset('TmUser')->find( { username => $username } );
 	if ( defined($db_user) && defined( $db_user->local_passwd ) ) {
 		$self->app->log->info( $username . " was found in the database. " );
-		my $db_local_passwd         = $db_user->local_passwd;
-		my $db_confirm_local_passwd = $db_user->confirm_local_passwd;
-		my $hex_pw_string           = sha1_hex($pass);
-		if ( $db_local_passwd eq $hex_pw_string ) {
+		if ( Utils::Helper::verify_pass($pass, $db_user->local_passwd) ) {
 			$local_user = $username;
 			$self->app->log->debug("Password matched.");
 			$is_authenticated = 1;

--- a/traffic_ops/app/lib/UI/Federation.pm
+++ b/traffic_ops/app/lib/UI/Federation.pm
@@ -21,7 +21,6 @@ use UI::Utils;
 use List::MoreUtils qw(uniq);
 
 use Mojo::Base 'Mojolicious::Controller';
-use Digest::SHA1 qw(sha1_hex);
 use Mojolicious::Validator;
 use Mojolicious::Validator::Validation;
 use Email::Valid;

--- a/traffic_ops/app/lib/UI/User.pm
+++ b/traffic_ops/app/lib/UI/User.pm
@@ -20,7 +20,7 @@ package UI::User;
 use UI::Utils;
 
 use Mojo::Base 'Mojolicious::Controller';
-use Digest::SHA1 qw(sha1_hex);
+use Utils::Helper;
 use Mojolicious::Validator;
 use Mojolicious::Validator::Validation;
 use Email::Valid;
@@ -187,10 +187,10 @@ sub update {
 
 		# ignore the local_passwd and confirm_local_passwd if it comes across as blank (or it didn't change)
 		if ( defined($local_passwd) && $local_passwd ne '' ) {
-			$dbh->local_passwd( sha1_hex( $self->param('tm_user.local_passwd') ) );
+			$dbh->local_passwd( Utils::Helper::hash_pass( $self->param('tm_user.local_passwd') ) );
 		}
 		if ( defined($confirm_local_passwd) && $confirm_local_passwd ne '' ) {
-			$dbh->confirm_local_passwd( sha1_hex( $self->param('tm_user.confirm_local_passwd') ) );
+			$dbh->confirm_local_passwd( Utils::Helper::hash_pass( $self->param('tm_user.confirm_local_passwd') ) );
 		}
 
 		$dbh->company( $self->param('tm_user.company') );
@@ -293,8 +293,8 @@ sub create_user {
 			public_ssh_key       => $self->param('tm_user.public_ssh_key'),
 			phone_number         => $self->param('tm_user.phone_number'),
 			email                => $self->param('tm_user.email'),
-			local_passwd         => sha1_hex( $self->param('tm_user.local_passwd') ),
-			confirm_local_passwd => sha1_hex( $self->param('tm_user.confirm_local_passwd') ),
+			local_passwd         => Utils::Helper::hash_pass( $self->param('tm_user.local_passwd') ),
+			confirm_local_passwd => Utils::Helper::hash_pass( $self->param('tm_user.confirm_local_passwd') ),
 			role                 => $self->param('tm_user.role'),
 			new_user             => 0,
 			uid                  => 0,

--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -28,7 +28,7 @@ use DBI;
 use POSIX;
 use File::Basename qw{dirname};
 use File::Path qw{make_path};
-use Digest::SHA1 qw(sha1_hex);
+use Crypt::ScryptKDF qw(scrypt_hash);
 use Data::Dumper qw(Dumper);
 use Scalar::Util qw(looks_like_number);
 use Getopt::Long;
@@ -212,6 +212,11 @@ sub generateCdnConf {
     InstallUtils::writePerl( $fileName, $cdnConf );
 }
 
+sub hash_pass {
+	my $pass = shift;
+	return scrypt_hash($pass, \64, 16384, 8, 1, 64);
+}
+
 # userInput: The entire input config file which is either user input or the defaults
 # fileName: The filename of the output config file
 #
@@ -242,7 +247,7 @@ sub generateUsersConf {
     my %config = getConfig( $userInput, $fileName );
 
     $user{username} = $config{tmAdminUser};
-    $user{password} = sha1_hex( $config{tmAdminPw} );
+    $user{password} = hash_pass( $config{tmAdminPw} );
 
     InstallUtils::writeJson( $fileName, \%user );
     $user{password} = $config{tmAdminPw};
@@ -540,13 +545,13 @@ QUERY
     invoke_db_admin_pl("seed");
 
     # Skip the insert if the admin 'username' is already there.
-    my $sha1_passwd = sha1_hex( $adminconf->{"password"} );
+    my $hashed_passwd = hash_pass( $adminconf->{"password"} );
     my $insert_admin = <<"ADMIN";
     insert into tm_user (username, role, local_passwd, confirm_local_passwd)
                 values  ('$adminconf->{"username"}',
                         (select id from role where name = 'admin'),
-                         '$sha1_passwd',
-                        '$sha1_passwd' )
+                         '$hashed_passwd',
+                        '$hashed_passwd' )
                         ON CONFLICT (username) DO NOTHING;
 ADMIN
     $dbh->do($insert_admin);


### PR DESCRIPTION
Note this is not a security vulnerability or mitigation in itself. In the event the database is compromised, it prevents an attacker from learning the users' passwords.

Which is the intention of hashing the passwords in the first place; but sha1 doesn't accomplish that. Nor does sha512, the problem isn't sha1's brokenness, it's that fast hashes aren't designed to solve this problem. The hash must be computationally slow ("slow" here means several milliseconds). Scrypt is a stretching hash, and solves the problem.