### PR TITLE
[TC-545] --DO NOT MERGE-- only return edge types specifically

### DIFF
--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -242,6 +242,7 @@ sub gen_crconfig_json {
 
             if ( !exists $cache_tracker{ $row->id } ) {
                 $cache_tracker{ $row->id } = $row->host_name;
+                $cache_tracker{ type }{ $row->id } = $row->type->name;
             }
 
             my $pid = $row->profile->id;
@@ -349,7 +350,7 @@ sub gen_crconfig_json {
             }
             foreach my $server ( keys %server_subrow_dedup ) {
 
-                next if ( !defined( $cache_tracker{$server} ) );
+                next if ( !defined( $cache_tracker{$server} ) || $cache_tracker{type}{$server} ne 'EDGE' );
 
                 foreach my $host ( @{ $ds_to_remap{ $row->xml_id } } ) {
                     my $remap;

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -241,8 +241,10 @@ sub gen_crconfig_json {
             }
 
             if ( !exists $cache_tracker{ $row->id } ) {
-                $cache_tracker{ $row->id } = $row->host_name;
-                $cache_tracker{ type }{ $row->id } = $row->type->name;
+                $cache_tracker{$row->id} = {
+                    name => $row->host_name,
+                    type  => $row->type->name,
+                }
             }
 
             my $pid = $row->profile->id;
@@ -350,7 +352,7 @@ sub gen_crconfig_json {
             }
             foreach my $server ( keys %server_subrow_dedup ) {
 
-                next if ( !defined( $cache_tracker{$server} ) || $cache_tracker{type}{$server} ne 'EDGE' );
+                next if ( !defined( $cache_tracker{$server}{name} ) || $cache_tracker{$server}{type} ne 'EDGE' );
 
                 foreach my $host ( @{ $ds_to_remap{ $row->xml_id } } ) {
                     my $remap;
@@ -361,13 +363,13 @@ sub gen_crconfig_json {
                             $remap = 'edge' . $host_copy . $ccr_domain_name;
                         }
                         else {
-                            $remap = $cache_tracker{$server} . $host_copy . $ccr_domain_name;
+                            $remap = $cache_tracker{$server}{name} . $host_copy . $ccr_domain_name;
                         }
                     }
                     else {
                         $remap = $host;
                     }
-                    push( @{ $data_obj->{'contentServers'}->{ $cache_tracker{$server} }->{'deliveryServices'}->{ $row->xml_id } }, $remap );
+                    push( @{ $data_obj->{'contentServers'}->{ $cache_tracker{$server}{name} }->{'deliveryServices'}->{ $row->xml_id } }, $remap );
                 }
             }
         }


### PR DESCRIPTION
This modifies the CRConfig search to only search for hosts of type edge and mid, rather than hosts of types whose names start with edge and mid.  This will filter out other types of edges from the results and prevent routing to those other types.