### PR TITLE
Traffic Ops golang api/1.2/hwinfo endpoint requires servername

### DIFF
--- a/lib/go-tc/hwinfos.go
+++ b/lib/go-tc/hwinfos.go
@@ -24,9 +24,10 @@ type HWInfoResponse struct {
 }
 
 type HWInfo struct {
-	Description string `json:"description" db:"description"`
-	ID          int    `json:"id" db:"id"`
-	LastUpdated string `json:"lastUpdated" db:"last_updated"`
-	ServerID    int    `json:"server_id" db:"serverid"`
-	Val         string `json:"val" db:"val"`
+	Description    string `json:"description" db:"description"`
+	ID             int    `json:"-" db:"id"`
+	LastUpdated    string `json:"lastUpdated" db:"last_updated"`
+	ServerHostName string `json:"serverHostName" db:"serverhostname"`
+	ServerID       int    `json:"serverId" db:"serverid"`
+	Val            string `json:"val" db:"val"`
 }

--- a/traffic_ops/traffic_ops_golang/hwinfo_test.go
+++ b/traffic_ops/traffic_ops_golang/hwinfo_test.go
@@ -33,11 +33,12 @@ import (
 func getTestHWInfo() []tc.HWInfo {
 	hwinfo := []tc.HWInfo{}
 	testHWInfo := tc.HWInfo{
-		ID:          1,
-		ServerID:    1,
-		Description: "Description",
-		Val:         "Val",
-		LastUpdated: "LastUpdated",
+		ID:             1,
+		ServerID:       1,
+		ServerHostName: "testserver1",
+		Description:    "Description",
+		Val:            "Val",
+		LastUpdated:    "LastUpdated",
 	}
 	hwinfo = append(hwinfo, testHWInfo)
 
@@ -45,6 +46,7 @@ func getTestHWInfo() []tc.HWInfo {
 	testHWInfo2.Description = "hwinfo2"
 	testHWInfo2.Val = "val2"
 	testHWInfo2.ServerID = 2
+	testHWInfo2.ServerHostName = "testserver2"
 	hwinfo = append(hwinfo, testHWInfo2)
 
 	return hwinfo
@@ -70,6 +72,7 @@ func TestGetHWInfo(t *testing.T) {
 			ts.Description,
 			ts.ID,
 			ts.LastUpdated,
+			ts.ServerHostName,
 			ts.ServerID,
 			ts.Val,
 		)


### PR DESCRIPTION
I missed the servername in the hwinfo endpoint -- required for compatibility with perl endpoint.