### PR TITLE
add recursive call to build_dependencies for .spec files with go code

### DIFF
--- a/traffic_monitor_golang/build/traffic_monitor.spec
+++ b/traffic_monitor_golang/build/traffic_monitor.spec
@@ -57,16 +57,20 @@ build_dependencies () {
     for (( i=0; i<${#array[@]}; i++ )); do
         curPkg=${array[i]};
         curPkgShort=${curPkg#$prefix};
-        echo "building $curPkg";
+        echo "checking $curPkg";
         godir=$GOPATH/src/$curPkg;
-        ( mkdir -p "$godir" && \
-          cd "$godir" && \
-          cp -r "$TC_DIR$curPkgShort"/* . && \
-          go get -v && \
-          echo "go building $curPkgShort at $(pwd)" && \
-          go build \
-        ) || { echo "Could not build go $curPkgShort at $(pwd): $!"; exit 1; };
-    done
+        if [ ! -d "$godir" ]; then
+          ( echo "building $curPkg" && \
+            mkdir -p "$godir" && \
+            cd "$godir" && \
+            cp -r "$TC_DIR$curPkgShort"/* . && \
+            build_dependencies "$curPkgShort" && \
+            go get -v && \
+            echo "go building $curPkgShort at $(pwd)" && \
+            go build \
+          ) || { echo "Could not build go $curPkgShort at $(pwd): $!"; exit 1; };
+        fi
+     done
 }
 
 #build traffic_monitor binary

--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -76,15 +76,19 @@ Built: %(date) by %{getenv: USER}
        for (( i=0; i<${#array[@]}; i++ )); do
            curPkg=${array[i]};
            curPkgShort=${curPkg#$prefix};
-           echo "building $curPkg";
+           echo "checking $curPkg";
            godir=$GOPATH/src/$curPkg;
-           ( mkdir -p "$godir" && \
-             cd "$godir" && \
-             cp -r "$TC_DIR$curPkgShort"/* . && \
-             go get -v &&\
-             echo "go building $curPkgShort at $(pwd)" && \
-             go build \
-           ) || { echo "Could not build go $curPkgShort at $(pwd): $!"; exit 1; };
+           if [ ! -d "$godir" ]; then
+             ( echo "building $curPkg" && \
+               mkdir -p "$godir" && \
+               cd "$godir" && \
+               cp -r "$TC_DIR$curPkgShort"/* . && \
+               build_dependencies "$curPkgShort" && \
+               go get -v &&\
+               echo "go building $curPkgShort at $(pwd)" && \
+               go build \
+             ) || { echo "Could not build go $curPkgShort at $(pwd): $!"; exit 1; };
+           fi
        done
     }
 

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -59,15 +59,19 @@ build_dependencies () {
     for (( i=0; i<${#array[@]}; i++ )); do
         curPkg=${array[i]};
         curPkgShort=${curPkg#$prefix};
-        echo "building $curPkg";
+        echo "checking $curPkg";
         godir=$GOPATH/src/$curPkg;
-        ( mkdir -p "$godir" && \
-          cd "$godir" && \
-          cp -r "$TC_DIR$curPkgShort"/* . && \
-          go get -v && \
-          echo "go building $curPkgShort at $(pwd)" && \
-          go build \
-        ) || { echo "Could not build go $curPkgShort at $(pwd): $!"; exit 1; };
+        if [ ! -d "$godir" ]; then
+          ( echo "building $curPkg" && \
+            mkdir -p "$godir" && \
+            cd "$godir" && \
+            cp -r "$TC_DIR$curPkgShort"/* . && \
+            build_dependencies "$curPkgShort" && \
+            go get -v && \
+            echo "go building $curPkgShort at $(pwd)" && \
+            go build \
+          ) || { echo "Could not build go $curPkgShort at $(pwd): $!"; exit 1; };
+        fi
     done
 }
 


### PR DESCRIPTION
I use the existence of a package's directory to exit recursion