### PR TITLE
[TC-414] docker-compose to run unit tests

### DIFF
--- a/traffic_ops/app/bin/tests/Dockerfile-unittest
+++ b/traffic_ops/app/bin/tests/Dockerfile-unittest
@@ -1,0 +1,66 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM centos:7
+MAINTAINER Dan Kirkwood <dangogh@apache.org>
+
+RUN yum -y install \
+        https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+
+RUN yum -y install \
+        cpanminus \
+        expat-devel \
+        gcc-c++ \
+        libcurl \
+        libcurl-devel \
+        libidn-devel \
+        libpcap-devel \
+        mkisofs \
+        nmap-ncat \
+        openssl-devel \
+        perl \
+        perl-App-cpanminus \
+        perl-DBD-Pg \
+        perl-DBI \
+        perl-Digest-SHA1 \
+        perl-JSON \
+        perl-TermReadKey \
+        perl-Test-CPAN-Meta \
+        perl-WWW-Curl \
+        perl-core \
+        perl-libwww-perl \
+        postgresql96 \
+        postgresql96-devel && \
+        yum clean all
+
+RUN curl -o - https://www.kernel.org/pub/software/scm/git/git-2.12.2.tar.gz | tar xzvf - -C /tmp && \
+        cd /tmp/git-2.12.2/ && \
+        make -i prefix=/usr install && \
+        rm -rf /tmp/git-2.12.2
+
+RUN cpanm -n Carton
+
+ADD install/bin/install_goose.sh /
+RUN /install_goose.sh
+
+ADD app /opt/traffic_ops/app
+WORKDIR /opt/traffic_ops/app
+RUN POSTGRES_HOME=/usr/pgsql-9.6 carton
+
+RUN rm -rf /root/.cpan*
+
+ADD app/bin/tests/runtests.sh /
+CMD [ "/runtests.sh", "/opt/traffic_ops/app/t", "test", "db", "5432" ]
+
+#
+# vi:syntax=Dockerfile

--- a/traffic_ops/app/bin/tests/docker-compose.yml
+++ b/traffic_ops/app/bin/tests/docker-compose.yml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+version: '2'
+
+volumes:
+  traffic_ops:
+
+services:
+  db:
+    image: postgres:9.6
+
+  unit:
+    build:
+      context: ../../..
+      dockerfile: app/bin/tests/Dockerfile-unittest
+    links:
+      - db
+    volumes:
+      - traffic_ops:/opt/traffic_ops

--- a/traffic_ops/app/bin/tests/runtests.sh
+++ b/traffic_ops/app/bin/tests/runtests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# set up db based on given conf file
+
+set -x
+testdir=$1
+dbenv=$2
+dbhost=$3
+dbport=${4:-5432}
+export PERL5LIB=/opt/traffic_ops/app/lib:/opt/traffic_ops/app/local/lib/perl5
+
+usage() {
+        echo "Usage: $(basename $0) <test dir> <dbenv> <host> <port>"
+        echo "  e.g. $(basename $0) ./t test db 5432"
+}
+
+finish() {
+        local st=$?
+        [[ $st -ne 0 ]] && echo "Exiting with status $st"
+        [[ -n $msg ]] && echo $msg
+}
+
+trap finish EXIT
+
+dbconf=/opt/traffic_ops/app/conf/$dbenv/database.conf
+if [[ ! -f $dbconf ]]; then
+        usage
+        msg="$dbconf should be a file"
+        exit 1
+fi
+
+if [[ ! -d $testdir ]]; then
+        usage
+        msg="$testdir should be a directory"
+        exit 1
+fi
+
+while ! nc $dbhost $dbport </dev/null; do # &>/dev/null; do
+        dig $dbhost +short
+        echo "waiting for $dbhost:$dbport"
+        sleep 3
+done
+
+# get dbname, user, password from database.conf;  update it with hostname of db container
+read dbname user pw <<<$(python -c "import json; d=json.load(open('$dbconf')); d['hostname']='$dbhost'; d['port']='$dbport'; json.dump(d, open('$dbconf', 'w')); print d['dbname'],d['user'],d['password']") || exit $?
+
+# update dbconf.yml
+sed -E -i "s/host=[^ ]+/host=$dbhost/" /opt/traffic_ops/app/db/dbconf.yml
+
+# create user if doesn't exist
+st=$(psql -h$dbhost -p$dbport -Upostgres -tAc "SELECT 1 from pg_roles WHERE rolname='$user'") || exit $?
+if [[ $st != 1 ]]; then
+        psql -h$dbhost -Upostgres -etAc "CREATE USER $user with LOGIN ENCRYPTED PASSWORD '$pw'" || exit $?
+fi
+
+
+st=$(psql -h$dbhost -p$dbport -Upostgres -tAc "SELECT 1 FROM pg_database WHERE datname='$dbname'") || exit $?
+if [[ $st != 1 ]]; then
+        createdb -h$dbhost -p$dbport -Upostgres -e --owner $user $dbname || exit $?
+fi
+
+cd /opt/traffic_ops/app
+export USER=root
+
+echo "/opt/traffic_ops/app/db/dbconf.yml"
+cat /opt/traffic_ops/app/db/dbconf.yml
+
+echo "/opt/traffic_ops/app/conf/$dbenv/database.conf"
+cat "/opt/traffic_ops/app/conf/$dbenv/database.conf"
+
+export GOROOT=/usr/local/go
+export GOPATH=/opt/traffic_ops/go
+PATH=$PATH:$GOPATH/bin:$GOROOT/bin
+
+export PGOPTIONS='--client-min-messages=warning'
+./db/admin.pl --env=test reset
+
+prove -qrp $testdir

--- a/traffic_ops/app/cpanfile
+++ b/traffic_ops/app/cpanfile
@@ -91,7 +91,7 @@ requires 'File::Spec::Functions';
 requires 'File::Temp';
 requires 'Getopt::Long';
 requires 'Getopt::Std';
-requires 'Google::ProtocolBuffers', '<= 0.11';
+requires 'Google::ProtocolBuffers';
 requires 'HTML::Entities';
 requires 'HTML::Parser';
 requires 'HTML::Tagset';


### PR DESCRIPTION
also removed restriction on Perl module Google::ProtocolBuffers in cpanfile.  The version restriction was for Centos 6.