### PR TITLE
exclude traffic_ops_golang vendor dependency in rat report

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -50,7 +50,8 @@ select2\..*(?:                       MIT. Properly documented in LICENSE ){0}
 prettyprint\.js(?:                   BSD 2-clause. Properly documented in LICENSE ){0}
 seelog(?:                            BSD 3-clause. Properly documented in LICENSE ){0}
 loading.scss(?:                      MIT. Properly documented in LICENSE ){0}
-theme.scss(?:                      MIT. Properly documented in LICENSE ){0}
+theme.scss(?:                        MIT. Properly documented in LICENSE ){0}
 influxdb(?:                          MIT. Properly documented in LICENSE ){0}
 errors(?:                            BSD 2-clause. Properly documented in LICENTS ){0}
 net(?:                               Go BSD. Properly documented in LICENSE ){0}
+go-sqlmock(?:                        BSD 3-clause. Properly documented in LICENSE ){0}


### PR DESCRIPTION
rat report shows go-sqlmock is not properly licensed,  but it is documented in the LICENSE file.  Adds to .rat-excludes so rat won't report it.

@rob05c -- your first merge?