### PR TITLE
Set file handle limit for TrafficOps golang proxy

### DIFF
--- a/traffic_ops/etc/init.d/traffic_ops
+++ b/traffic_ops/etc/init.d/traffic_ops
@@ -61,6 +61,7 @@ start ()
 {
 	stop
 	echo -e "Starting Traffic Ops\n"
+	ulimit -n 200000 || echo "Setting ulimit max files failed for traffic_ops_golang"
 	cd $TO_DIR && $TO_DIR/bin/traffic_ops_golang -cfg $TO_DIR/conf/cdn.conf -dbcfg $TO_DIR/conf/production/database.conf &
 	cd $TO_DIR && $TO_DIR/local/bin/hypnotoad script/cdn
 }


### PR DESCRIPTION
Because the trafficops initd script uses start-stop-daemon, it doesn't pass through PAM which would apply any limits.conf increases to the number of possible file handles. As such, when the Golang proxy is submitted to load it can run out of available file handles and experience failures.

Fixes #1381 