### PR TITLE
[TC-416] tomcat init script fixes for traffic_router

### DIFF
--- a/traffic_router/core/src/main/etc/init.d/tomcat
+++ b/traffic_router/core/src/main/etc/init.d/tomcat
@@ -31,13 +31,18 @@
 
 . /etc/rc.d/init.d/functions
 
-export NAME=tomcat
-export TOMCAT_HOME=/opt/$NAME
-export CATALINA_PID=/var/run/tomcat/$NAME.pid
-export CATALINA_OPTS="-Xms512m -Xmx8192m -Dlog4j.configuration=file:///opt/traffic_router/conf/log4j.properties"
-export TOMCAT_LOCK=/var/lock/subsys/$NAME
+NAME=tomcat
+TOMCAT_HOME=/opt/$NAME
+CATALINA_PID=/var/run/tomcat/$NAME.pid
+TOMCAT_LOCK=/var/lock/subsys/$NAME
+CATALINA_OPTS="-Xms512m -Xmx8192m -Dlog4j.configuration=file:///opt/traffic_router/conf/log4j.properties"
+SHUTDOWN_TIMEOUT=10
+SHUTDOWN_FORCE=true
+
+export NAME TOMCAT_HOME CATALINA_PID TOMCAT_LOCK
 
 start() {
+    export CATALINA_OPTS
     runuser -s /bin/bash root -c "$TOMCAT_HOME/bin/startup.sh"
 	RETVAL=$?
 	echo -n "Starting $NAME"
@@ -52,7 +57,9 @@ start() {
 
 
 stop() {
-	$TOMCAT_HOME/bin/shutdown.sh
+	SHUTDOWN_OPTS="$SHUTDOWN_TIMEOUT"
+	[[ $SHUTDOWN_FORCE == "true" ]] && SHUTDOWN_OPTS="$SHUTDOWN_TIMEOUT -force"
+	$TOMCAT_HOME/bin/shutdown.sh $SHUTDOWN_OPTS
 	RETVAL=$?
 	echo -n "Stopping $NAME"
 	if [ $RETVAL = 0 ]; then
@@ -80,6 +87,7 @@ case "$1" in
 		fi 
 		;; 
 	force-stop)
+		# this is useless on el7, and of dubious usefulness on el6
 		stop
 		;; 
 	restart)


### PR DESCRIPTION
Improving the reliabitiy of STOPPING tomcat service.

1. Add following variables to init script:
SHUTDOWN_TIMEOUT (default 10 seconds)
SHUTDOWN_FORCE (default "true" - kill if the shutdown times out)

2. Only export $CATALINA_OPTS when needed (to start the server)
Tomcat control scripts do this fun thing where to stop the current
jvm, catalina *starts* a second jvm, which then tells the first
to stop. This is all well and good, except we really don't want
to start this second jvm with our custom $CATALINA_OPTS, especially
on servers under memory pressure!