### PR TITLE
Clean up regex used to scrub 'X-MoneyTrace'

### DIFF
--- a/traffic_ops/install/data/profiles/export_profiles.pl
+++ b/traffic_ops/install/data/profiles/export_profiles.pl
@@ -108,7 +108,7 @@ sub parameterInsert {
 
 sub scrub_value {
     my $value = shift;
-	$value =~ s/ xmt="%\<\{X-MoneyTrace\}cqh>"//g;
+	$value =~ s/ xmt="%<\{X-MoneyTrace\}cqh>"//g;
 	return $value;
 }
 


### PR DESCRIPTION
Un-escape the leading angle bracket so that it matches its corresponding
end bracket. Upon first look it seemed like the escaped bracket might've
caused an issue with the regex replacement, but the regex works the same
in both cases.