### PR TITLE
[BACKPORT][TC-518] ToCDUCheck and ToCHRCheck: Value formatted as float instead of int #1090

### DIFF
--- a/traffic_ops/app/bin/checks/ToCDUCheck.pl
+++ b/traffic_ops/app/bin/checks/ToCDUCheck.pl
@@ -104,7 +104,7 @@ foreach my $server ( @{$jdataserver} ) {
 				ERROR "$host_name: cache size is 0!";
 				next;
 			}
-			my $percentage_cache_used = sprintf( "%3.2f", ( $used / $size ) * 100 );
+			my $percentage_cache_used = sprintf( "%3d", ( $used / $size ) * 100 );
 			TRACE "$host_name: percentage cache used == " . $percentage_cache_used;
 			$ext->post_result( $server->{id}, $check_name, $percentage_cache_used );
 		}

--- a/traffic_ops/app/bin/checks/ToCHRCheck.pl
+++ b/traffic_ops/app/bin/checks/ToCHRCheck.pl
@@ -149,7 +149,7 @@ foreach my $server ( @{$jdataserver} ) {
 					my $h  = $hits - $prev_hits;
 					my $m  = $miss - $prev_miss;
 					my $e  = $errors - $prev_errors;
-					my $hr = sprintf( "%3.2f", $h / ( $h + $m + $e ) * 100 );
+					my $hr = sprintf( "%3d", $h / ( $h + $m + $e ) * 100 );
 					TRACE "$host_name: \% hitratio: $hr\%   errors: $e period: $secs\n";
 					$ext->post_result( $server->{id}, $check_name, $hr );
 				}


### PR DESCRIPTION
- Convertion was auto-applied by MySQL, but not with Postgresql resulting in errors in logs

Cherry-picking 5cb898398f7fe4bba165e99c84a6c119d898d5b7
Fixes #1090 
