### PR TITLE
adds data patch step to upgrade.pl

### DIFF
--- a/traffic_ops/app/db/admin.pl
+++ b/traffic_ops/app/db/admin.pl
@@ -62,13 +62,15 @@ my $usage = "\n"
 	. "dropdb  - Execute db 'dropdb' on the database for the current environment.\n"
 	. "down  - Roll back a single migration from the current version.\n"
 	. "drop_user  - Execute 'drop_user' the user for the current environment (traffic_ops).\n"
+	. "patch  - Execute sql from db/patches.sql for loading post-migration data patches.\n"; 
 	. "redo  - Roll back the most recently applied migration, then run it again.\n"
 	. "reset  - Execute db 'dropdb', 'createdb', load_schema, migrate on the database for the current environment.\n"
 	. "reverse_schema  - Reverse engineer the lib/Schema/Result files from the environment database.\n"
 	. "seed  - Execute sql from db/seeds.sql for loading static data.\n"
 	. "show_users  - Execute sql to show all of the user for the current environment.\n"
 	. "status  - Print the status of all migrations.\n"
-	. "upgrade  - Execute migrate then seed on the database for the current environment.\n";
+	. "upgrade  - Execute migrate, seed, and patches on the database for the current environment.\n";
+
 
 my $environment = 'development';
 my $db_protocol;
@@ -114,6 +116,7 @@ if ( defined($argument) ) {
 	elsif ( $argument eq 'upgrade' ) {
 		migrate('up');
 		seed();
+		patches();
 	}
 	elsif ( $argument eq 'migrate' ) {
 		migrate('up');
@@ -139,6 +142,8 @@ if ( defined($argument) ) {
 	elsif ( $argument eq 'reverse_schema' ) {
 		reverse_schema();
 	}
+	elsif ( $argument eq 'patch' ) {
+		patches();
 	else {
 		print $usage;
 	}
@@ -185,6 +190,13 @@ sub seed {
 	if ( system("psql -h $host_ip -p $host_port -d $db_name -U $db_user -e < db/seeds.sql") != 0 ) {
 		die "Can't seed database w/ required data\n";
 	}
+}
+
+sub patches {
+	print "Patching database with required data fixes.\n";
+	local $ENV{PGPASSWORD} = $db_password;
+	if ( system("psql -h $host_ip -p $host_port -d $db_name -U $db_user -e < db/patches.sql") != 0 ) {
+		die "Can't patch database w/ required data\n";
 }
 
 sub load_schema {

--- a/traffic_ops/app/db/patches.sql
+++ b/traffic_ops/app/db/patches.sql
@@ -1,0 +1,17 @@
+-- -- -- -- -- -- -- /*
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+
+-- THIS FILE INCLUDES POST-MIGRATION DATA FIXES REQUIRED OF TRAFFIC OPS


### PR DESCRIPTION
This adds a patches.sql execution step after migration and seeds, for cases where the upgrade requires data patches needing both the new data structure and seed data to be present.