### PR TITLE
Add new endpoints for snapshot configs to python API

### DIFF
--- a/traffic_control/clients/python/trafficops/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/trafficops/tosession.py
@@ -818,6 +818,24 @@ class TOSession(restapi.RestApiSession):
         :raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
         """
 
+    @restapi.api_request(u'get', u'cdns/{cdn_name}/snapshot', (u'1.2',))
+    def get_current_snapshot_crconfig(self, cdn_name=None):
+        """
+        Retrieve the currently implemented CR Snapshot
+        :param cdn_name: The CDN name
+        :type cdn_name: Text
+        :rtype: Tuple[Dict[Text, Any], requests.Response]
+        :raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+        """
+    @restapi.api_request(u'get', u'cdns/{cdn_name}/snapshot/new', (u'1.2',))
+    def get_pending_snapshot_crconfig(self, cdn_name=None):
+        """
+        Retrieve the pending CR Snapshot
+        :param cdn_name: The CDN name
+        :type cdn_name: Text
+        :rtype: Tuple[Dict[Text, Any], requests.Response]
+        :raises: Union[trafficops.restapi.LoginError, trafficops.restapi.OperationError]
+        """
 
 if __name__ == u'__main__':
     # Sample usages


### PR DESCRIPTION
Adds more API endpoints (retrieve current and pending snapshot configs) to take better advantage of the Snapshot Config API for the trafficops Python API. 