### PR TITLE
CRConfig generation checks for any caches rather than each type.

### DIFF
--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -90,20 +90,19 @@ sub gen_crconfig_json {
         "^EDGE" => "EDGE",
         "^MID"  => "MID",
     };
-
+    my $found;
     for my $cachetype ( keys %{$types} ) {
-        my $found = 0;
-
+        
         for my $this_type ( keys %{$profile_cache} ) {
             if ( $this_type =~ m/$cachetype/ && scalar( @{ $profile_cache->{$this_type} } ) > 0 ) {
                 push @profile_caches, @{ $profile_cache->{$this_type} };
                 $found = 1;
             }
         }
+    }
 
-        if ( !$found ) {
-            my $e = Mojo::Exception->throw( "No " . $types->{$cachetype} . " profiles found for CDN: " . $cdn_name );
-        }
+    if ( !$found ) {
+        my $e = Mojo::Exception->throw( "No cache profiles found for CDN: " . $cdn_name );
     }
 
     my %condition = (


### PR DESCRIPTION
CRConfig generation will now only check for at least one cache, rather than requiring one of each type, in order to generate a snapshot.