### PR TITLE
[TC-374] handle orphan processes in TO init.d

### DIFF
--- a/traffic_ops/etc/init.d/traffic_ops
+++ b/traffic_ops/etc/init.d/traffic_ops
@@ -49,9 +49,10 @@ stopHypnotoad ()
 	echo -e "Shutting down Traffic Ops\n"
 	if [ -e $PIDFILE ]; then
 		_PID=`/bin/cat $PIDFILE`
-		PID=`/bin/ps -ef|/bin/awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'`
-		if [[ ! -z $PID && $_PID = $PID ]]; then
-			kill -term $PID
+		PIDS=( `/bin/ps -ef | /bin/awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'` )
+		# Check if original is in pidfile,  but kill any orphans, too..
+		if [[ " ${PIDS[@]} " =~ " $PID " ]]; then
+			kill -term "${PIDS[@]}"
 		fi
 	fi
 }


### PR DESCRIPTION
allows stop and/or restart of TO in case of orphaned workers.

To test,  find a worker process (`ps -ef | grep /opt/traffic_ops/app/scripts/cdn`) and kill with a HUP signal:   `kill -HUP 5432`

You should see a new process with a parent of 1:

```
$ ps -ef | awk '/^trafops/&&/\/script\/cdn/ { if ($3 == 1) {print} }'
trafops  29881     1  0 18:05 ?        00:00:00 /opt/traffic_ops/app/script/cdn```
```

Restart:
```sudo systemctl restart traffic_ops```

The only `/script/cdn` process with a parent of 1 should be owned by `root` and should be the one in the `/var/run/traffic_ops.pid` file.