### PR TITLE
[CDN-415] skip stats that are greater than 24 hours old

### DIFF
--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -576,6 +576,13 @@ func calcDsValues(rascalData []byte, cdnName string, sampleTime int64, config St
 	})
 	for dsName, dsData := range jData.DeliveryService {
 		for dsMetric, dsMetricData := range dsData {
+			//Get the stat time and make sure it's greater than the time 24 hours ago. If not, skip it so influxdb doesn't throw retention policy errors.
+			validTime := time.Now().AddDate(0, 0, -1).UnixNano() / 1000000
+			timeStamp := int64(dsMetricData[0].Time)
+			if timeStamp < validTime {
+				log.Info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", dsName, dsMetric, timeStamp))
+				continue
+			}
 			var cachegroup, statName string
 			tags := map[string]string{
 				"deliveryservice": dsName,
@@ -662,6 +669,13 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 		cache := cacheMap[cacheName]
 
 		for statName, statData := range cacheData {
+			//Get the stat time and make sure it's greater than the time 24 hours ago.  If not, skip it so influxdb doesn't throw retention policy errors.
+			validTime := time.Now().AddDate(0, 0, -1).UnixNano() / 1000000
+			timeStamp := int64(statData[0].Time)
+			if timeStamp < validTime {
+				log.Info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", cacheName, statName, timeStamp))
+				continue
+			}
 			dataKey := statName
 			dataKey = strings.Replace(dataKey, ".bandwidth", ".kbps", 1)
 			dataKey = strings.Replace(dataKey, "-", "_", -1)


### PR DESCRIPTION
This prevents traffic stats from attempting to add records to influxdb that are greater than 24 hours old, which violates the db retention policy and causes errors in the log.  When a stat is greater than 24 hours, it is skipped.