### PR TITLE
Fix golang unit

### DIFF
--- a/traffic_ops/app/bin/tests/Dockerfile-golangtest
+++ b/traffic_ops/app/bin/tests/Dockerfile-golangtest
@@ -14,8 +14,10 @@
 FROM golang:1.8
 MAINTAINER Dan Kirkwood <dangogh@apache.org>
 ARG DIR=github.com/apache/incubator-trafficcontrol
+
 ADD traffic_ops /go/src/$DIR/traffic_ops
-ADD traffic_monitor_golang/common /go/src/$DIR/traffic_monitor_golang/common
+ADD lib /go/src/$DIR/lib
+
 WORKDIR /go/src/$DIR/traffic_ops/traffic_ops_golang
 
 CMD bash -c 'go test -v $(go list ./... | grep -v /vendor/)'

--- a/traffic_ops/traffic_ops_golang/api/alerts_test.go
+++ b/traffic_ops/traffic_ops_golang/api/alerts_test.go
@@ -20,11 +20,11 @@ package api
  */
 
 import (
-	"testing"
-	"net/http/httptest"
-	"net/http"
 	"fmt"
-	"github.com/apache/incubator-trafficcontrol/traffic_stats/assert"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
 )
 
 func TestGetHandleErrorFunc(t *testing.T) {
@@ -35,9 +35,8 @@ func TestGetHandleErrorFunc(t *testing.T) {
 	}
 	body := `{"alerts":[{"text":"this is an error","level":"error"}]}`
 
-
-	errHandler := GetHandleErrorFunc(w,r)
-	errHandler(fmt.Errorf("this is an error"),http.StatusBadRequest)
+	errHandler := GetHandleErrorFunc(w, r)
+	errHandler(fmt.Errorf("this is an error"), http.StatusBadRequest)
 	if w.Body.String() != body {
 		t.Error("Expected body", body, "got", w.Body.String())
 	}
@@ -45,8 +44,8 @@ func TestGetHandleErrorFunc(t *testing.T) {
 	w = httptest.NewRecorder()
 	body = `{"alerts":[]}`
 
-	errHandler = GetHandleErrorFunc(w,r)
-	errHandler(nil,http.StatusBadRequest)
+	errHandler = GetHandleErrorFunc(w, r)
+	errHandler(nil, http.StatusBadRequest)
 	if w.Body.String() != body {
 		t.Error("Expected body", body, "got", w.Body.String())
 	}
@@ -55,9 +54,13 @@ func TestGetHandleErrorFunc(t *testing.T) {
 func TestCreateAlerts(t *testing.T) {
 	expected := Alerts{[]Alert{}}
 	alerts := CreateAlerts(WarnLevel)
-	assert.Equal(t,alerts,expected)
+	if !reflect.DeepEqual(expected, alerts) {
+		t.Errorf("Expected %v Got %v", expected, alerts)
+	}
 
-	expected = Alerts{[]Alert{Alert{"message 1",WarnLevel.String()},Alert{"message 2",WarnLevel.String()},Alert{"message 3",WarnLevel.String()}}}
-	alerts = CreateAlerts(WarnLevel,"message 1","message 2","message 3")
-	assert.Equal(t,alerts,expected)
+	expected = Alerts{[]Alert{Alert{"message 1", WarnLevel.String()}, Alert{"message 2", WarnLevel.String()}, Alert{"message 3", WarnLevel.String()}}}
+	alerts = CreateAlerts(WarnLevel, "message 1", "message 2", "message 3")
+	if !reflect.DeepEqual(expected, alerts) {
+		t.Errorf("Expected %v Got %v", expected, alerts)
+	}
 }

--- a/traffic_ops/traffic_ops_golang/ats/config_test.go
+++ b/traffic_ops/traffic_ops_golang/ats/config_test.go
@@ -1,10 +1,5 @@
 package ats
 
-import (
-	"testing"
-	"github.com/apache/incubator-trafficcontrol/traffic_stats/assert"
-)
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -24,7 +19,12 @@ import (
  * under the License.
  */
 
- func TestGetConfigFile(t *testing.T) {
-	 cfgFile := GetConfigFile(HeaderRewritePrefix,"my-xml-id")
-	 assert.Equal(t,cfgFile,"hdr_rw_my-xml-id.config")
- }
+import "testing"
+
+func TestGetConfigFile(t *testing.T) {
+	expected := "hdr_rw_my-xml-id.config"
+	cfgFile := GetConfigFile(HeaderRewritePrefix, "my-xml-id")
+	if cfgFile != expected {
+		t.Errorf("Expected %s.   Got %s", expected, cfgFile)
+	}
+}

--- a/traffic_ops/traffic_ops_golang/servers_test.go
+++ b/traffic_ops/traffic_ops_golang/servers_test.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/apache/incubator-trafficcontrol/lib/go-log"
@@ -28,7 +29,6 @@ import (
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/jmoiron/sqlx"
 
-	"github.com/apache/incubator-trafficcontrol/traffic_stats/assert"
 	"github.com/lib/pq"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
@@ -248,6 +248,10 @@ func TestAssignDsesToServer(t *testing.T) {
 	mock.ExpectCommit()
 
 	result, err := assignDeliveryServicesToServer(100, newDses, true, db)
-	assert.Equal(t, result, newDses)
-	assert.Equal(t, err, nil)
+	if err != nil {
+		t.Errorf("error assigning deliveryservice: %v", err)
+	}
+	if !reflect.DeepEqual(result, newDses) {
+		t.Errorf("delivery services assigned: Expected %v.   Got  %v", newDses, result)
+	}
 }


### PR DESCRIPTION
golang unit tests run in a docker container in Jenkins,  so must have all dependencies pulled in:   log moved from traffic_monitor/common into lib,   and a dependency on traffic_stats/assert had crept in.

These are both fixed, and unit tests will pass again.