### PR TITLE
remove postinstall from update instructions; update cdn.conf

### DIFF
--- a/traffic_ops/app/conf/cdn.conf
+++ b/traffic_ops/app/conf/cdn.conf
@@ -1,14 +1,16 @@
 {
 	hypnotoad => {
 		listen => [
-			'https://[::]:443?cert=/etc/pki/tls/certs/localhost.crt&key=/etc/pki/tls/private/localhost.key&verify=0x00&ciphers=AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH:!ED'
+		        # Traffic Ops is proxied to port 60443 by the traffic_ops_golang process
+			'https://[::]:60443?cert=/etc/pki/tls/certs/localhost.crt&key=/etc/pki/tls/private/localhost.key&verify=0x00&ciphers=AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH:!ED'
 		],
 		user     => 'trafops',
 		group    => 'trafops',
 		heartbeat_timeout => 20,
 		pid_file => '/var/run/traffic_ops.pid',
-		workers  => 96
+		workers  => 12,     # Number of workers to run in parallel. Start with a small number.  Increase as need arises.
 	},
+	traffic_ops_golang_port => '443',
 	cors => {
 		access_control_allow_origin => '*'
 	},

--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -147,7 +147,7 @@ Built: %(date) by %{getenv: USER}
 
     # upgrade
     if [ "$1" == "2" ]; then
-	service traffic_ops stop
+	systemctl stop traffic_ops
     fi
 
 %post
@@ -187,11 +187,11 @@ Built: %(date) by %{getenv: USER}
     # upgrade
     if [ "$1" == "2" ]; then
         echo -e "\n\nTo complete the update, perform the following steps:\n"
-        echo -e "1. Run 'PERL5LIB=/opt/traffic_ops/app/lib:/opt/traffic_ops/app/local/lib/perl5 ./db/admin.pl --env production upgrade'\n"
+        echo -e "1. If any *.rpmnew files are in /opt/traffic_ops/...,  reconcile with any local changes\n"
+        echo -e "2. Run 'PERL5LIB=/opt/traffic_ops/app/lib:/opt/traffic_ops/app/local/lib/perl5 ./db/admin.pl --env production upgrade'\n"
         echo -e "   from the /opt/traffic_ops/app directory.\n"
-        echo -e "2. Run '/opt/traffic_ops/install/bin/postinstall' from the root home directory.\n\n"
-        echo -e "To start Traffic Ops:  service traffic_ops start\n";
-        echo -e "To stop Traffic Ops:   service traffic_ops stop\n\n";
+        echo -e "To start Traffic Ops:  systemctl start traffic_ops\n";
+        echo -e "To stop Traffic Ops:   systemctl stop traffic_ops\n\n";
     fi
     /bin/chown -R %{TRAFFIC_OPS_USER}:%{TRAFFIC_OPS_GROUP} %{PACKAGEDIR}
     /bin/chown -R %{TRAFFIC_OPS_USER}:%{TRAFFIC_OPS_GROUP} %{TRAFFIC_OPS_LOG_DIR}
@@ -201,7 +201,7 @@ Built: %(date) by %{getenv: USER}
 
 if [ "$1" = "0" ]; then
     # stop service before starting the uninstall
-    service traffic_ops stop
+    systemctl stop traffic_ops
 fi
 
 %postun

--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -183,22 +183,6 @@ sub generateDbConf {
     return \%todbconf;
 }
 
-sub setCdnConfGoPort {
-    my $cdnConf = shift;
-    if ( exists $cdnConf->{traffic_ops_golang_port} ) {
-        return $cdnConf;
-    }
-
-    my $listen = $cdnConf->{hypnotoad}{listen}[0];
-    my ($port) = $listen =~ /:(\d+)/;
-    $listen =~ s/:$port/:60443/;
-    $listen =~ s{'https://\[::\]}{'https://127.0.0.1};
-
-    $cdnConf->{traffic_ops_golang_port} = $port;
-    $cdnConf->{hypnotoad}{listen} = [ $listen ];
-    return $cdnConf;
-}
-
 # userInput: The entire input config file which is either user input or the defaults
 # fileName: The filename of the output config file
 #
@@ -238,7 +222,6 @@ sub generateCdnConf {
         $cdnConf->{to}{base_url} = $cdnConfiguration{base_url};
     }
 
-    $cdnConf = setCdnConfGoPort($cdnConf);
     $cdnConf->{hypnotoad}{workers} = $cdnConfiguration{workers};
     #InstallUtils::logger("cdnConf: " . Dumper($cdnConf), "info" );
     InstallUtils::writePerl( $fileName, $cdnConf );
@@ -467,11 +450,11 @@ sub getDefaults {
                 "config_var"             => "genSecret"
             },
             {
-                "Number of secrets to keep?" => "10",
+                "Number of secrets to keep?" => "1",
                 "config_var"                 => "keepSecrets"
             },
             {
-                "Number of workers?" => "96",
+                "Number of workers?" => "12",
                 "config_var"         => "workers"
             },
             {


### PR DESCRIPTION
Fixes #1112 Fixes #1099 

1. cdn.conf updated to handle traffic_ops perl/go split with golang proxy in place
2. updates instructions in traffic_ops.spec when upgrading to remove postinstall
3. defaults number of workers to reasonable start value -- can be increased for production
4. defaults number of secrets to keep to 1 -- only need more to allow existing cookies to be used.