### PR TITLE
[BACKPORT] [TC-521] TPv2 - accounts for missing dependency that centos 7.3 doesn't provide

### DIFF
--- a/infrastructure/docker/build/Dockerfile-traffic_portal
+++ b/infrastructure/docker/build/Dockerfile-traffic_portal
@@ -30,7 +30,8 @@ RUN	yum -y install \
 	yum -y clean all
 
 # traffic_portal specific
-RUN	yum -y install \
+RUN	rpm -ivh https://kojipkgs.fedoraproject.org//packages/http-parser/2.7.1/3.el7/x86_64/http-parser-2.7.1-3.el7.x86_64.rpm && \
+	yum -y install \
 		gcc \
 		libffi-devel \
 		make \


### PR DESCRIPTION
… when centos 7.4 is available this dependency will be provided with the distro.

(cherry picked from commit 15901255c1847800bbd871e33c757017ec23f74f)