### PR TITLE
[TC-406] update ORT for kernel compatibility

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -302,7 +302,7 @@ sub revalidate_while_sleeping {
 
 sub os_version {
   my $release = "UNKNOWN";
-  if (`uname -r` =~ m/.+(el\d)(\.\w+)*\.x86_64/)  {
+  if (`uname -r` =~ m/.+(el\d)(?:\.\w+)*\.x86_64/)  {
     $release = uc $1;
   }
   exists $supported_el_release{$release} ? return $release

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -302,7 +302,7 @@ sub revalidate_while_sleeping {
 
 sub os_version {
   my $release = "UNKNOWN";
-  if (`uname -r` =~ m/.+(el\d)\.x86_64/)  {
+  if (`uname -r` =~ m/.+(el\d).*\.x86_64/)  {
     $release = uc $1;
   }
   exists $supported_el_release{$release} ? return $release

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -302,7 +302,7 @@ sub revalidate_while_sleeping {
 
 sub os_version {
   my $release = "UNKNOWN";
-  if (`uname -r` =~ m/.+(el\d).*\.x86_64/)  {
+  if (`uname -r` =~ m/.+(el\d)(\.\w+)*\.x86_64/)  {
     $release = uc $1;
   }
   exists $supported_el_release{$release} ? return $release


### PR DESCRIPTION
Updates ORT for compatibility with the 4.9 kernel, which adds a ".centos" after the el version.