### PR TITLE
Fix parent.config generation so that unavailable_server_retry_responses is not empty.

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2020,7 +2020,11 @@ sub parent_dot_config {
 				$text .= "$parents round_robin=$mso_algorithm qstring=$parent_qstring go_direct=false parent_is_proxy=false";
 
 				if ( $ats_major_version >= 6 && $parent_retry ne "" ) {
-					$text .= " parent_retry=$parent_retry unavailable_server_retry_responses=$unavailable_server_retry_responses";
+					if ( $unavailable_server_retry_responses ne "") {
+						$text .= " parent_retry=$parent_retry unavailable_server_retry_responses=$unavailable_server_retry_responses";
+					} else {
+						$text .= " parent_retry=$parent_retry";
+					}
 					$text .= " max_simple_retries=$max_simple_retries max_unavailable_server_retries=$max_unavailable_server_retries";
 				}
 				$text .= "\n";

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -1183,7 +1183,11 @@ sub parent_dot_config {
 				$text .= "$parents round_robin=$mso_algorithm qstring=$parent_qstring go_direct=false parent_is_proxy=false";
 
 				if ( $ats_major_version >= 6 && $parent_retry ne "" ) {
-					$text .= " parent_retry=$parent_retry unavailable_server_retry_responses=$unavailable_server_retry_responses";
+					if ( $unavailable_server_retry_responses ne "") {
+						$text .= " parent_retry=$parent_retry unavailable_server_retry_responses=$unavailable_server_retry_responses";
+					} else {
+						$text .= " parent_retry=$parent_retry";
+					}
 					$text .= " max_simple_retries=$max_simple_retries max_unavailable_server_retries=$max_unavailable_server_retries";
 				}
 				$text .= "\n";


### PR DESCRIPTION
Currently the mid-tier parent.config is being generated with an empty unavailable_server_retry_responses parameter list causing ats to ignore ther line in parent.config where this is used.

This PR fixes parent.config generation so that the 'unavailable_server_retry_responses' config
parameter is not written with an empty list and is written only when there is a defined list of response codes.  Otherwise, this parameter is defaulted.