### PR TITLE
Change Traffic Ops `/update` to `priv > 10` to facilitate minimal syncds priveleges

### DIFF
--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -69,6 +69,7 @@ insert into role (name, description, priv_level) values ('steering', 'Role for S
 insert into role (name, description, priv_level) values ('read-only user', 'Read-Only user', 10) ON CONFLICT (name) DO NOTHING;
 insert into role (name, description, priv_level) values ('portal', 'Portal User', 2) ON CONFLICT (name) DO NOTHING;
 insert into role (name, description, priv_level) values ('disallowed', 'Block all access', 0) ON CONFLICT (name) DO NOTHING;
+insert into role (name, description, priv_level) values ('ort', 'ORT User', 11) ON CONFLICT (name) DO NOTHING;
 
 -- tenants
 insert into tenant (name, active, parent_id) values ('root', true, null) ON CONFLICT DO NOTHING;

--- a/traffic_ops/app/lib/UI/Server.pm
+++ b/traffic_ops/app/lib/UI/Server.pm
@@ -958,7 +958,9 @@ sub postupdate {
 	my $reval_updated = $self->param("reval_updated");
 	my $host_name = $self->param("host_name");
 
-	if ( !&is_admin($self) ) {
+	&stash_role($self);
+	# Intentionally <= 10 rather than < 20 to allow an ORT role with level 11 to post to this, but not other admin routes.
+	if ( $self->stash('priv_level') <= 10 ) {
 		$self->render( text => "Forbidden", status => 403, layout => undef );
 		return;
 	}


### PR DESCRIPTION
This specifically allows creating a role with privilege level between
10 and 20 (e.g. 11), for ORT/syncds, which can only access GET routes
plus POST /update in order to minimize access privileges.