### PR TITLE
Update language on frontpage for Traffic Monitor

### DIFF
--- a/misc/traffic-control-cdn/index.html
+++ b/misc/traffic-control-cdn/index.html
@@ -59,7 +59,7 @@ under the License.
         </tr>
         <tr>
             <td class="tableMainCell"><a href="traffic_monitor/index.html"><img src="images/traffic_monitor_logo.png"></a></td>
-            <td class="tableMainCell">Traffic Monitor is a Java Tomcat application that implements the CDN health protocol. Every cache in the CDN is checked using HTTP for vital stats, and based on these stats, caches are declared healthy or unhealthy. This information is then used by Traffic Router to make it's routing decisions.
+            <td class="tableMainCell">Traffic Monitor is a Golang application, originally written as a Java Tomcat application, that implements the CDN health protocol. Every cache in the CDN is checked using HTTP for vital stats, and based on these stats, caches are declared healthy or unhealthy. This information is then used by Traffic Router to make it's routing decisions.
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Traffic Monitor is transitioning toward a new Golang implementation and as such it should be noted on the front page.

#1320