### PR TITLE
[WIP] Adds cachekey plugin support to edges via remap.config

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1922,6 +1922,19 @@ sub format_parent_info {
 	return $text;
 }
 
+sub ats_ver {
+	my $self       = shift;
+	my $server_obj = shift;
+
+	my $ats_ver =
+		$self->db->resultset('ProfileParameter')
+		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server_obj->profile->id },
+		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
+	my $ats_major_version = substr( $ats_ver, 0, 1 );
+
+	return $ats_major_version;
+}
+
 sub parent_dot_config {
 	my $self       = shift;
 	my $server_obj = shift;
@@ -1929,11 +1942,7 @@ sub parent_dot_config {
 
 	my $server_type = $server_obj->type->name;
 
-	my $ats_ver =
-		$self->db->resultset('ProfileParameter')
-		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server_obj->profile->id },
-		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
-	my $ats_major_version = substr( $ats_ver, 0, 1 );
+	my $ats_major_version = $self->ats_ver( $server_obj );
 	my $parent_info;
 	my $text = $self->header_comment( $server_obj->host_name );
 	if ( !defined($data) ) {
@@ -2231,6 +2240,14 @@ sub build_remap_line {
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {
 		$text .= " \@plugin=cacheurl.so \@pparam=" . $remap->{cacheurl_file};
+	}
+
+	if ( defined( $remap->{'param'}->{'cachekey.config'} ) ) {
+		print STDERR Dumper($remap->{'param'}->{'cachekey.config'});
+		$text .= " \@plugin=cachekey.so";
+		foreach my $ck_entry ( keys %{ $remap->{'param'}->{'cachekey.config'} } ) {
+			$text .= " \@pparam=--" . $ck_entry . "=" . $remap->{'param'}->{'cachekey.config'}->{$ck_entry};
+		}
 	}
 
 	# Note: should use full path here?

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2243,7 +2243,6 @@ sub build_remap_line {
 	}
 
 	if ( defined( $remap->{'param'}->{'cachekey.config'} ) ) {
-		print STDERR Dumper($remap->{'param'}->{'cachekey.config'});
 		$text .= " \@plugin=cachekey.so";
 		foreach my $ck_entry ( keys %{ $remap->{'param'}->{'cachekey.config'} } ) {
 			$text .= " \@pparam=--" . $ck_entry . "=" . $remap->{'param'}->{'cachekey.config'}->{$ck_entry};


### PR DESCRIPTION
This makes use of the ds profiles to add cachekey support to the remap.config.

Parameters are named for the plugin parameter with a config file name of cachekey.config.  This creates entries in the remap.config as in the following example:

Parameter name - "ua-capture"
Parameter config file - "cachekey.config"
Parameter value - "(Mozilla\/[^\s]*).*"

Parameter name - "include-headers"
Parameter config file - "cachekey.config"
Parameter value - "H1,H2"

@plugin=cachekey.so @pparam=--ua-capture=(Mozilla\/[^\s]*).* @pparam=--include-headers=H1,H2