### PR TITLE
Add Traffic Ops Golang logging config object

### DIFF
--- a/traffic_ops/traffic_ops_golang/traffic_ops_golang.go
+++ b/traffic_ops/traffic_ops_golang/traffic_ops_golang.go
@@ -65,6 +65,8 @@ func main() {
 		return
 	}
 
+	log.Infof("Using Config: %+v\n", cfg)
+
 	sslStr := "require"
 	if !cfg.DBSSL {
 		sslStr = "disable"


### PR DESCRIPTION
This makes it easier to debug config issues, especially with the `oldcfg` flag and how it creates the `Config` object.