### PR TITLE
Add Traffic Ops Client cache hit, IP to functions

### DIFF
--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -133,7 +133,7 @@ func StartOpsConfigManager(
 		useCache := false
 		trafficOpsRequestTimeout := time.Second * time.Duration(10)
 
-		realToSession, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
+		realToSession, _, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
 		if err != nil {
 			handleErr(fmt.Errorf("MonitorConfigPoller: error instantiating Session with traffic_ops: %s\n", err))
 			return

--- a/traffic_monitor/tools/nagios-validate-deliveryservices.go
+++ b/traffic_monitor/tools/nagios-validate-deliveryservices.go
@@ -43,7 +43,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_monitor/tools/nagios-validate-offline.go
+++ b/traffic_monitor/tools/nagios-validate-offline.go
@@ -43,7 +43,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_monitor/tools/nagios-validate-peerpoller.go
+++ b/traffic_monitor/tools/nagios-validate-peerpoller.go
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_monitor/tools/nagios-validate-queryinterval.go
+++ b/traffic_monitor/tools/nagios-validate-queryinterval.go
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_monitor/tools/validator-service.go
+++ b/traffic_monitor/tools/validator-service.go
@@ -149,7 +149,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_ops/client/cachegroup.go
+++ b/traffic_ops/client/cachegroup.go
@@ -23,18 +23,25 @@ import (
 
 // CacheGroups gets the CacheGroups in an array of CacheGroup structs
 // (note CacheGroup used to be called location)
+// Deprecated: use GetCacheGroups.
 func (to *Session) CacheGroups() ([]tc.CacheGroup, error) {
+	cgs, _, err := to.GetCacheGroups()
+	return cgs, err
+}
+
+func (to *Session) GetCacheGroups() ([]tc.CacheGroup, ReqInf, error) {
 	url := "/api/1.2/cachegroups.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil) // TODO change to getBytesWithTTL, return CacheHitStatus
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.CacheGroupsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/cdn.go
+++ b/traffic_ops/client/cdn.go
@@ -22,50 +22,71 @@ import (
 	tc "github.com/apache/incubator-trafficcontrol/lib/go-tc"
 )
 
+// Deprecated: use GetCDNs.
 func (to *Session) CDNs() ([]tc.CDN, error) {
+	cdns, _, err := to.GetCDNs()
+	return cdns, err
+}
+
+func (to *Session) GetCDNs() ([]tc.CDN, ReqInf, error) {
 	url := "/api/1.2/cdns.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil) // TODO change to getBytesWithTTL, which caches
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.CDNsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }
 
 // CDNName gets an array of CDNs
+// Deprecated: use GetCDNName
 func (to *Session) CDNName(name string) ([]tc.CDN, error) {
+	n, _, err := to.GetCDNName(name)
+	return n, err
+}
+
+func (to *Session) GetCDNName(name string) ([]tc.CDN, ReqInf, error) {
 	url := fmt.Sprintf("/api/1.2/cdns/name/%s.json", name)
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil) // TODO change to getBytesWithTTL, return CacheHitStatus
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.CDNsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }
 
+// Deprecated: use GetCDNSSLKeys
 func (to *Session) CDNSSLKeys(name string) ([]tc.CDNSSLKeys, error) {
+	ks, _, err := to.GetCDNSSLKeys(name)
+	return ks, err
+}
+
+func (to *Session) GetCDNSSLKeys(name string) ([]tc.CDNSSLKeys, ReqInf, error) {
 	url := fmt.Sprintf("/api/1.2/cdns/name/%s/sslkeys.json", name)
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil) // TODO change to getBytesWithTTL, return CacheHitStatus
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.CDNSSLKeysResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/crconfig.go
+++ b/traffic_ops/client/crconfig.go
@@ -24,7 +24,7 @@ func (to *Session) CRConfigRaw(cdn string) ([]byte, error) {
 }
 
 // GetCRConfig returns the raw JSON bytes of the CRConfig from Traffic Ops, and whether the bytes were from the client's internal cache.
-func (to *Session) GetCRConfig(cdn string) ([]byte, CacheHitStatus, error) {
+func (to *Session) GetCRConfig(cdn string) ([]byte, ReqInf, error) {
 	url := fmt.Sprintf("/CRConfig-Snapshots/%s/CRConfig.json", cdn)
 	return to.getBytesWithTTL(url, tmPollingInterval)
 }

--- a/traffic_ops/client/delivery_service.go
+++ b/traffic_ops/client/delivery_service.go
@@ -23,36 +23,54 @@ import (
 )
 
 // DeliveryServices gets an array of DeliveryServices
+// Deprecated: use GetDeliveryServices
 func (to *Session) DeliveryServices() ([]tc.DeliveryService, error) {
-	var data tc.GetDeliveryServiceResponse
-	err := get(to, deliveryServicesEp(), &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data.Response, nil
+	dses, _, err := to.GetDeliveryServices()
+	return dses, err
 }
 
-// DeliveryServices gets an array of DeliveryServices
-func (to *Session) DeliveryServicesByServer(id int) ([]tc.DeliveryService, error) {
+func (to *Session) GetDeliveryServices() ([]tc.DeliveryService, ReqInf, error) {
 	var data tc.GetDeliveryServiceResponse
-	err := get(to, deliveryServicesByServerEp(strconv.Itoa(id)), &data)
+	reqInf, err := get(to, deliveryServicesEp(), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
+}
+
+// DeliveryServicesByServer gets an array of all DeliveryServices with the given server ID assigend.
+// Deprecated: use GetDeliveryServicesByServer
+func (to *Session) DeliveryServicesByServer(id int) ([]tc.DeliveryService, error) {
+	dses, _, err := to.GetDeliveryServicesByServer(id)
+	return dses, err
+}
+
+func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryService, ReqInf, error) {
+	var data tc.GetDeliveryServiceResponse
+	reqInf, err := get(to, deliveryServicesByServerEp(strconv.Itoa(id)), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
 }
 
 // DeliveryService gets the DeliveryService for the ID it's passed
+// Deprecated: use GetDeliveryService
 func (to *Session) DeliveryService(id string) (*tc.DeliveryService, error) {
+	ds, _, err := to.GetDeliveryService(id)
+	return ds, err
+}
+
+func (to *Session) GetDeliveryService(id string) (*tc.DeliveryService, ReqInf, error) {
 	var data tc.GetDeliveryServiceResponse
-	err := get(to, deliveryServiceEp(id), &data)
+	reqInf, err := get(to, deliveryServiceEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response[0], nil
+	return &data.Response[0], reqInf, nil
 }
 
 // CreateDeliveryService creates the DeliveryService it's passed
@@ -98,119 +116,170 @@ func (to *Session) DeleteDeliveryService(id string) (*tc.DeleteDeliveryServiceRe
 }
 
 // DeliveryServiceState gets the DeliveryServiceState for the ID it's passed
+// Deprecated: use GetDeliveryServiceState
 func (to *Session) DeliveryServiceState(id string) (*tc.DeliveryServiceState, error) {
+	dss, _, err := to.GetDeliveryServiceState(id)
+	return dss, err
+}
+
+func (to *Session) GetDeliveryServiceState(id string) (*tc.DeliveryServiceState, ReqInf, error) {
 	var data tc.DeliveryServiceStateResponse
-	err := get(to, deliveryServiceStateEp(id), &data)
+	reqInf, err := get(to, deliveryServiceStateEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceHealth gets the DeliveryServiceHealth for the ID it's passed
+// Deprecated: use GetDeliveryServiceHealth
 func (to *Session) DeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, error) {
+	dsh, _, err := to.GetDeliveryServiceHealth(id)
+	return dsh, err
+}
+
+func (to *Session) GetDeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, ReqInf, error) {
 	var data tc.DeliveryServiceHealthResponse
-	err := get(to, deliveryServiceHealthEp(id), &data)
+	reqInf, err := get(to, deliveryServiceHealthEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceCapacity gets the DeliveryServiceCapacity for the ID it's passed
+// Deprecated: use GetDeliveryServiceCapacity
 func (to *Session) DeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, error) {
+	dsc, _, err := to.GetDeliveryServiceCapacity(id)
+	return dsc, err
+}
+
+func (to *Session) GetDeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, ReqInf, error) {
 	var data tc.DeliveryServiceCapacityResponse
-	err := get(to, deliveryServiceCapacityEp(id), &data)
+	reqInf, err := get(to, deliveryServiceCapacityEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceRouting gets the DeliveryServiceRouting for the ID it's passed
+// Deprecated: use GetDeliveryServiceRouting
 func (to *Session) DeliveryServiceRouting(id string) (*tc.DeliveryServiceRouting, error) {
+	dsr, _, err := to.GetDeliveryServiceRouting(id)
+	return dsr, err
+}
+
+func (to *Session) GetDeliveryServiceRouting(id string) (*tc.DeliveryServiceRouting, ReqInf, error) {
 	var data tc.DeliveryServiceRoutingResponse
-	err := get(to, deliveryServiceRoutingEp(id), &data)
+	reqInf, err := get(to, deliveryServiceRoutingEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceServer gets the DeliveryServiceServer
+// Deprecated: use GetDeliveryServiceServer
 func (to *Session) DeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, error) {
-	var data tc.DeliveryServiceServerResponse
-	err := get(to, deliveryServiceServerEp(page, limit), &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data.Response, nil
+	dss, _, err := to.GetDeliveryServiceServer(page, limit)
+	return dss, err
 }
 
-// DeliveryServiceServer gets the DeliveryServiceServer
-func (to *Session) DeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, error) {
-	var data tc.DeliveryServiceRegexResponse
-	err := get(to, deliveryServiceRegexesEp(), &data)
+func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, ReqInf, error) {
+	var data tc.DeliveryServiceServerResponse
+	reqInf, err := get(to, deliveryServiceServerEp(page, limit), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
+}
+
+// DeliveryServiceRegexes gets the DeliveryService regexes
+// Deprecated: use GetDeliveryServiceRegexes
+func (to *Session) DeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, error) {
+	dsrs, _, err := to.GetDeliveryServiceRegexes()
+	return dsrs, err
+}
+func (to *Session) GetDeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, ReqInf, error) {
+	var data tc.DeliveryServiceRegexResponse
+	reqInf, err := get(to, deliveryServiceRegexesEp(), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
 }
 
 // DeliveryServiceSSLKeysByID gets the DeliveryServiceSSLKeys by ID
+// Deprecated: use GetDeliveryServiceSSLKeysByID
 func (to *Session) DeliveryServiceSSLKeysByID(id string) (*tc.DeliveryServiceSSLKeys, error) {
+	dsks, _, err := to.GetDeliveryServiceSSLKeysByID(id)
+	return dsks, err
+}
+
+func (to *Session) GetDeliveryServiceSSLKeysByID(id string) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
 	var data tc.DeliveryServiceSSLKeysResponse
-	err := get(to, deliveryServiceSSLKeysByIDEp(id), &data)
+	reqInf, err := get(to, deliveryServiceSSLKeysByIDEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceSSLKeysByHostname gets the DeliveryServiceSSLKeys by Hostname
+// Deprecated: use GetDeliveryServiceSSLKeysByHostname
 func (to *Session) DeliveryServiceSSLKeysByHostname(hostname string) (*tc.DeliveryServiceSSLKeys, error) {
-	var data tc.DeliveryServiceSSLKeysResponse
-	err := get(to, deliveryServiceSSLKeysByHostnameEp(hostname), &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return &data.Response, nil
+	dsks, _, err := to.GetDeliveryServiceSSLKeysByHostname(hostname)
+	return dsks, err
 }
 
-func get(to *Session, endpoint string, respStruct interface{}) error {
+func (to *Session) GetDeliveryServiceSSLKeysByHostname(hostname string) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
+	var data tc.DeliveryServiceSSLKeysResponse
+	reqInf, err := get(to, deliveryServiceSSLKeysByHostnameEp(hostname), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return &data.Response, reqInf, nil
+}
+
+func get(to *Session, endpoint string, respStruct interface{}) (ReqInf, error) {
 	return makeReq(to, "GET", endpoint, nil, respStruct)
 }
 
 func post(to *Session, endpoint string, body []byte, respStruct interface{}) error {
-	return makeReq(to, "POST", endpoint, body, respStruct)
+	_, err := makeReq(to, "POST", endpoint, body, respStruct)
+	return err
 }
 
 func put(to *Session, endpoint string, body []byte, respStruct interface{}) error {
-	return makeReq(to, "PUT", endpoint, body, respStruct)
+	_, err := makeReq(to, "PUT", endpoint, body, respStruct)
+	return err
 }
 
 func del(to *Session, endpoint string, respStruct interface{}) error {
-	return makeReq(to, "DELETE", endpoint, nil, respStruct)
+	_, err := makeReq(to, "DELETE", endpoint, nil, respStruct)
+	return err
 }
 
-func makeReq(to *Session, method, endpoint string, body []byte, respStruct interface{}) error {
-	resp, err := to.request(method, endpoint, body)
+func makeReq(to *Session, method, endpoint string, body []byte, respStruct interface{}) (ReqInf, error) {
+	resp, remoteAddr, err := to.request(method, endpoint, body) // TODO change to getBytesWithTTL
+	reqInf := ReqInf{RemoteAddr: remoteAddr, CacheHitStatus: CacheHitStatusMiss}
 	if err != nil {
-		return err
+		return reqInf, err
 	}
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(respStruct); err != nil {
-		return err
+		return reqInf, err
 	}
 
-	return nil
+	return reqInf, nil
 }

--- a/traffic_ops/client/hardware.go
+++ b/traffic_ops/client/hardware.go
@@ -23,21 +23,28 @@ import (
 )
 
 // Hardware gets an array of Hardware
+// Deprecated: use GetHardware
 func (to *Session) Hardware(limit int) ([]tc.Hardware, error) {
+	h, _, err := to.GetHardware(limit)
+	return h, err
+}
+
+func (to *Session) GetHardware(limit int) ([]tc.Hardware, ReqInf, error) {
 	url := "/api/1.2/hwinfo.json"
 	if limit > 0 {
 		url += fmt.Sprintf("?limit=%v", limit)
 	}
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.HardwareResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/parameter.go
+++ b/traffic_ops/client/parameter.go
@@ -23,18 +23,25 @@ import (
 )
 
 // Parameters gets an array of parameter structs for the profile given
+// Deprecated: use GetParameters
 func (to *Session) Parameters(profileName string) ([]tc.Parameter, error) {
+	ps, _, err := to.GetParameters(profileName)
+	return ps, err
+}
+
+func (to *Session) GetParameters(profileName string) ([]tc.Parameter, ReqInf, error) {
 	url := fmt.Sprintf("/api/1.2/parameters/profile/%s.json", profileName)
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.ParametersResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/profile.go
+++ b/traffic_ops/client/profile.go
@@ -22,18 +22,25 @@ import (
 )
 
 // Profiles gets an array of Profiles
+// Deprecated: use GetProfiles
 func (to *Session) Profiles() ([]tc.Profile, error) {
+	ps, _, err := to.GetProfiles()
+	return ps, err
+}
+
+func (to *Session) GetProfiles() ([]tc.Profile, ReqInf, error) {
 	url := "/api/1.2/profiles.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.ProfilesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/stats_summary.go
+++ b/traffic_ops/client/stats_summary.go
@@ -21,7 +21,13 @@ import (
 )
 
 // SummaryStats ...
+// Deprecated: use GetSummaryStats
 func (to *Session) SummaryStats(cdn string, deliveryService string, statName string) ([]tc.StatsSummary, error) {
+	ss, _, err := to.GetSummaryStats(cdn, deliveryService, statName)
+	return ss, err
+}
+
+func (to *Session) GetSummaryStats(cdn string, deliveryService string, statName string) ([]tc.StatsSummary, ReqInf, error) {
 	var queryParams []string
 	if len(cdn) > 0 {
 		queryParams = append(queryParams, fmt.Sprintf("cdnName=%s", cdn))
@@ -45,61 +51,75 @@ func (to *Session) SummaryStats(cdn string, deliveryService string, statName str
 		queryURL += queryParamString
 	}
 
-	resp, err := to.request("GET", queryURL, nil)
+	resp, remoteAddr, err := to.request("GET", queryURL, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.StatsSummaryResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }
 
 // SummaryStatsLastUpdated ...
+// Deprecated: use GetSummaryStatsLastUpdated
 func (to *Session) SummaryStatsLastUpdated(statName string) (string, error) {
+	s, _, err := to.GetSummaryStatsLastUpdated(statName)
+	return s, err
+}
+
+func (to *Session) GetSummaryStatsLastUpdated(statName string) (string, ReqInf, error) {
 	queryURL := "/api/1.2/stats_summary.json?lastSummaryDate=true"
 	if len(statName) > 0 {
 		queryURL += fmt.Sprintf("?statName=%s", statName)
 	}
 
-	resp, err := to.request("GET", queryURL, nil)
+	resp, remoteAddr, err := to.request("GET", queryURL, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return "", err
+		return "", reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.LastUpdated
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return "", err
+		return "", reqInf, err
 	}
 
 	if len(data.Response.SummaryTime) > 0 {
-		return data.Response.SummaryTime, nil
+		return data.Response.SummaryTime, reqInf, nil
 	}
 	t := "1970-01-01 00:00:00"
-	return t, nil
+	return t, reqInf, nil
 }
 
 // AddSummaryStats ...
+// Deprecated: use DoAddSummaryStats
 func (to *Session) AddSummaryStats(statsSummary tc.StatsSummary) error {
+	_, err := to.DoAddSummaryStats(statsSummary)
+	return err
+}
+func (to *Session) DoAddSummaryStats(statsSummary tc.StatsSummary) (ReqInf, error) {
 	reqBody, err := json.Marshal(statsSummary)
 	if err != nil {
-		return err
+		return ReqInf{}, err
 	}
 
 	url := "/api/1.2/stats_summary/create"
-	resp, err := to.request("POST", url, reqBody)
+	resp, remoteAddr, err := to.request("POST", url, reqBody)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return err
+		return reqInf, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		err := fmt.Errorf("Response code = %s and Status = %s", strconv.Itoa(resp.StatusCode), resp.Status)
-		return err
+		return reqInf, err
 	}
-	return nil
+	return reqInf, nil
 }

--- a/traffic_ops/client/traffic_monitor.go
+++ b/traffic_ops/client/traffic_monitor.go
@@ -27,31 +27,44 @@ import (
  */
 
 // TrafficMonitorConfigMap ...
+// Deprecated: use GetTrafficMonitorConfigMap
 func (to *Session) TrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, error) {
-	tmConfig, err := to.TrafficMonitorConfig(cdn)
+	m, _, err := to.GetTrafficMonitorConfigMap(cdn)
+	return m, err
+}
+
+func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, ReqInf, error) {
+	tmConfig, reqInf, err := to.GetTrafficMonitorConfig(cdn)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	tmConfigMap, err := tc.TrafficMonitorTransformToMap(tmConfig)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
-	return tmConfigMap, nil
+	return tmConfigMap, reqInf, nil
 }
 
 // TrafficMonitorConfig ...
+// Deprecated: use GetTrafficMonitorConfig
 func (to *Session) TrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, error) {
+	c, _, err := to.GetTrafficMonitorConfig(cdn)
+	return c, err
+}
+
+func (to *Session) GetTrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, ReqInf, error) {
 	url := fmt.Sprintf("/api/1.2/cdns/%s/configs/monitoring.json", cdn)
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.TMConfigResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }

--- a/traffic_ops/client/type.go
+++ b/traffic_ops/client/type.go
@@ -24,22 +24,28 @@ import (
 
 // Types gets an array of Types.
 // optional parameter: userInTable
+// Deprecated: use GetTypes
 func (to *Session) Types(useInTable ...string) ([]tc.Type, error) {
+	t, _, err := to.GetTypes(useInTable...)
+	return t, err
+}
 
+func (to *Session) GetTypes(useInTable ...string) ([]tc.Type, ReqInf, error) {
 	if len(useInTable) > 1 {
-		return nil, errors.New("Please pass in a single value for the 'useInTable' parameter")
+		return nil, ReqInf{}, errors.New("Please pass in a single value for the 'useInTable' parameter")
 	}
 
 	url := "/api/1.2/types.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.TypeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
 	var types []tc.Type
@@ -53,5 +59,5 @@ func (to *Session) Types(useInTable ...string) ([]tc.Type, error) {
 		}
 	}
 
-	return types, nil
+	return types, reqInf, nil
 }

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -22,18 +22,25 @@ import (
 )
 
 // Users gets an array of Users.
+// Deprecated: use GetUsers
 func (to *Session) Users() ([]tc.User, error) {
+	us, _, err := to.GetUsers()
+	return us, err
+}
+
+func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
 	url := "/api/1.2/users.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.UsersResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -416,7 +416,7 @@ func queryDB(con influx.Client, cmd string, database string) (res []influx.Resul
 }
 
 func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
-	to, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
+	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
 		log.Error(newErr)
@@ -430,7 +430,7 @@ func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
 
 func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 	var runningConfig RunningConfig
-	to, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
+	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
 	if err != nil {
 		msg := fmt.Sprintf("Error logging in to %v: %v", config.ToURL, err)
 		if init {


### PR DESCRIPTION
This makes it possible for clients to debug, for example, GSLB issues.