### PR TITLE
Fixed the response for a deliveryservice with no urisigning keys.

### DIFF
--- a/lib/go-tc/alerts.go
+++ b/lib/go-tc/alerts.go
@@ -64,6 +64,7 @@ func GetHandleErrorFunc(w http.ResponseWriter, r *http.Request) func(err error, 
 			fmt.Fprintf(w, http.StatusText(http.StatusInternalServerError))
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		fmt.Fprintf(w, "%s", errBytes)
 	}

--- a/traffic_ops/traffic_ops_golang/riak.go
+++ b/traffic_ops/traffic_ops_golang/riak.go
@@ -174,8 +174,15 @@ func getUrisignkeysHandler(db *sqlx.DB, cfg Config) http.HandlerFunc {
 
 		resp, err := getStringValueFromRiakObject(fvc.Response)
 		if err != nil {
-			handleErr(err, http.StatusNotFound)
-			return
+			var empty URISignerKeyset
+			respBytes, err := json.Marshal(empty)
+			if err != nil {
+				log.Errorf("failed to marshal an empty response: %s\n", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, http.StatusText(http.StatusInternalServerError))
+				return
+			}
+			resp = string(respBytes)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, "%s", resp)


### PR DESCRIPTION
Fixed the response for a deliveryservice with no urisigning keys to return an empty object with an http 200.  Also fixed tc.GetErrorHandleFunc() to set the content-type to application/json.