### PR TITLE
[BACKPORT][TC-549] adds perl-Crypt-ScryptKDF to traffic_ops rpm deps

### DIFF
--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -36,7 +36,7 @@ Requires:         cpanminus, expat-devel, gcc-c++, libcurl, libpcap-devel, mkiso
 Requires:         openssl-devel, perl, perl-core, perl-DBD-Pg, perl-DBI, perl-Digest-SHA1
 Requires:         libidn-devel, libcurl-devel
 Requires:         postgresql96 >= 9.6.2 , postgresql96-devel >= 9.6.2
-Requires:         perl-JSON, perl-libwww-perl, perl-Test-CPAN-Meta, perl-WWW-Curl, perl-TermReadKey
+Requires:         perl-JSON, perl-libwww-perl, perl-Test-CPAN-Meta, perl-WWW-Curl, perl-TermReadKey, perl-Crypt-ScryptKDF
 Requires(pre):    /usr/sbin/useradd, /usr/bin/getent
 Requires(postun): /usr/sbin/userdel
 


### PR DESCRIPTION
 so postinstall wil run

(cherry picked from commit 3737bb1429cfadea51ef6f28a6098eb08c29a8df)