### PR TITLE
Fix TO ORT for missing Content-Length, per RFC

### DIFF
--- a/traffic_ops/app/lib/TrafficOps.pm
+++ b/traffic_ops/app/lib/TrafficOps.pm
@@ -48,6 +48,7 @@ use Utils::Helper::TrafficOpsRoutesLoader;
 use File::Path qw(make_path);
 use IO::Compress::Gzip 'gzip';
 use IO::Socket::SSL;
+use Digest::SHA qw(sha512_base64);
 
 use Utils::Helper::Version;
 
@@ -170,6 +171,8 @@ sub startup {
 	$self->hook(
 		after_render => sub {
 			my ( $c, $output, $format ) = @_;
+
+			$c->res->headers->header('Whole-Content-SHA512' => sha512_base64($$output) . '==');
 
 			# Check if user agent accepts gzip compression
 			return unless ( $c->req->headers->accept_encoding // '' ) =~ /gzip/i;

--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1623,9 +1623,7 @@ sub check_lwp_response_content_length {
 	my $url           = $lwp_response->request->uri;
 
 	if ( !defined($lwp_response->header('Content-Length')) ) {
-		( $log_level >> $panic_level ) && print $log_level_str . " $url did not return a Content-Length header!\n";
-		exit;
-		return 1;
+		return 0; # Content-Length MAY be omitted per HTTP/1.1 RFC 7230, and in fact MUST NOT be included with a 'Transfer-Encoding: Chunked' header, which MUST be accepted by clients.
 	}
 	elsif ( $lwp_response->header('Content-Length') != length($lwp_response->content()) ) {
 		( $log_level >> $panic_level ) && print $log_level_str . " $url returned a Content-Length of " . $lwp_response->header('Content-Length') . ", however actual content length is " . length($lwp_response->content()) . "!\n";

--- a/traffic_ops/build/traffic_ops_ort.spec
+++ b/traffic_ops/build/traffic_ops_ort.spec
@@ -26,8 +26,8 @@ Source0:	traffic_ops_ort-%{version}.tgz
 URL:		https://github.com/apache/incubator-trafficcontrol/
 Vendor:		Apache Software Foundation
 Packager:	daniel_kirkwood at Cable dot Comcast dot com
-%{?el6:Requires: perl-JSON, perl-libwww-perl, perl-Crypt-SSLeay}
-%{?el7:Requires: perl-JSON, perl-libwww-perl, perl-Crypt-SSLeay, perl-LWP-Protocol-https}
+%{?el6:Requires: perl-JSON, perl-libwww-perl, perl-Crypt-SSLeay, perl-Digest-SHA}
+%{?el7:Requires: perl-JSON, perl-libwww-perl, perl-Crypt-SSLeay, perl-LWP-Protocol-https, perl-Digest-SHA}
 
 
 %description


### PR DESCRIPTION
Content-Length MAY be omitted per HTTP/1.1 RFC 7230, and in fact MUST
NOT be included with a 'Transfer-Encoding: Chunked' header, which MUST
be accepted by clients.

Fixes TC-503