### PR TITLE
Re-add managment interface code to gen iso

### DIFF
--- a/traffic_ops/app/lib/API/Iso.pm
+++ b/traffic_ops/app/lib/API/Iso.pm
@@ -164,10 +164,10 @@ sub generate_iso {
 	close NF;
 
 	#generate and write management network config file if mgmt_IPAddress is defined
-	my $mgmt_network_string = "IPADDR=\"$mgmt_ip_address\"\nNETMASK=\"$mgmt_ip_netmask\"\nGATEWAY=\"$mgmt_ip_gateway\"\nHOSTNAME=\"$fqdn\"\nDHCP=\"$dhcp\"";
+	my $mgmt_network_string = "IPADDR=\"$mgmt_ip_address\"\nNETMASK=\"$mgmt_ip_netmask\"\nGATEWAY=\"$mgmt_ip_gateway\"\nDEVICE=$mgmt_interface";
 	$mgmt_ip_address =~ s/\/.*//g;
 	if (is_ipv6($mgmt_ip_address)) {
-		$mgmt_network_string = "IPV6ADDR=\"$mgmt_ip_address\"\nNETMASK=\"$mgmt_ip_netmask\"\nGATEWAY=\"$mgmt_ip_gateway\"\nHOSTNAME=\"$fqdn\"\nDHCP=\"$dhcp\"";
+		$mgmt_network_string = "IPV6ADDR=\"$mgmt_ip_address\"\nNETMASK=\"$mgmt_ip_netmask\"\nGATEWAY=\"$mgmt_ip_gateway\"\nDEVICE=$mgmt_interface";
 	}
 
 	open( NF, "> $cfg_dir/mgmt_network.cfg" ) or die "$cfg_dir/mgmt_network.cfg: $!";

--- a/traffic_ops/app/lib/UI/GenIso.pm
+++ b/traffic_ops/app/lib/UI/GenIso.pm
@@ -25,7 +25,6 @@ use File::Path qw(make_path);
 use Data::Dumper;
 use Common::ReturnCodes qw(SUCCESS ERROR);
 use Mojolicious::Plugin::Config;
-use Data::Validate::IP qw(is_ipv4 is_ipv6);
 use API::Iso;
 
 my $filebasedir = "/var/www/files";


### PR DESCRIPTION
I mistakenly removed this when I consolidated some copy/paste code that was in UI and API.  I added it back in so that we can actually generate isos with management network interface config.