### PR TITLE
custom or no headers for take and bake files

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1011,6 +1011,9 @@ sub take_and_bake_server {
 		if ( $parameter eq "header" && $data->{$parameter} eq "none" ) {
 			$header = "";
 		}
+		elsif ( $parameter eq "header" ) {
+			$header = $data->{$parameter} . "\n";
+		}
 		else {
 			$text .= $data->{$parameter} . "\n";
 		}
@@ -1033,6 +1036,9 @@ sub take_and_bake_profile {
 	foreach my $parameter ( sort keys %{$data} ) {
 		if ( $parameter eq "header" && $data->{$parameter} eq "none" ) {
 			$header = "";
+		}
+		elsif ( $parameter eq "header" ) {
+			$header = $data->{$parameter} . "\n";
 		}
 		else {
 			$text .= $data->{$parameter} . "\n";

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1008,10 +1008,12 @@ sub take_and_bake_server {
 	my $header = $self->header_comment( $server_obj->host_name );
 	my $text;
 	foreach my $parameter ( sort keys %{$data} ) {
-		if ( $parameter eq "no_header" ) {
+		if ( $parameter eq "header" && $data->{$parameter} eq "none" ) {
 			$header = "";
 		}
-		$text .= $data->{$parameter} . "\n";
+		else {
+			$text .= $data->{$parameter} . "\n";
+		}
 	}
 
 	$text =~ s/\s*__RETURN__\s*/\n/g;
@@ -1029,10 +1031,12 @@ sub take_and_bake_profile {
 	my $header = $self->header_comment( $profile_obj->name );
 	my $text;
 	foreach my $parameter ( sort keys %{$data} ) {
-		if ( $parameter eq "no_header" ) {
+		if ( $parameter eq "header" && $data->{$parameter} eq "none" ) {
 			$header = "";
 		}
-		$text .= $data->{$parameter} . "\n";
+		else {
+			$text .= $data->{$parameter} . "\n";
+		}
 	}
 	
 	$text =~ s/\s*__RETURN__\s*/\n/g;

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1005,12 +1005,18 @@ sub take_and_bake_server {
 	my $filename   = shift;
 
 	my $data = $self->param_data( $server_obj, $filename );
-	my $text = $self->header_comment( $server_obj->host_name );
+	my $header = $self->header_comment( $server_obj->host_name );
+	my $text;
 	foreach my $parameter ( sort keys %{$data} ) {
+		if ( $parameter eq "no_header" ) {
+			$header = "";
+		}
 		$text .= $data->{$parameter} . "\n";
 	}
+
 	$text =~ s/\s*__RETURN__\s*/\n/g;
-	return $text;
+	my $response = $header . $text;
+	return $response;
 }
 
 #generates a generic config file based on a profile and parameters which match the supplied filename.
@@ -1020,12 +1026,18 @@ sub take_and_bake_profile {
 	my $filename    = shift;
 
 	my $data = $self->profile_param_data( $profile_obj->id, $filename );
-	my $text = $self->header_comment( $profile_obj->name );
+	my $header = $self->header_comment( $profile_obj->name );
+	my $text;
 	foreach my $parameter ( sort keys %{$data} ) {
+		if ( $parameter eq "no_header" ) {
+			$header = "";
+		}
 		$text .= $data->{$parameter} . "\n";
 	}
+	
 	$text =~ s/\s*__RETURN__\s*/\n/g;
-	return $text;
+	my $response = $header . $text;
+	return $response;
 }
 
 #generates a generic config file based on a profile and parameters which match the supplied filename.


### PR DESCRIPTION
Removes the header from take and bake files generated via parameter if a parameter for the config file is created with the name "header" and value of "none".  Setting this header to another value will result in that value being used for the header instead of the standard header.