### PR TITLE
Automatic License Checking with Weasel

### DIFF
--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -76,3 +76,9 @@ services:
       context: ../../..
     volumes:
       - ../../..:/trafficcontrol:z
+
+  weasel:
+    image: licenseweasel/weasel:0.1
+    volumes:
+      - ../../..:/trafficcontrol:z
+    command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']


### PR DESCRIPTION
As we discussed in #289 , this isn't really the right place for a general-purpose license verification tool to live. I've found a new home for it over at https://github.com/Comcast/weasel and just vendored it here.

I added a docker task for it that should run fine with `pkg`. It outputs to `dist/weasel.txt`, so we can figure out what failed if we miss a license somewhere.

I also fixed some license issues we had hanging around, so that I wouldn't break the build.