### PR TITLE
make delivery service `MultiSiteOrigin` an `int`

### DIFF
--- a/traffic_ops/client/delivery_service_resources.go
+++ b/traffic_ops/client/delivery_service_resources.go
@@ -87,7 +87,7 @@ type DeliveryService struct {
 	RegexRemap           string                 `json:"regexRemap"`
 	CacheURL             string                 `json:"cacheurl"`
 	RemapText            string                 `json:"remapText"`
-	MultiSiteOrigin      bool                   `json:"multiSiteOrigin"`
+	MultiSiteOrigin      int                    `json:"multiSiteOrigin"`
 	DisplayName          string                 `json:"displayName"`
 	InitialDispersion    int                    `json:"initialDispersion"`
 	MatchList            []DeliveryServiceMatch `json:"matchList,omitempty"`

--- a/traffic_ops/client/fixtures/delivery_service.go
+++ b/traffic_ops/client/fixtures/delivery_service.go
@@ -43,7 +43,7 @@ func DeliveryServices() *client.GetDeliveryServiceResponse {
 				IPV6RoutingEnabled:   true,
 				RangeRequestHandling: 0,
 				TRResponseHeaders:    "Access-Control-Allow-Origin: *",
-				MultiSiteOrigin:      false,
+				MultiSiteOrigin:      1,
 				DisplayName:          "Testing",
 				InitialDispersion:    1,
 			},


### PR DESCRIPTION
According to [the docs](https://trafficcontrol.incubator.apache.org/docs/latest/development/traffic_ops_api/v12/deliveryservice.html),
a delivery service's `MultiSiteOrigin` is technically an `int` representing
a boolean value, where `1` represents "enabled" and `0` represents "disabled."