### PR TITLE
Add TO Perl 1.3 routing

### DIFF
--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -50,6 +50,10 @@ sub define {
 	$version = "1.2";
 	$self->api_routes( $r, $version, $namespace );
 
+	# 1.3 Routes
+	$version = "1.3";
+	$self->api_routes( $r, $version, $namespace );
+
 	# Traffic Stats Extension
 	$self->traffic_stats_routes( $r, $version );
 


### PR DESCRIPTION
This is necessary, as we already have 1.3 endpoints in TO Go. So
Perl needs to route reqs to 1.3 too, so clients can use 1.3 entirely.