### PR TITLE
Tenant parent - on delete cascade

### DIFF
--- a/traffic_ops/app/db/migrations/20173107000000_parent_tenant_delete_cascade.sql
+++ b/traffic_ops/app/db/migrations/20173107000000_parent_tenant_delete_cascade.sql
@@ -1,0 +1,27 @@
+/*
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+-- Tenant table: Add "ON DELETE CASCADE" for parent tenant
+ALTER TABLE tenant DROP CONSTRAINT fk_parentid;
+ALTER TABLE tenant ADD CONSTRAINT fk_parentid FOREIGN KEY (parent_id) REFERENCES tenant(id) ON DELETE CASCADE;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE tenant DROP CONSTRAINT fk_parentid;
+ALTER TABLE tenant ADD CONSTRAINT fk_parentid FOREIGN KEY (parent_id) REFERENCES tenant(id);


### PR DESCRIPTION
WIP: need to verify this is the right thing to do
On tenant  deletion, the child tenant are deleted automatically (via the DB).
Note that we block tenant deletion by the API when it has a child tenants.