### PR TITLE
Updated Traffic Ops ISO Generation process to work with management interfaces

### DIFF
--- a/traffic_ops/app/lib/API/Iso.pm
+++ b/traffic_ops/app/lib/API/Iso.pm
@@ -226,6 +226,7 @@ sub generate_iso {
 sub is_valid {
 	my $self   = shift;
 	my $params = shift;
+	my $mgmtIpAddress = $params->{mgmtIpAddress};
 
 	my $rules = {
 		fields => [qw/osversionDir hostName domainName rootPass dhcp ipAddress ipNetmask ipGateway ip6Address ip6Gateway interfaceName interfaceMtu disk mgmtInterface mgmtIpGateway mgmtIpAddress mgmtIpNetmask/],
@@ -239,8 +240,8 @@ sub is_valid {
 			dhcp         => [ is_required("is required") ],
 			interfaceMtu => [ is_required("is required") ],
 			disk => [ is_required("is required") ],
-			mgmtInterface => [ is_required_if(defined($params->{mgmtIpAddress}), "- Management interface is required when Management IP is provided") ],
-			mgmtIpGateway => [ is_required_if(defined($params->{mgmtIpAddress}), "- Management gateway is required when Management IP is provided") ],
+			mgmtInterface => [ is_required_if((defined($mgmtIpAddress) && $mgmtIpAddress ne ""), "- Management interface is required when Management IP is provided") ],
+			mgmtIpGateway => [ is_required_if((defined($mgmtIpAddress) && $mgmtIpAddress ne ""), "- Management gateway is required when Management IP is provided") ],
 			ipAddress    => is_required_if(
 				sub {
 					my $params = shift;

--- a/traffic_ops/app/lib/API/Iso.pm
+++ b/traffic_ops/app/lib/API/Iso.pm
@@ -228,7 +228,7 @@ sub is_valid {
 	my $params = shift;
 
 	my $rules = {
-		fields => [qw/osversionDir hostName domainName rootPass dhcp ipAddress ipNetmask ipGateway ip6Address ip6Gateway interfaceName interfaceMtu disk mgmtInterface mgmtIpGateway/],
+		fields => [qw/osversionDir hostName domainName rootPass dhcp ipAddress ipNetmask ipGateway ip6Address ip6Gateway interfaceName interfaceMtu disk mgmtInterface mgmtIpGateway mgmtIpAddress mgmtIpNetmask/],
 
 		# Validation checks to perform
 		checks => [

--- a/traffic_ops/app/lib/UI/GenIso.pm
+++ b/traffic_ops/app/lib/UI/GenIso.pm
@@ -25,14 +25,16 @@ use File::Path qw(make_path);
 use Data::Dumper;
 use Common::ReturnCodes qw(SUCCESS ERROR);
 use Mojolicious::Plugin::Config;
+use Data::Validate::IP qw(is_ipv4 is_ipv6);
+use API::Iso;
 
 my $filebasedir = "/var/www/files";
 my $ksfiles_parm_name = "kickstart.files.location";
 my $ksfiles_configfile_name = "mkisofs";
 
 # This is the directory we put the configuration files in for kickstart &
-# scripts to process: 
-my $install_cfg = "ks_scripts"; 
+# scripts to process:
+my $install_cfg = "ks_scripts";
 
 sub geniso {
 	my $self = shift;
@@ -75,137 +77,35 @@ sub geniso {
 	if (defined($hostname)){
 		my $iso_file_name = $self->iso_download();
 		$self->stash( iso_file_name => $iso_file_name);
-		#return $self->redirect_to('/geniso');
-                #return $self->redirect_to("/$iso_dir/" . $iso_file_name);
 		return $self->render('gen_iso/geniso');
 	}
 }
 
 sub iso_download {
 	my $self = shift;
-	my $hostname = $self->param('hostname');
-	my $osversion = $self->param('osversion');
-	my $rootpass = $self->param('rootpass');
-	my $dhcp = $self->param('dhcp');
-	my $ipaddr = $self->param('ipaddr');
-	my $netmask = $self->param('netmask');
-	my $gateway = $self->param('gateway');
-	my $ip6_address = $self->param('ip6_address');
-	my $ip6_gateway = $self->param('ip6_gateway');
-	my $dev = $self->param('dev');
-	my $mtu = $self->param('mtu');
-	my $ondisk = $self->param('ondisk');
-
-	# This sets up the "strength" of the hash. So far $1 works (md5). It will produce a sha256 ($5), but it's untested.
-	# PROTIP: Do not put the $ in.
-	my $digest = "1";
-
-	# Read /etc/resolv.conf and get the nameservers. This is (supposedly) a hack
-	# until we get a reasonable UI set up. 
-	my ($nameservers, $line, $nsip) = "";
-	open(RESOLV, '< /etc/resolv.conf') || die ("/etc/resolv.conf: $!");
-	while ($line = <RESOLV>) {
-		if ($line =~ /^nameserver /) {
-			$nsip = (split(" ", $line))[1];
-			$nameservers = "$nsip $nameservers";
-		}
-	}
-
-	$nameservers =~ s/ /,/g;
-	$nameservers =~ s/,$//;
-
-	my $dir;
-	my $ksdir = $self->db->resultset('Parameter')->search( { -and => [ name => $ksfiles_parm_name, config_file => $ksfiles_configfile_name ] } )->get_column('value')->single();
-
-	if (defined $ksdir && $ksdir ne "") {
-		$dir = $ksdir . "/" . $osversion;
-	} else {
-		$dir = $filebasedir . "/" . $osversion;
-	}
-
-	my $cfg_dir = "$dir/$install_cfg";
-	$self->app->log->info("cfg_dir: " . $cfg_dir);
-
-	# This constructs the network.cfg file that gets written in the $install_cfg directory
-	# in network.cfg
-	# This is what we need to create:
-	# IP='192.168.0.2'
-	# IPV6='...'
-	# NETMASK='255.255.255.0'
-	# GATEWAY='192.168.0.1'
-	# NAMESERVER='8.8.8.8,8.8.4.4'
-	# HOSTNAME='mid-cache-01.mycdn.mydomain.net' 
-	# MTU='1500' 
-	# BOND_DEVICE='em0'
-	# BONDOPTS='mode=802.3ad,lacp_rate=fast,xmit_hash_policy=layer3+4'
-	my $network_string = "IPADDR=\"$ipaddr\"\nNETMASK=\"$netmask\"\nGATEWAY=\"$gateway\"\nBOND_DEVICE=\"$dev\"\nMTU=\"$mtu\"\nNAMESERVER=\"$nameservers\"\nHOSTNAME=\"$hostname\"\nNETWORKING_IPV6=\"yes\"\nIPV6ADDR=\"$ip6_address\"\nIPV6_DEFAULTGW=\"$ip6_gateway\"\nBONDING_OPTS=\"miimon=100 mode=4 lacp_rate=fast xmit_hash_policy=layer3+4\"\nDHCP=\"$dhcp\"";
-	# Write out the networking config: 
-	open(NF, "> $cfg_dir/network.cfg") or die "$cfg_dir/network.cfg: $!";
-	print NF $network_string;
-	close NF;
-
-	my $root_pass_string;
-
-	if ($rootpass eq "") {
-		# The following password SHOULD be "Fred". YMMV, you should change this. 
-		$root_pass_string = "#No password was passed in." . "\n" . ' rootpw --iscrypted $1$52LoLYxu$AcrXyEZGxiOOv4xp4E0mn/' . "\n";
-	} else {
-		my @chars = ("A".."Z", "a".."z",0..9) or die 'the @chars thing didn\'t work';
-		my $salt;
-		$salt .= $chars[rand @chars] for 1..8;
-		my $kripted_pw = crypt("$rootpass","\$$digest\$$salt\$") . "\n";
-		$root_pass_string = "rootpw --iscrypted $kripted_pw";
-	}
-
-	open(PWF, "> $cfg_dir/password.cfg") or die "$cfg_dir/password.cfg: $!";
-	print PWF "$root_pass_string";
-	close PWF;
-
-	open (DSK, "> $cfg_dir/disk.cfg") or die "$cfg_dir/disk.cfg: $!";
-	print DSK "boot_drives=\"$ondisk\"";
-	close DSK;
-
-	my $config_file = $ENV{'MOJO_CONFIG'};
-	my $fh;
-	open($fh, "<", $config_file) or die "$config_file: $!";
-
-	my $iso_dir = "iso";
-	my $config = $self->app->config;
-	my $iso_root_path = $config->{'geniso'}{'iso_root_path'}; 
-
-	my $iso_dir_path = join("/", $iso_root_path, $iso_dir);
-	make_path($iso_dir_path);
-
-	my $iso_file_name = "$hostname-$osversion.iso";
-	my $iso_file_path = join("/", $iso_dir_path, $iso_file_name);
-
-	my $cmd = "mkisofs -o $iso_file_path -joliet-long -input-charset utf-8 -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -R -J -v -T $dir";
-	my $type = "default";
-	my $custom_cmd = sprintf("%s/%s", $dir, "generate");
-
-	if (-f $custom_cmd && -x $custom_cmd) {
-		$cmd = sprintf("%s %s", $custom_cmd, $iso_file_path);
-		$type = "custom";
-	} elsif (-f $custom_cmd && ! -x $custom_cmd) {
-		$self->app->log->warn("$custom_cmd exists but is not executable; using $type ISO generation command");
-	}
-
-	$self->app->log->info("Using $type ISO generation command: " . $cmd);
-
-	# This just writes the string we're going to use to generate the ISO. You
-	# won't need it unless you're debugging stuff, but it doesn't really hurt.
-	open(STUF,"> $cfg_dir/state.out") or die "$cfg_dir/state.out: $!";
-	print STUF "Dir== $dir\n";
-	print STUF "$cmd\n";
-	close STUF;
-
-	$self->app->log->info("Writing ISO: " . $iso_file_path);
-	my $output = `$cmd 2>&1` || die("Error executing $cmd:");
-	$self->app->log->info($output);
+	my $params = {
+		hostName => $self->param('hostname'),
+		osversionDir => $self->param('osversion'),
+		rootPass => $self->param('rootpass'),
+		dhcp => $self->param('dhcp'),
+		ipAddress => $self->param('ipaddr'),
+		ipNetmask => $self->param('netmask'),
+		ipGateway => $self->param('gateway'),
+		ip6Address => $self->param('ip6_address'),
+		ip6Gateway => $self->param('ip6_gateway'),
+		interfaceName => $self->param('dev'),
+		interfaceMtu => $self->param('mtu'),
+		disk => $self->param('ondisk'),
+		mgmtIpAddress => $self->param('mgmt_ip_address'),
+		mgmtIpNetmask => $self->param('mgmt_ip_netmask'),
+		mgmtIpGateway => $self->param('mgmt_ip_gateway'),
+		mgmtInterface => $self->param('mgmt_interface')
+	};
+	my $dl_res = &API::Iso::generate_iso($self, $params);
 
 	# serverselect
 	$self->flash( message => "Download ISO here" );
-	return $iso_file_name;
+	return $dl_res->{isoName};
 }
 
 sub find_conf_path {

--- a/traffic_ops/app/t/api/1.2/iso.t
+++ b/traffic_ops/app/t/api/1.2/iso.t
@@ -40,6 +40,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "rootPass" => "password",
             "dhcp" => "yes",
             "interfaceMtu" => 1500,
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "osversionDir is required" )
@@ -51,6 +52,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "rootPass" => "password",
             "dhcp" => "yes",
             "interfaceMtu" => 1500,
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "hostName is required" )
@@ -62,6 +64,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "rootPass" => "password",
             "dhcp" => "yes",
             "interfaceMtu" => 1500,
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "domainName is required" )
@@ -73,6 +76,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "domainName" => "baz.com",
             "dhcp" => "yes",
             "interfaceMtu" => 1500,
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "rootPass is required" )
@@ -84,6 +88,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "domainName" => "baz.com",
             "rootPass" => "password",
             "interfaceMtu" => 1500,
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "dhcp is required" )
@@ -95,6 +100,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "domainName" => "baz.com",
             "rootPass" => "password",
             "dhcp" => "yes",
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "interfaceMtu is required" )
@@ -109,6 +115,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "interfaceMtu" => 1500,
             "ipNetmask" => "255.255.255.255",
             "ipGateway" => "10.10.10.10",
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "ipAddress is required if DHCP is no" )
@@ -123,6 +130,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "interfaceMtu" => 1500,
             "ipAddress" => "10.10.10.10",
             "ipGateway" => "10.10.10.10",
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "ipNetmask is required if DHCP is no" )
@@ -137,6 +145,7 @@ ok $t->post_ok('/api/1.2/isos' => {Accept => 'application/json'} => json => {
             "interfaceMtu" => 1500,
             "ipAddress" => "10.10.10.10",
             "ipNetmask" => "255.255.255.255",
+            "disk" => "bond0",
         })
         ->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
         ->json_is( "/alerts/0/text" => "ipGateway is required if DHCP is no" )

--- a/traffic_ops/app/templates/gen_iso/geniso.html.ep
+++ b/traffic_ops/app/templates/gen_iso/geniso.html.ep
@@ -21,7 +21,7 @@ alert( "<%= flash 'alertmsg' %>" );
 <script>
 $(function () {
 	$(document).ready(function () {
-		
+
 %= include 'jmenu'
 
 	});
@@ -51,17 +51,21 @@ $(function () {
 								$(document).ready(function(){
 									$("#serverselect").change(function() {
 										var selected_server_id = $("#serverselect").val();
-										$.get("/server_by_id/" + selected_server_id,
+										$.get("/api/1.2/servers/" + selected_server_id,
 											function(newvalues){
-												$("#hostname").val(newvalues.host_name + "." + newvalues.domain_name);
-												$("#ipaddr").val(newvalues.ip_address);
-												$("#netmask").val(newvalues.ip_netmask);
-												$("#gateway").val(newvalues.ip_gateway);
-												$("#ip6_address").val(newvalues.ip6_address);
-												$("#ip6_gateway").val(newvalues.ip6_gateway);
-												$("#dev").val(newvalues.interface_name);
-												$("#mtu").val(newvalues.interface_mtu);
+												$("#hostname").val(newvalues.response[0].hostName + "." + newvalues.response[0].domainName);
+												$("#ipaddr").val(newvalues.response[0].ipAddress);
+												$("#netmask").val(newvalues.response[0].ipNetmask);
+												$("#gateway").val(newvalues.response[0].ipGateway);
+												$("#ip6_address").val(newvalues.response[0].ip6Address);
+												$("#ip6_gateway").val(newvalues.response[0].ip6Gateway);
+												$("#dev").val(newvalues.response[0].interfaceName);
+												$("#mtu").val(newvalues.response[0].interfaceMtu);
 												$("#dhcp").val("no");
+												$("#mgmt_ip_address").val(newvalues.response[0].mgmtIpAddress);
+												$("#mgmt_ip_netmask").val(newvalues.response[0].mgmtIpNetmask);
+												$("#mgmt_ip_gateway").val(newvalues.response[0].mgmtIpGateway);
+												$("#mgmt_interface").val(newvalues.response[0].mgmtInterface);
 											}
 										);
 									});
@@ -145,6 +149,26 @@ $(function () {
 									<td>Network Device:</td>
 									<td> <input type="text" size=45 id="dev" name="dev"/ value=""></td>
 									<td>Optional.  Typical values are bond0, eth4, etc.  Note: if you enter bond0, a LACP bonding config will be written</td>
+								</tr>
+								<tr>
+									<td>Management IP Address:</td>
+									<td> <input type="text" size=45 id="mgmt_ip_address" name="mgmt_ip_address" value=""></td>
+									<td>Optional</td>
+								</tr>
+								<tr>
+									<td>Management Netmask:</td>
+									<td><input type="text" size=45 id="mgmt_ip_netmask" name="mgmt_ip_netmask"/ value=""></td>
+									<td>Required only if Management IP Address is IPv4</td>
+								</tr>
+								<tr>
+									<td>Management Gateway:</td>
+									<td><input type="text" size=45 id="mgmt_ip_gateway" name="mgmt_ip_gateway"/ value=""></td>
+									<td>Required if Management IP Address is entered.</td>
+								</tr>
+								<tr>
+									<td>Management Network Device:</td>
+									<td> <input type="text" size=45 id="mgmt_interface" name="mgmt_interface"/ value=""></td>
+									<td>Required if Management IP Address is entered.  The name of the management interface.</td>
 								</tr>
 								<tr>
 									<td>MTU:</td>

--- a/traffic_portal/app/src/common/modules/form/iso/form.iso.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/iso/form.iso.tpl.html
@@ -147,8 +147,40 @@ under the License.
                     <span ng-show="hasError(isoForm.interfaceName)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
+            <div class="form-group" ng-show="!isDHCP(iso)" ng-class="{'has-error': hasError(isoForm.mgmtIpAddress), 'has-feedback': hasError(isoForm.mgmtIpAddress)}">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Management IP Address</label>
+                <div class="col-md-10 col-sm-10 col-xs-12">
+                    <input id="mgmtIpAddress" name="mgmtIpAddress" type="text" class="form-control" ng-model="iso.mgmtIpAddress" ng-maxlength="50" autofocus>
+                    <small class="input-error" ng-show="hasPropertyError(isoForm.mgmtIpAddress, 'maxlength')">Too Long</small>
+                    <span ng-show="hasError(isoForm.mgmtIpAddress)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                </div>
+            </div>
+            <div class="form-group" ng-show="!isDHCP(iso)" ng-class="{'has-error': hasError(isoForm.mgmtIpNetmask), 'has-feedback': hasError(isoForm.mgmtIpNetmask)}">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Management IP Netmask</label>
+                <div class="col-md-10 col-sm-10 col-xs-12">
+                    <input id="mgmtIpNetmask" name="mgmtIpNetmask" type="text" class="form-control" ng-model="iso.mgmtIpNetmask" ng-maxlength="50" autofocus>
+                    <small class="input-error" ng-show="hasPropertyError(isoForm.mgmtIpNetmask, 'maxlength')">Too Long</small>
+                    <span ng-show="hasError(isoForm.mgmtIpNetmask)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                </div>
+            </div>
+            <div class="form-group" ng-show="!isDHCP(iso)" ng-class="{'has-error': hasError(isoForm.mgmtIpGateway), 'has-feedback': hasError(isoForm.mgmtIpGateway)}">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Management IP Gateway</label>
+                <div class="col-md-10 col-sm-10 col-xs-12">
+                    <input id="mgmtIpGateway" name="mgmtIpGateway" type="text" class="form-control" ng-model="iso.mgmtIpGateway" ng-maxlength="50" autofocus>
+                    <small class="input-error" ng-show="hasPropertyError(isoForm.mgmtIpGateway, 'maxlength')">Too Long</small>
+                    <span ng-show="hasError(isoForm.mgmtIpGateway)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                </div>
+            </div>
+            <div class="form-group" ng-show="!isDHCP(iso)" ng-class="{'has-error': hasError(isoForm.mgmtInterface), 'has-feedback': hasError(isoForm.mgmtInterface)}">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Management Interface</label>
+                <div class="col-md-10 col-sm-10 col-xs-12">
+                    <input id="mgmtInterface" name="mgmtInterface" type="text" class="form-control" placeholder="Typical values are em3, eth3, etc. The name of the management interface. Required if Management IP Address is entered." ng-model="iso.mgmtInterface" ng-maxlength="50" autofocus>
+                    <small class="input-error" ng-show="hasPropertyError(isoForm.mgmtInterface, 'maxlength')">Too Long</small>
+                    <span ng-show="hasError(isoForm.mgmtInterface)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                </div>
+            </div>
             <div class="form-group" ng-class="{'has-error': hasError(isoForm.disk), 'has-feedback': hasError(isoForm.disk)}">
-                <label class="control-label col-md-2 col-sm-2 col-xs-12">Disk for OS Install</label>
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Disk for OS Install*</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <input id="disk" name="disk" type="text" class="form-control" placeholder='Typical values are "sda"' ng-model="iso.disk" ng-maxlength="8" autofocus>
                     <small class="input-error" ng-show="hasPropertyError(isoForm.disk, 'maxlength')">Too Long</small>

--- a/traffic_portal/app/src/common/modules/form/iso/form.iso.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/iso/form.iso.tpl.html
@@ -182,7 +182,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(isoForm.disk), 'has-feedback': hasError(isoForm.disk)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">Disk for OS Install*</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input id="disk" name="disk" type="text" class="form-control" placeholder='Typical values are "sda"' ng-model="iso.disk" ng-maxlength="8" autofocus>
+                    <input id="disk" name="disk" type="text" class="form-control" placeholder='Typical values are "sda"' ng-model="iso.disk" ng-maxlength="8" required autofocus>
                     <small class="input-error" ng-show="hasPropertyError(isoForm.disk, 'maxlength')">Too Long</small>
                     <span ng-show="hasError(isoForm.disk)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>


### PR DESCRIPTION
Sometimes a server requires that users access on a management network interface instead of through the payload network interface.  Traffic Ops did not have the ability to support passing management network interface information to the kickstart scripts, even though the data was in the database.  This change makes it so that management network interface information can be provided and sent to the kickstart scripts. 