### PR TITLE
[TC-454] Reduces remap and parent load times, sorts results

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -872,7 +872,7 @@ sub ds_data {
 	else {
 		$rs_dsinfo = $self->db->resultset('DeliveryServiceInfoForServerList')->search( {}, { bind => [ $server_obj->id ] } );
 	}
-
+	
 	my $j = 0;
 	while ( my $dsinfo = $rs_dsinfo->next ) {
 		my $org_fqdn                  	= $dsinfo->org_server_fqdn;
@@ -894,7 +894,7 @@ sub ds_data {
 		my $multi_site_origin           = $dsinfo->multi_site_origin;
 		my $multi_site_origin_algorithm = 0;
 
-		if ( $re_type eq 'HOST_REGEXP' ) {
+		if ( $re_type eq 'HOST_REGEXP' && defined($org_fqdn) ) {
 			my $host_re = $dsinfo->pattern;
 			my $map_to  = $org_fqdn . "/";
 			if ( $host_re =~ /\.\*$/ ) {
@@ -982,9 +982,229 @@ sub ds_data {
 
 		$j++;
 	}
-
+	
 	return $response_obj;
 }
+
+sub parent_ds_data {
+	my $self = shift;
+	my $server_obj = shift;
+	my $response_obj;
+
+	$response_obj->{host_name}   = $server_obj->host_name;
+	$response_obj->{domain_name} = $server_obj->domain_name;
+
+
+	if ( $server_obj->type->name =~ m/^MID/ ) {
+		# the mids will do all deliveryservices in this CDN
+		my $rs_dsinfo = $self->db->resultset('DeliveryServiceInfoForDomainList')->search( {}, { bind => [ $server_obj->cdn->name ] } );
+
+		my $j = 0;
+		while ( my $dsinfo = $rs_dsinfo->next ) {
+			my $org_fqdn                  	= $dsinfo->org_server_fqdn;
+			my $qstring_ignore              = $dsinfo->qstring_ignore;
+			my $ds_xml_id                   = $dsinfo->xml_id;
+			my $origin_shield               = $dsinfo->origin_shield;
+			my $multi_site_origin           = $dsinfo->multi_site_origin;
+			
+			$response_obj->{dslist}->[$j]->{"org"}                         = $org_fqdn;
+			$response_obj->{dslist}->[$j]->{"qstring_ignore"}              = $qstring_ignore;
+			$response_obj->{dslist}->[$j]->{"ds_xml_id"}                   = $ds_xml_id;
+			$response_obj->{dslist}->[$j]->{"origin_shield"}               = $origin_shield;
+			$response_obj->{dslist}->[$j]->{"multi_site_origin"}           = $multi_site_origin;
+			
+	
+			if ( defined( $dsinfo->profile ) ) {
+				my $dsparamrs = $self->db->resultset('ProfileParameter')->search( { profile => $dsinfo->profile }, { prefetch => [ 'profile', 'parameter' ] } );
+				while ( my $prow = $dsparamrs->next ) {
+					$response_obj->{dslist}->[$j]->{'param'}->{ $prow->parameter->config_file }->{ $prow->parameter->name } = $prow->parameter->value;
+				}
+			}
+
+			$j++;
+		}
+		return $response_obj;
+	}
+	else {
+		my $rs_dsinfo = $self->db->resultset('DeliveryServiceInfoForServerList')->search( {}, { bind => [ $server_obj->id ] } );
+		
+		my $j = 0;
+		while ( my $dsinfo = $rs_dsinfo->next ) {
+			my $org_fqdn                  	= $dsinfo->org_server_fqdn;
+			my $ds_type                     = $dsinfo->ds_type;
+			my $qstring_ignore              = $dsinfo->qstring_ignore;
+			my $ds_xml_id                   = $dsinfo->xml_id;
+			my $origin_shield               = $dsinfo->origin_shield;
+			my $multi_site_origin           = $dsinfo->multi_site_origin;
+			
+			$response_obj->{dslist}->[$j]->{"org"}                         = $org_fqdn;
+			$response_obj->{dslist}->[$j]->{"type"}                        = $ds_type;
+			$response_obj->{dslist}->[$j]->{"qstring_ignore"}              = $qstring_ignore;
+
+			if ( defined( $dsinfo->profile ) ) {
+				my $dsqstring = $self->db->resultset('ProfileParameter')
+				                ->search( { -and => [ 'parameter.config_file' => 'parent.config', 'parameter.name' => 'psel.qstring_handling', profile => $dsinfo->profile ] },
+				                { prefetch => [ 'parameter' ] } )->get_column('parameter.value')->single();
+				if ( defined $dsqstring ) {
+					$response_obj->{dslist}->[$j]->{'param'}->{'parent.config'}->{'psel.qstring_handling'} = $dsqstring;
+				}
+			}
+			$j++;
+		}
+		return $response_obj;
+	}
+}
+
+sub remap_ds_data {
+	my $self = shift;
+	my $server_obj = shift;
+	my $response_obj;
+
+	$response_obj->{host_name}   = $server_obj->host_name;
+	$response_obj->{domain_name} = $server_obj->domain_name;
+
+
+	if ( $server_obj->type->name =~ m/^MID/ ) {
+		# the mids will do all deliveryservices in this CDN
+		my $rs_dsinfo = $self->db->resultset('DeliveryServiceInfoForDomainList')->search( {}, { bind => [ $server_obj->cdn->name ] } );
+
+		my $j = 0;
+		while ( my $dsinfo = $rs_dsinfo->next ) {
+			my $org_fqdn                  	= $dsinfo->org_server_fqdn;
+			my $ds_type                     = $dsinfo->ds_type;
+			my $qstring_ignore              = $dsinfo->qstring_ignore;
+			my $ds_xml_id                   = $dsinfo->xml_id;
+			my $mid_header_rewrite          = $dsinfo->mid_header_rewrite;
+			my $range_request_handling      = $dsinfo->range_request_handling;
+			my $cacheurl                    = $dsinfo->cacheurl;
+			
+
+
+			$response_obj->{dslist}->[$j]->{"org"}                         = $org_fqdn;
+			$response_obj->{dslist}->[$j]->{"type"}                        = $ds_type;
+			$response_obj->{dslist}->[$j]->{"mid_header_rewrite"}          = $mid_header_rewrite;
+			$response_obj->{dslist}->[$j]->{"cacheurl"}                    = $cacheurl;
+			$response_obj->{dslist}->[$j]->{"qstring_ignore"}              = $qstring_ignore;
+			$response_obj->{dslist}->[$j]->{"range_request_handling"}      = $range_request_handling;
+		
+			if ( defined($mid_header_rewrite) ) {
+				my $fname = "hdr_rw_mid_" . $ds_xml_id . ".config";
+				$response_obj->{dslist}->[$j]->{"mid_hdr_rw_file"} = $fname;
+			}
+			if ( defined($cacheurl) ) {
+				my $fname = "cacheurl_" . $ds_xml_id . ".config";
+				$response_obj->{dslist}->[$j]->{"cacheurl_file"} = $fname;
+			}
+			if ( defined( $dsinfo->profile ) ) {
+				my $dsparamrs = $self->db->resultset('ProfileParameter')->search( { profile => $dsinfo->profile }, { prefetch => [ 'profile', 'parameter' ] } );
+				while ( my $prow = $dsparamrs->next ) {
+					$response_obj->{dslist}->[$j]->{'param'}->{ $prow->parameter->config_file }->{ $prow->parameter->name } = $prow->parameter->value;
+				}
+			}
+		
+			$j++;
+		}
+		return $response_obj;
+	}
+	else {
+		my $rs_dsinfo = $self->db->resultset('DeliveryServiceInfoForServerList')->search( {}, { bind => [ $server_obj->id ] } );
+		
+		my $j = 0;
+		while ( my $dsinfo = $rs_dsinfo->next ) {
+			my $org_fqdn                  	= $dsinfo->org_server_fqdn;
+			my $dscp                        = $dsinfo->dscp;
+			my $re_type                     = $dsinfo->re_type;
+			my $ds_type                     = $dsinfo->ds_type;
+			my $signed                      = $dsinfo->signed;
+			my $qstring_ignore              = $dsinfo->qstring_ignore;
+			my $ds_xml_id                   = $dsinfo->xml_id;
+			my $ds_domain                   = $dsinfo->domain_name;
+			my $edge_header_rewrite         = $dsinfo->edge_header_rewrite;
+			my $regex_remap                 = $dsinfo->regex_remap;
+			my $protocol                    = $dsinfo->protocol;
+			my $range_request_handling      = $dsinfo->range_request_handling;
+			my $cacheurl                    = $dsinfo->cacheurl;
+			my $remap_text                  = $dsinfo->remap_text;
+			
+			if ( $re_type eq 'HOST_REGEXP' && defined($org_fqdn) ) {
+				my $host_re = $dsinfo->pattern;
+				my $map_to  = $org_fqdn . "/";
+				if ( $host_re =~ /\.\*$/ ) {
+					my $re = $host_re;
+					$re =~ s/\\//g;
+					$re =~ s/\.\*//g;
+					my $hname = $ds_type =~ /^DNS/ ? "edge" : "ccr";
+					my $portstr = "";
+					if ( $hname eq "ccr" && $server_obj->tcp_port > 0 && $server_obj->tcp_port != 80 ) {
+						$portstr = ":" . $server_obj->tcp_port;
+					}
+					my $map_from = "http://" . $hname . $re . $ds_domain . $portstr . "/";
+					if ( $protocol == HTTP ) {
+						$response_obj->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
+					}
+					elsif ( $protocol == HTTPS || $protocol == HTTP_TO_HTTPS ) {
+						$map_from = "https://" . $hname . $re . $ds_domain . "/";
+						$response_obj->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
+					}
+					elsif ( $protocol == HTTP_AND_HTTPS ) {
+	
+						#add the first one with http
+						$response_obj->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
+	
+						#add the second one for https
+						my $map_from2 = "https://" . $hname . $re . $ds_domain . "/";
+						$response_obj->{dslist}->[$j]->{"remap_line2"}->{$map_from2} = $map_to;
+					}
+				}
+				else {
+					my $map_from = "http://" . $host_re . "/";
+					if ( $protocol == HTTP ) {
+						$response_obj->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
+					}
+					elsif ( $protocol == HTTPS || $protocol == HTTP_TO_HTTPS ) {
+						$map_from = "https://" . $host_re . "/";
+						$response_obj->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
+					}
+					elsif ( $protocol == HTTP_AND_HTTPS ) {
+	
+						#add the first with http
+						$response_obj->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
+	
+						#add the second with https
+						my $map_from2 = "https://" . $host_re . "/";
+						$response_obj->{dslist}->[$j]->{"remap_line2"}->{$map_from2} = $map_to;
+					}
+				}
+			}
+			$response_obj->{dslist}->[$j]->{"dscp"}                        = $dscp;
+			$response_obj->{dslist}->[$j]->{"org"}                         = $org_fqdn;
+			$response_obj->{dslist}->[$j]->{"type"}                        = $ds_type;
+			$response_obj->{dslist}->[$j]->{"signed"}                      = $signed;
+			$response_obj->{dslist}->[$j]->{"qstring_ignore"}              = $qstring_ignore;
+			$response_obj->{dslist}->[$j]->{"ds_xml_id"}                   = $ds_xml_id;
+			$response_obj->{dslist}->[$j]->{"edge_header_rewrite"}         = $edge_header_rewrite;
+			$response_obj->{dslist}->[$j]->{"regex_remap"}                 = $regex_remap;
+			$response_obj->{dslist}->[$j]->{"range_request_handling"}      = $range_request_handling;
+			$response_obj->{dslist}->[$j]->{"cacheurl"}                    = $cacheurl;
+			$response_obj->{dslist}->[$j]->{"remap_text"}                  = $remap_text;
+	
+			if ( defined($edge_header_rewrite) ) {
+				my $fname = "hdr_rw_" . $ds_xml_id . ".config";
+				$response_obj->{dslist}->[$j]->{"hdr_rw_file"} = $fname;
+			}
+			if ( defined($cacheurl) ) {
+				my $fname = "cacheurl_" . $ds_xml_id . ".config";
+				$response_obj->{dslist}->[$j]->{"cacheurl_file"} = $fname;
+			}
+	
+			$j++;
+		}
+		
+		return $response_obj;
+
+	}
+}
+
 
 #generates the 12m_facts file
 sub facts {
@@ -1005,23 +1225,12 @@ sub take_and_bake_server {
 	my $filename   = shift;
 
 	my $data = $self->param_data( $server_obj, $filename );
-	my $header = $self->header_comment( $server_obj->host_name );
-	my $text;
+	my $text = $self->header_comment( $server_obj->host_name );
 	foreach my $parameter ( sort keys %{$data} ) {
-		if ( $parameter eq "header" && $data->{$parameter} eq "none" ) {
-			$header = "";
-		}
-		elsif ( $parameter eq "header" ) {
-			$header = $data->{$parameter} . "\n";
-		}
-		else {
-			$text .= $data->{$parameter} . "\n";
-		}
+		$text .= $data->{$parameter} . "\n";
 	}
-
 	$text =~ s/\s*__RETURN__\s*/\n/g;
-	my $response = $header . $text;
-	return $response;
+	return $text;
 }
 
 #generates a generic config file based on a profile and parameters which match the supplied filename.
@@ -1031,23 +1240,12 @@ sub take_and_bake_profile {
 	my $filename    = shift;
 
 	my $data = $self->profile_param_data( $profile_obj->id, $filename );
-	my $header = $self->header_comment( $profile_obj->name );
-	my $text;
+	my $text = $self->header_comment( $profile_obj->name );
 	foreach my $parameter ( sort keys %{$data} ) {
-		if ( $parameter eq "header" && $data->{$parameter} eq "none" ) {
-			$header = "";
-		}
-		elsif ( $parameter eq "header" ) {
-			$header = $data->{$parameter} . "\n";
-		}
-		else {
-			$text .= $data->{$parameter} . "\n";
-		}
+		$text .= $data->{$parameter} . "\n";
 	}
-	
 	$text =~ s/\s*__RETURN__\s*/\n/g;
-	my $response = $header . $text;
-	return $response;
+	return $text;
 }
 
 #generates a generic config file based on a profile and parameters which match the supplied filename.
@@ -1946,35 +2144,29 @@ sub format_parent_info {
 	return $text;
 }
 
-sub ats_ver {
+sub parent_dot_config { #fix qstring - should be ignore for quika
 	my $self       = shift;
 	my $server_obj = shift;
+	my $data;
+	my $server_type = $server_obj->type->name;
 
 	my $ats_ver =
 		$self->db->resultset('ProfileParameter')
 		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server_obj->profile->id },
 		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
 	my $ats_major_version = substr( $ats_ver, 0, 1 );
-
-	return $ats_major_version;
-}
-
-sub parent_dot_config {
-	my $self       = shift;
-	my $server_obj = shift;
-	my $data;
-
-	my $server_type = $server_obj->type->name;
-
-	my $ats_major_version = $self->ats_ver( $server_obj );
 	my $parent_info;
-	my $text = $self->header_comment( $server_obj->host_name );
-	if ( !defined($data) ) {
-		$data = $self->ds_data($server_obj);
-	}
+	my $header = $self->header_comment( $server_obj->host_name );
+	my @text_array;
+
+	
 	if ( $server_type =~ m/^MID/ ) {
 		my @unique_origins;
-		foreach my $ds ( sort @{ $data->{dslist} } ) {
+		if ( !defined($data) ) {
+			$data = $self->parent_ds_data($server_obj);
+		}
+		foreach my $ds ( @{ $data->{dslist} } ) {
+			my $text;
 			my $xml_id                             = $ds->{ds_xml_id};
 			my $origin_shield                      = $ds->{origin_shield};
 			my $multi_site_origin                  = $ds->{multi_site_origin} || 0;
@@ -1984,7 +2176,7 @@ sub parent_dot_config {
 			my $max_simple_retries                 = $ds->{'param'}->{'parent.config'}->{'mso.max_simple_retries'} || 1;
 			my $max_unavailable_server_retries     = $ds->{'param'}->{'parent.config'}->{'mso.max_unavailable_server_retries'} || 1;
 
-			my $qsh            = $ds->{'param'}->{'parent.config'}->{'mso.qstring_handling'};
+			my $qsh            = $ds->{'param'}->{'parent.config'}->{'psel.qstring_handling'};
 			my $parent_qstring = "ignore";                                                      # default is ignore, unless for alg consistent_hash
 			if ( !defined($qsh) && $mso_algorithm eq 'consistent_hash' && $ds->{qstring_ignore} == 0 ) {
 				$parent_qstring = 'consider';
@@ -2059,19 +2251,55 @@ sub parent_dot_config {
 					$text .= " max_simple_retries=$max_simple_retries max_unavailable_server_retries=$max_unavailable_server_retries";
 				}
 				$text .= "\n";
+				push @text_array, $text;
 			}
 		}
-
+		
 		#$text .= "dest_domain=. go_direct=true\n"; # this is implicit.
 		#$self->app->log->debug( "MID PARENT.CONFIG:\n" . $text . "\n" );
+		my $text = $header;
+		foreach my $line (sort @text_array ){
+			$text .= $line;
+		}
+
 		return $text;
 	}
 	else {    #"True" Parent - we are genning a EDGE config that points to a parent proxy.
-
 		$parent_info = $self->parent_data($server_obj);
 		my %done = ();
+		my $qsh = $self->profile_param_value( $server_obj->profile->id, 'parent.config', 'psel.qstring_handling');
+		my @parent_info;
+		my @secondary_parent_info;
+		foreach my $parent ( @{ $parent_info->{all_parents} } ) {
+			my $ptxt = format_parent_info($parent);
+			if ( $parent->{primary_parent} ) {
+				push @parent_info, $ptxt;
+			}
+			elsif ( $parent->{secondary_parent} ) {
+				push @secondary_parent_info, $ptxt;
+			}
+		}
+		if ( scalar @parent_info == 0  ) {
+			@parent_info = @secondary_parent_info;
+			@secondary_parent_info = ();
+		}
+		my %seen;
+		@parent_info = grep { !$seen{$_}++ } @parent_info;
+		my $parents = 'parent="' . join( '', sort @parent_info ) . '"';
+		my $secparents = '';
+		if ( scalar @secondary_parent_info > 0 ) {
+			my %seen;
+			@secondary_parent_info = grep { !$seen{$_}++ } @secondary_parent_info;
+			$secparents = 'secondary_parent="' . join( '', sort @secondary_parent_info ) . '"';
+		}
+		my $round_robin = 'round_robin=consistent_hash';
+		my $go_direct   = 'go_direct=false';
 
+		if ( !defined($data) ) {
+			$data = $self->parent_ds_data($server_obj);
+		}
 		foreach my $ds ( sort @{ $data->{dslist} } ) {
+			my $text;
 			my $org = $ds->{org};
 			next if !defined $org || $org eq "";
 			next if $done{$org};
@@ -2082,44 +2310,19 @@ sub parent_dot_config {
 			else {
 				# check for profile psel.qstring_handling.  If this parameter is assigned to the server profile,
 				# then edges will use the qstring handling value specified in the parameter for all profiles.
-				my $qsh = $self->profile_param_value( $server_obj->profile->id, 'parent.config', 'psel.qstring_handling');
+				
 				# If there is no defined parameter in the profile, then check the delivery service profile.
 				# If psel.qstring_handling exists in the DS profile, then we use that value for the specified DS only.
 				# This is used only if not overridden by a server profile qstring handling parameter.
+				my $ds_qsh = $qsh;
 				if (!defined($qsh)) {
-					$qsh = $ds->{'param'}->{'parent.config'}->{'psel.qstring_handling'};
+					$ds_qsh = $ds->{'param'}->{'parent.config'}->{'psel.qstring_handling'};
 				}
-				my $parent_qstring = defined($qsh) ? $qsh : "ignore";
-				if ( $ds->{qstring_ignore} == 0 && !defined($qsh) ) {
+				my $parent_qstring = defined($ds_qsh) ? $ds_qsh : "ignore";
+				
+				if ( $ds->{qstring_ignore} == 0 && !defined($ds_qsh) ) {
 					$parent_qstring = "consider";
 				}
-
-				my @parent_info;
-				my @secondary_parent_info;
-				foreach my $parent ( @{ $parent_info->{all_parents} } ) {
-					my $ptxt = format_parent_info($parent);
-					if ( $parent->{primary_parent} ) {
-						push @parent_info, $ptxt;
-					}
-					elsif ( $parent->{secondary_parent} ) {
-						push @secondary_parent_info, $ptxt;
-					}
-				}
-				if ( scalar @parent_info == 0  ) {
-					@parent_info = @secondary_parent_info;
-					@secondary_parent_info = ();
-				}
-				my %seen;
-				@parent_info = grep { !$seen{$_}++ } @parent_info;
-				my $parents = 'parent="' . join( '', sort @parent_info ) . '"';
-				my $secparents = '';
-				if ( scalar @secondary_parent_info > 0 ) {
-					my %seen;
-					@secondary_parent_info = grep { !$seen{$_}++ } @secondary_parent_info;
-					$secparents = 'secondary_parent="' . join( '', sort @secondary_parent_info ) . '"';
-				}
-				my $round_robin = 'round_robin=consistent_hash';
-				my $go_direct   = 'go_direct=false';
 				$text
 					.= "dest_domain="
 					. $org_uri->host
@@ -2127,9 +2330,11 @@ sub parent_dot_config {
 					. $org_uri->port
 					. " $parents $secparents $round_robin $go_direct qstring=$parent_qstring\n";
 			}
+			push @text_array, $text;
 			$done{$org} = 1;
 		}
 
+		my $default_dest_text;
 		my $parent_select_alg = $self->profile_param_value( $server_obj->profile->id, 'parent.config', 'algorithm', undef );
 		if ( defined($parent_select_alg) && $parent_select_alg eq 'consistent_hash' ) {
 			my @parent_info;
@@ -2138,28 +2343,35 @@ sub parent_dot_config {
 			}
 			my %seen;
 			@parent_info = grep { !$seen{$_}++ } @parent_info;
-			$text .= "dest_domain=.";
-			$text .= " parent=\"" . join( '', sort @parent_info ) . "\"";
-			$text .= " round_robin=consistent_hash go_direct=false";
+			$default_dest_text .= "dest_domain=.";
+			$default_dest_text .= " parent=\"" . join( '', sort @parent_info ) . "\"";
+			$default_dest_text .= " round_robin=consistent_hash go_direct=false";
 		}
 		else {    # default to old situation.
-			$text .= "dest_domain=.";
+			$default_dest_text .= "dest_domain=.";
 			my @parent_info;
 			foreach my $parent ( @{ $parent_info->{"all_parents"} } ) {
 				push @parent_info, $parent->{"host_name"} . "." . $parent->{"domain_name"} . ":" . $parent->{"port"} . ";";
 			}
 			my %seen;
 			@parent_info = grep { !$seen{$_}++ } @parent_info;
-			$text .= " parent=\"" . join( '', sort @parent_info ) . "\"";
-			$text .= " round_robin=urlhash go_direct=false";
+			$default_dest_text .= " parent=\"" . join( '', sort @parent_info ) . "\"";
+			$default_dest_text .= " round_robin=urlhash go_direct=false";
 		}
 
 		my $qstring = $self->profile_param_value( $server_obj->profile->id, 'parent.config', 'qstring', undef );
 		if ( defined($qstring) ) {
-			$text .= " qstring=" . $qstring;
+			$default_dest_text .= " qstring=" . $qstring;
 		}
 
-		$text .= "\n";
+		$default_dest_text .= "\n";
+
+		my $text = $header;
+		foreach my $line (sort @text_array ){
+			$text .= $line;
+		}
+
+		$text .= $default_dest_text;
 		return $text;
 	}
 }
@@ -2168,13 +2380,14 @@ sub remap_dot_config {
 	my $self       = shift;
 	my $server_obj = shift;
 	my $data;
+	my @text_array;
 
+	
 	my $pdata = $self->param_data( $server_obj, 'package' );
-	my $text = $self->header_comment( $server_obj->host_name );
+	my $header = $self->header_comment( $server_obj->host_name );
 	if ( !defined($data) ) {
-		$data = $self->ds_data($server_obj);
+		$data = $self->remap_ds_data($server_obj);
 	}
-
 	if ( $server_obj->type->name =~ m/^MID/ ) {
 		my %mid_remap;
 		foreach my $ds ( @{ $data->{dslist} } ) {
@@ -2199,22 +2412,32 @@ sub remap_dot_config {
 			}
 		}
 		foreach my $key ( keys %mid_remap ) {
-			$text .= "map " . $key . " " . $key . $mid_remap{$key} . "\n";
+			my $remap_text .= "map " . $key . " " . $key . $mid_remap{$key} . "\n";
+			push @text_array, $remap_text;
 		}
-
+		my $text = $header;
+		foreach my $line (sort @text_array ){
+			$text .= $line;
+		}
 		return $text;
 	}
 
 	# mids don't get here.
 	foreach my $ds ( @{ $data->{dslist} } ) {
+		my $remap_text;
 		foreach my $map_from ( keys %{ $ds->{remap_line} } ) {
 			my $map_to = $ds->{remap_line}->{$map_from};
-			$text = $self->build_remap_line( $server_obj, $pdata, $text, $data, $ds, $map_from, $map_to );
+			$remap_text = $self->build_remap_line( $server_obj, $pdata, $remap_text, $ds, $map_from, $map_to );
 		}
 		foreach my $map_from ( keys %{ $ds->{remap_line2} } ) {
 			my $map_to = $ds->{remap_line2}->{$map_from};
-			$text = $self->build_remap_line( $server_obj, $pdata, $text, $data, $ds, $map_from, $map_to );
+			$remap_text = $self->build_remap_line( $server_obj, $pdata, $remap_text, $ds, $map_from, $map_to );
 		}
+		push @text_array, $remap_text;
+	}
+	my $text = $header;
+	foreach my $line (sort @text_array ){
+		$text .= $line;
 	}
 	return $text;
 }
@@ -2224,7 +2447,6 @@ sub build_remap_line {
 	my $server_obj 	= shift;
 	my $pdata       = shift;
 	my $text        = shift;
-	my $data        = shift;
 	my $remap       = shift;
 	my $map_from    = shift;
 	my $map_to      = shift;
@@ -2268,13 +2490,6 @@ sub build_remap_line {
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {
 		$text .= " \@plugin=cacheurl.so \@pparam=" . $remap->{cacheurl_file};
-	}
-
-	if ( defined( $remap->{'param'}->{'cachekey.config'} ) ) {
-		$text .= " \@plugin=cachekey.so";
-		foreach my $ck_entry ( keys %{ $remap->{'param'}->{'cachekey.config'} } ) {
-			$text .= " \@pparam=--" . $ck_entry . "=" . $remap->{'param'}->{'cachekey.config'}->{$ck_entry};
-		}
 	}
 
 	# Note: should use full path here?

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1225,12 +1225,22 @@ sub take_and_bake_server {
 	my $filename   = shift;
 
 	my $data = $self->param_data( $server_obj, $filename );
-	my $text = $self->header_comment( $server_obj->host_name );
+	my $header = $self->header_comment( $server_obj->host_name );
+	my $text;
 	foreach my $parameter ( sort keys %{$data} ) {
-		$text .= $data->{$parameter} . "\n";
+		if ( $parameter eq "header" && $data->{$parameter} eq "none" ) {
+			$header = "";
+		}
+		elsif ( $parameter eq "header" ) {
+			$header = $data->{$parameter} . "\n";
+		}
+		else {
+			$text .= $data->{$parameter} . "\n";
+		}
 	}
 	$text =~ s/\s*__RETURN__\s*/\n/g;
-	return $text;
+	my $response = $header . $text;
+	return $response;
 }
 
 #generates a generic config file based on a profile and parameters which match the supplied filename.
@@ -1240,12 +1250,22 @@ sub take_and_bake_profile {
 	my $filename    = shift;
 
 	my $data = $self->profile_param_data( $profile_obj->id, $filename );
-	my $text = $self->header_comment( $profile_obj->name );
+	my $header = $self->header_comment( $profile_obj->name );
+	my $text;
 	foreach my $parameter ( sort keys %{$data} ) {
-		$text .= $data->{$parameter} . "\n";
+		if ( $parameter eq "header" && $data->{$parameter} eq "none" ) {
+			$header = "";
+		}
+		elsif ( $parameter eq "header" ) {
+			$header = $data->{$parameter} . "\n";
+		}
+		else {
+			$text .= $data->{$parameter} . "\n";
+		}
 	}
 	$text =~ s/\s*__RETURN__\s*/\n/g;
-	return $text;
+	my $response = $header . $text;
+	return $response;
 }
 
 #generates a generic config file based on a profile and parameters which match the supplied filename.
@@ -2490,6 +2510,13 @@ sub build_remap_line {
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {
 		$text .= " \@plugin=cacheurl.so \@pparam=" . $remap->{cacheurl_file};
+	}
+
+	if ( defined( $remap->{'param'}->{'cachekey.config'} ) ) {		
+		$text .= " \@plugin=cachekey.so";		
+		foreach my $ck_entry ( keys %{ $remap->{'param'}->{'cachekey.config'} } ) {		
+			$text .= " \@pparam=--" . $ck_entry . "=" . $remap->{'param'}->{'cachekey.config'}->{$ck_entry};		
+		}		
 	}
 
 	# Note: should use full path here?


### PR DESCRIPTION
This PR does some final cleanup to the config files API before branching for 2.1.  The following has been changed in this PR:

1) Increased efficiency of parent and remap config file generation by around 40-50%.
2) Added sorting of result text for parent and remap config files, ensuring consistent sorting so that they are not marked as changed by ORT from one run to the next.  Also improves manual search-ability.
3) Adds a filter to ensure that steering delivery services, which are missing an org_fqdn entry, are not included when processing delivery services.