### PR TITLE
Add TenantID field to delivery service resoure

### DIFF
--- a/traffic_ops/client/delivery_service_resources.go
+++ b/traffic_ops/client/delivery_service_resources.go
@@ -83,6 +83,7 @@ type DeliveryService struct {
 	RangeRequestHandling int                    `json:"rangeRequestHandling"`
 	EdgeHeaderRewrite    string                 `json:"edgeHeaderRewrite"`
 	MidHeaderRewrite     string                 `json:"midHeaderRewrite"`
+	TenantID             int                    `json:"tenant_id"`
 	TRResponseHeaders    string                 `json:"trResponseHeaders"`
 	RegexRemap           string                 `json:"regexRemap"`
 	CacheURL             string                 `json:"cacheurl"`

--- a/traffic_ops/client/delivery_service_resources.go
+++ b/traffic_ops/client/delivery_service_resources.go
@@ -83,7 +83,7 @@ type DeliveryService struct {
 	RangeRequestHandling int                    `json:"rangeRequestHandling"`
 	EdgeHeaderRewrite    string                 `json:"edgeHeaderRewrite"`
 	MidHeaderRewrite     string                 `json:"midHeaderRewrite"`
-	TenantID             int                    `json:"tenant_id"`
+	TenantID             int                    `json:"tenant_id,omitempty"`
 	TRResponseHeaders    string                 `json:"trResponseHeaders"`
 	RegexRemap           string                 `json:"regexRemap"`
 	CacheURL             string                 `json:"cacheurl"`


### PR DESCRIPTION
WHY:
TenantID is now a field on delivery service as of this commit:
https://github.com/apache/incubator-trafficcontrol/commit/b34693ee9f9fd15104b8e461513b54bce78cbb21