### PR TITLE
allow unit/integration tests to continue if cleanup in docker fails

### DIFF
--- a/traffic_ops/app/bin/tests/Dockerfile-test
+++ b/traffic_ops/app/bin/tests/Dockerfile-test
@@ -52,7 +52,8 @@ ADD app /opt/traffic_ops/app
 WORKDIR /opt/traffic_ops/app
 RUN POSTGRES_HOME=/usr/pgsql-9.6 carton
 
-RUN rm -rf /root/.cpan*
+# ignore this if it fails
+RUN rm -rf /root/.cpan* 2>/dev/null || true
 
 ADD app/bin/tests/runtests.sh /
 ARG TESTDIR


### PR DESCRIPTION
cleanup of /root/.cpan* fails sometimes, but should not keep process from continuing.