### PR TITLE
license updates

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -54,4 +54,4 @@ theme.scss(?:                        MIT. Properly documented in LICENSE ){0}
 influxdb(?:                          MIT. Properly documented in LICENSE ){0}
 errors(?:                            BSD 2-clause. Properly documented in LICENTS ){0}
 net(?:                               Go BSD. Properly documented in LICENSE ){0}
-go-sqlmock(?:                        BSD 3-clause. Properly documented in LICENSE ){0}
+go-sqlmock.v1(?:                     BSD 3-clause. Properly documented in LICENSE ){0}

--- a/traffic_portal/app/src/modules/private/tools/iso/iso.tpl.html
+++ b/traffic_portal/app/src/modules/private/tools/iso/iso.tpl.html
@@ -1,0 +1,19 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+

--- a/traffic_portal/app/src/modules/private/tools/iso/isoCtlr.js
+++ b/traffic_portal/app/src/modules/private/tools/iso/isoCtlr.js
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+


### PR DESCRIPTION
fixed gosqlmock path in .rat-excludes
added license missing in traffic_portal files