### PR TITLE
Remove unset profileId's from delivery service requests

### DIFF
--- a/traffic_ops/client/delivery_service_resources.go
+++ b/traffic_ops/client/delivery_service_resources.go
@@ -61,7 +61,7 @@ type DeliveryService struct {
 	OrgServerFQDN        string                 `json:"orgServerFqdn"`
 	TypeID               int                    `json:"typeId"`
 	Type                 string                 `json:"type"`
-	ProfileID            int                    `json:"profileId"`
+	ProfileID            int                    `json:"profileId,omitempty"`
 	ProfileName          string                 `json:"profileName"`
 	ProfileDesc          string                 `json:"profileDescription"`
 	CDNName              string                 `json:"cdnName"`


### PR DESCRIPTION
WHY:
`profileId`'s that are not set are being defaulted to `0`, which is an
invalid ID.