### PR TITLE
add install_go.sh to tests Dockerfile

### DIFF
--- a/traffic_ops/app/bin/tests/Dockerfile-test
+++ b/traffic_ops/app/bin/tests/Dockerfile-test
@@ -46,6 +46,8 @@ RUN yum -y install \
 RUN cpanm -n Carton
 
 ADD install/bin/install_goose.sh /
+ADD install/bin/install_go.sh /
+RUN /install_go.sh
 RUN /install_goose.sh
 
 ADD app /opt/traffic_ops/app


### PR DESCRIPTION
This fixes the TO unit/integration test failures introduced by #1108 