### PR TITLE
Fix TO Go monitoring numeric values

### DIFF
--- a/traffic_ops/traffic_ops_golang/monitoring.go
+++ b/traffic_ops/traffic_ops_golang/monitoring.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/lib/pq"
@@ -74,18 +75,18 @@ type Coordinates struct {
 }
 
 type Profile struct {
-	Name       string            `json:"name"`
-	Type       string            `json:"type"`
-	Parameters map[string]string `json:"parameters"`
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Parameters map[string]interface{} `json:"parameters"`
 }
 
 type Monitoring struct {
-	TrafficServers   []Cache           `json:"trafficServers"`
-	TrafficMonitors  []Monitor         `json:"trafficMonitors"`
-	Cachegroups      []Cachegroup      `json:"cacheGroups"`
-	Profiles         []Profile         `json:"profiles"`
-	DeliveryServices []DeliveryService `json:"deliveryServices"`
-	Config           map[string]string `json:"config"`
+	TrafficServers   []Cache                `json:"trafficServers"`
+	TrafficMonitors  []Monitor              `json:"trafficMonitors"`
+	Cachegroups      []Cachegroup           `json:"cacheGroups"`
+	Profiles         []Profile              `json:"profiles"`
+	DeliveryServices []DeliveryService      `json:"deliveryServices"`
+	Config           map[string]interface{} `json:"config"`
 }
 
 type MonitoringResponse struct {
@@ -300,9 +301,14 @@ WHERE pr.config_file = $2;
 		}
 		profile := profiles[profileName.String]
 		if profile.Parameters == nil {
-			profile.Parameters = map[string]string{}
+			profile.Parameters = map[string]interface{}{}
 		}
-		profile.Parameters[name.String] = value.String
+
+		if valNum, err := strconv.Atoi(value.String); err == nil {
+			profile.Parameters[name.String] = valNum
+		} else {
+			profile.Parameters[name.String] = value.String
+		}
 		profiles[profileName.String] = profile
 
 	}
@@ -352,7 +358,7 @@ AND ds.active = true
 	return dses, nil
 }
 
-func getConfig(db *sql.DB) (map[string]string, error) {
+func getConfig(db *sql.DB) (map[string]interface{}, error) {
 	// TODO remove 'like' in query? Slow?
 	query := fmt.Sprintf(`
 SELECT pr.name, pr.value
@@ -368,7 +374,7 @@ WHERE pr.config_file = '%s'
 	}
 	defer rows.Close()
 
-	cfg := map[string]string{}
+	cfg := map[string]interface{}{}
 
 	for rows.Next() {
 		var name sql.NullString
@@ -376,7 +382,11 @@ WHERE pr.config_file = '%s'
 		if err := rows.Scan(&name, &val); err != nil {
 			return nil, err
 		}
-		cfg[name.String] = val.String
+		if valNum, err := strconv.Atoi(val.String); err == nil {
+			cfg[name.String] = valNum
+		} else {
+			cfg[name.String] = val.String
+		}
 	}
 	return cfg, nil
 }

--- a/traffic_ops/traffic_ops_golang/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring_test.go
@@ -269,7 +269,7 @@ func TestGetProfiles(t *testing.T) {
 		Profile{
 			Name: router.Profile,
 			Type: RouterType,
-			Parameters: map[string]string{
+			Parameters: map[string]interface{}{
 				"param0": "param0Val",
 				"param1": "param1Val",
 			},
@@ -277,7 +277,7 @@ func TestGetProfiles(t *testing.T) {
 		Profile{
 			Name: cache.Profile,
 			Type: "myType2",
-			Parameters: map[string]string{
+			Parameters: map[string]interface{}{
 				"2param0": "2param0Val",
 				"2param1": "2param1Val",
 			},
@@ -389,7 +389,7 @@ func TestGetConfig(t *testing.T) {
 	}
 	defer db.Close()
 
-	config := map[string]string{
+	config := map[string]interface{}{
 		"name0": "val0",
 		"name1": "val1",
 	}
@@ -519,7 +519,7 @@ func TestGetMonitoringJson(t *testing.T) {
 			Profile{
 				Name: router.Profile,
 				Type: RouterType,
-				Parameters: map[string]string{
+				Parameters: map[string]interface{}{
 					"param0": "param0Val",
 					"param1": "param1Val",
 				},
@@ -527,7 +527,7 @@ func TestGetMonitoringJson(t *testing.T) {
 			Profile{
 				Name: cache.Profile,
 				Type: "EDGE",
-				Parameters: map[string]string{
+				Parameters: map[string]interface{}{
 					"2param0": "2param0Val",
 					"2param1": "2param1Val",
 				},
@@ -582,7 +582,7 @@ func TestGetMonitoringJson(t *testing.T) {
 		//
 		// getConfig
 		//
-		config := map[string]string{
+		config := map[string]interface{}{
 			"name0": "val0",
 			"name1": "val1",
 		}


### PR DESCRIPTION
Perl TO monitoring.json returns numeric types for parameters whose strings successfully convert to integers. This replicates that behavior.