### PR TITLE
fix missing license info in ignore_routing migration

### DIFF
--- a/traffic_ops/app/db/migrations/20170825124926_ignore_routing.sql
+++ b/traffic_ops/app/db/migrations/20170825124926_ignore_routing.sql
@@ -1,3 +1,14 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied


### PR DESCRIPTION
Adds the missing license info to the ignore_routing migration file.