### PR TITLE
[BACKPORT] Fix typo in Traffic Ops init script to stop properly

### DIFF
--- a/traffic_ops/etc/init.d/traffic_ops
+++ b/traffic_ops/etc/init.d/traffic_ops
@@ -51,7 +51,7 @@ stopHypnotoad ()
 		_PID=`/bin/cat $PIDFILE`
 		PIDS=( `/bin/ps -ef | /bin/awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'` )
 		# Check if original is in pidfile,  but kill any orphans, too..
-		if [[ " ${PIDS[@]} " =~ " $PID " ]]; then
+		if [[ " ${PIDS[@]} " =~ " $_PID " ]]; then
 			kill -term "${PIDS[@]}"
 		fi
 	fi


### PR DESCRIPTION
(cherry picked from commit b6d08ceb551b401ebcd89b1504a4cedf79bd4ad1)