### PR TITLE
[Backport TC-356] update .rat-excludes with dirs already vetted for license

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,4 +1,5 @@
 .*\.md(?:                            Markdown files aren't usually code. ){0}
+BUILD_NUMBER(?:                      This very short file doesn't support comments and doesn't constitute code. ){0}
 VERSION(?:                           This very short file doesn't support comments and doesn't constitute code. ){0}
 .*\.min\.css(?:                      minified files are generated files, more akin to compiled binaries. Their source bears the license. ){0}
 .*\.min\.js(?:                       minified files ){0}
@@ -49,3 +50,7 @@ sorttable\.js(?:                     X11. Properly documented in LICENSE ){0}
 select2\..*(?:                       MIT. Properly documented in LICENSE ){0}
 prettyprint\.js(?:                   BSD 2-clause. Properly documented in LICENSE ){0}
 seelog(?:                            BSD 3-clause. Properly documented in LICENSE ){0}
+loading.scss(?:                      MIT. Properly documented in LICENSE ){0}
+influxdb(?:                          MIT. Properly documented in LICENSE ){0}
+errors(?:                            BSD 2-clause. Properly documented in LICENTS ){0}
+net(?:                               Go BSD. Properly documented in LICENSE ){0}


### PR DESCRIPTION
(cherry picked from commit b0e72d1807a883524ded209b505761e788652770)