### PR TITLE
Fix Traffic Monitor 2.x MonitorConfigPoller livelock

### DIFF
--- a/traffic_monitor_golang/traffic_monitor/version.go
+++ b/traffic_monitor_golang/traffic_monitor/version.go
@@ -20,4 +20,4 @@ package main
  */
 
 // Version is the current version of the app, in string form.
-var Version = "2.0.9"
+var Version = "2.0.10"


### PR DESCRIPTION
Fixes the MonitorConfigPoller for-select to be nonblocking, making
livelocks impossible.