### PR TITLE
Update Traffic Monitor Documentation header and linking

### DIFF
--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -13,13 +13,13 @@
 .. limitations under the License.
 .. 
 
-******************************
-Traffic Monitor Administration
-******************************
+***************************************
+Traffic Monitor Administration (Legacy)
+***************************************
 
 .. _rl-tm-java:
 
-* These instructions are for the Java Traffic Monitor, for the Golang beta, see :ref:`rl-tm-golang`.
+* These instructions are for the legacy Java Traffic Monitor, for the new Golang version, see :ref:`here <rl-tm-golang>`.
 
 Installing Traffic Monitor
 ==========================

--- a/docs/source/admin/traffic_monitor_golang.rst
+++ b/docs/source/admin/traffic_monitor_golang.rst
@@ -19,7 +19,7 @@ Traffic Monitor Administration
 
 .. _rl-tm-golang:
 
-* These instructions are for the beta Golang Traffic Monitor, for the old Java version, see :ref:`rl-tm-java`.
+* These instructions are for the Golang Traffic Monitor, for the legacy Java version, see :ref:`here <rl-tm-java>`.
 
 Installing Traffic Monitor
 ==========================


### PR DESCRIPTION
The Traffic Monitor component was significantly updated with a Golang
rewrite but the old documentation was left ambiguous in the html tree
navigation menu.  Additionally the links between the two articles were
broken.  This provides a more clear distinction between the two on which
is the current version.

#1313 