### PR TITLE
adds docs/ prefix to hrefs on versions; use master for latest

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,3 +1,19 @@
+{#
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#}
+
 {# TEMPLATE VAR SETTINGS #}
 {%- set url_root = pathto('', 1) %}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}

--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,3 +1,19 @@
+{#
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#}
+
 {# Add rst-badge after rst-versions for small badge style. #}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">

--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -8,10 +8,10 @@
     <div class="rst-other-versions">
       <dl>
         <dt>Versions</dt>
-        <dd><a href="/latest/">latest</a></dd>
-        <dd><a href="/2.0.x/">2.0.x</a></dd>
-        <dd><a href="/1.8.x/">1.8.x</a></dd>
-        <dd><a href="/1.7.x/">1.7.x</a></dd>
+        <dd><a href="/docs/master/">latest</a></dd>
+        <dd><a href="/docs/2.0/">2.0</a></dd>
+        <dd><a href="/docs/1.8.1/">1.8</a></dd>
+        <dd><a href="/docs/1.7.0/">1.7</a></dd>
       </dl>
       <hr/>
       Free document hosting provided by <a href="http://www.readthedocs.org">Read the Docs</a>.


### PR DESCRIPTION
previous PR got the links wrong..   This fixes that issue and uses the "master" dir for "latest"