### PR TITLE
Add Golang log nil logger support, for performance

### DIFF
--- a/traffic_monitor_golang/common/log/log.go
+++ b/traffic_monitor_golang/common/log/log.go
@@ -41,11 +41,21 @@ var (
 )
 
 func initLogger(logger **log.Logger, oldLogCloser *io.Closer, newLogWriter io.WriteCloser, logPrefix string, logFlags int) {
+	if newLogWriter == nil {
+		*logger = nil
+		if *oldLogCloser != nil {
+			(*oldLogCloser).Close()
+			*oldLogCloser = nil
+		}
+		return
+	}
+
 	if *logger != nil {
 		(*logger).SetOutput(newLogWriter)
 	} else {
 		*logger = log.New(newLogWriter, logPrefix, logFlags)
 	}
+
 	if *oldLogCloser != nil {
 		(*oldLogCloser).Close()
 	}
@@ -65,32 +75,59 @@ const timeFormat = time.RFC3339Nano
 const stackFrame = 3
 
 func Errorf(format string, v ...interface{}) {
+	if Error == nil {
+		return
+	}
 	Error.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
 }
 func Errorln(v ...interface{}) {
+	if Error == nil {
+		return
+	}
 	Error.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
 }
 func Warnf(format string, v ...interface{}) {
+	if Warning == nil {
+		return
+	}
 	Warning.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
 }
 func Warnln(v ...interface{}) {
+	if Warning == nil {
+		return
+	}
 	Warning.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
 }
 func Infof(format string, v ...interface{}) {
+	if Info == nil {
+		return
+	}
 	Info.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
 }
 func Infoln(v ...interface{}) {
+	if Info == nil {
+		return
+	}
 	Info.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
 }
 func Debugf(format string, v ...interface{}) {
+	if Debug == nil {
+		return
+	}
 	Debug.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintf(format, v...))
 }
 func Debugln(v ...interface{}) {
+	if Debug == nil {
+		return
+	}
 	Debug.Output(stackFrame, time.Now().Format(timeFormat)+": "+fmt.Sprintln(v...))
 }
 
 // event log entries (TM event.log, TR access.log, etc)
 func Eventf(t time.Time, format string, v ...interface{}) {
+	if Event == nil {
+		return
+	}
 	// 1484001185.287 ...
 	Event.Printf("%.3f %s", float64(t.Unix())+(float64(t.Nanosecond())/1e9), fmt.Sprintf(format, v...))
 }

--- a/traffic_monitor_golang/common/log/log.go
+++ b/traffic_monitor_golang/common/log/log.go
@@ -23,7 +23,6 @@ package log
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -199,7 +198,9 @@ func GetLogWriter(location LogLocation) (io.WriteCloser, error) {
 	case LogLocationStderr:
 		return NopCloser(os.Stderr), nil
 	case LogLocationNull:
-		return NopCloser(ioutil.Discard), nil
+		fallthrough
+	case "":
+		return nil, nil
 	default:
 		return os.OpenFile(string(location), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	}

--- a/traffic_monitor_golang/traffic_monitor/manager/manager.go
+++ b/traffic_monitor_golang/traffic_monitor/manager/manager.go
@@ -184,19 +184,15 @@ func startMonitorConfigFilePoller(filename string) error {
 			log.Errorf("monitor config file poll, polling file '%v': %v", filename, err)
 			return
 		}
-
 		cfg, err := config.LoadBytes(bytes)
 		if err != nil {
 			log.Errorf("monitor config file poll, loading bytes '%v' from '%v': %v", string(bytes), filename, err)
 			return
 		}
-
-		eventW, errW, warnW, infoW, debugW, err := config.GetLogWriters(cfg)
-		if err != nil {
+		if err := log.InitCfg(cfg); err != nil {
 			log.Errorf("monitor config file poll, getting log writers '%v': %v", filename, err)
 			return
 		}
-		log.Init(eventW, errW, warnW, infoW, debugW)
 	}
 
 	bytes, err := ioutil.ReadFile(filename)

--- a/traffic_monitor_golang/traffic_monitor/traffic_monitor.go
+++ b/traffic_monitor_golang/traffic_monitor/traffic_monitor.go
@@ -63,12 +63,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	eventW, errW, warnW, infoW, debugW, err := config.GetLogWriters(cfg)
-	if err != nil {
+	if err := log.InitCfg(cfg); err != nil {
 		fmt.Printf("Error starting service: failed to create log writers: %v\n", err)
 		os.Exit(1)
 	}
-	log.Init(eventW, errW, warnW, infoW, debugW)
 
 	log.Infof("Starting with config %+v\n", cfg)
 


### PR DESCRIPTION
From profiling, the log `Format(timeFormat)` call is expensive, and
incurred even for null loggers. This allows applications to set null
loggers to be nil, instead of ioutil.Discard, for better performance.