### PR TITLE
Add TM log EventRaw, for performance.

### DIFF
--- a/traffic_monitor_golang/common/log/log.go
+++ b/traffic_monitor_golang/common/log/log.go
@@ -138,6 +138,14 @@ func EventfRaw(format string, v ...interface{}) {
 	Event.Printf(format, v...)
 }
 
+// EventRaw writes to the event log with no prefix, and no newline. Go's Printf is slow, using this with string concatenation is by far the fastest way to log, and should be used for frequent logs.
+func EventRaw(s string) {
+	if Event == nil {
+		return
+	}
+	Event.Output(stackFrame, s)
+}
+
 // Close calls `Close()` on the given Closer, and logs any error. On error, the context is logged, followed by a colon, the error message, and a newline. This is primarily designed to be used in `defer`, for example, `defer log.Close(resp.Body, "readData fetching /foo/bar")`.
 func Close(c io.Closer, context string) {
 	err := c.Close()


### PR DESCRIPTION
Not using Printf is drastically faster for frequent logs, like Events.