### PR TITLE
Add Traffic Monitor CRConfig history endpoint, rejecting bad configs

### DIFF
--- a/lib/go-tc/crconfig.go
+++ b/lib/go-tc/crconfig.go
@@ -1,0 +1,149 @@
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// CRConfig is JSON-serializable as the CRConfig used by Traffic Control.
+type CRConfig struct {
+	Config           CRConfigConfig                       `json:"config,omitempty"`
+	ContentServers   map[string]CRConfigTrafficOpsServer  `json:"contentServers,omitempty"`
+	ContentRouters   map[string]CRConfigRouter            `json:"contentRouters,omitempty"`
+	DeliveryServices map[string]CRConfigDeliveryService   `json:"deliveryServices,omitempty"`
+	EdgeLocations    map[string]CRConfigLatitudeLongitude `json:"edgeLocations,omitempty"`
+	Monitors         map[string]CRConfigMonitor           `json:"monitors,omitempty"`
+	Stats            CRConfigStats                        `json:"stats,omitempty"`
+}
+
+type CRConfigConfig struct {
+	APICacheControlMaxAge                      *string      `json:"api.cache-control.max_age,omitempty"`
+	ConsistentDNSRouting                       *string      `json:"consistent.dns.routing,omitempty"`
+	CoverageZonePollingIntervalSeconds         *string      `json:"coveragezone.polling.interval,omitempty"`
+	CoverageZonePollingURL                     *string      `json:"coveragezone.polling.url,omitempty"`
+	DNSSecDynamicResponseExpiration            *string      `json:"dnssec.dynamic.response.expiration,omitempty"`
+	DNSSecEnabled                              *string      `json:"dnssec.enabled,omitempty"`
+	DomainName                                 *string      `json:"domain_name,omitempty"`
+	FederationMappingPollingIntervalSeconds    *string      `json:"federationmapping.polling.interval,omitempty"`
+	FederationMappingPollingURL                *string      `json:"federationmapping.polling.url"`
+	GeoLocationPollingInterval                 *string      `json:"geolocation.polling.interval,omitempty"`
+	GeoLocationPollingURL                      *string      `json:"geolocation.polling.url,omitempty"`
+	KeyStoreMaintenanceIntervalSeconds         *string      `json:"keystore.maintenance.interval,omitempty"`
+	NeustarPollingIntervalSeconds              *string      `json:"neustar.polling.interval,omitempty"`
+	NeustarPollingURL                          *string      `json:"neustar.polling.url,omitempty"`
+	SOA                                        *SOA         `json:"soa,omitempty"`
+	DNSSecInceptionSeconds                     *string      `json:"dnssec.inception,omitempty"`
+	Ttls                                       *CRConfigTTL `json:"ttls,omitempty"`
+	Weight                                     *string      `json:"weight,omitempty"`
+	ZoneManagerCacheMaintenanceIntervalSeconds *string      `json:"zonemanager.cache.maintenance.interval,omitempty"`
+	ZoneManagerThreadpoolScale                 *string      `json:"zonemanager.threadpool.scale,omitempty"`
+}
+
+type CRConfigTTL struct {
+	ASeconds      *string `json:"A,omitempty"`
+	AAAASeconds   *string `json:"AAAA,omitempty"`
+	DNSkeySeconds *string `json:"DNSKEY,omitempty"`
+	DSSeconds     *string `json:"DS,omitempty"`
+	NSSeconds     *string `json:"NS,omitempty"`
+	SOASeconds    *string `json:"SOA,omitempty"`
+}
+
+type CRConfigRouterStatus string
+
+type CRConfigRouter struct {
+	APIPort      *string               `json:"apiPort,omitempty"`
+	FQDN         *string               `json:"fqdn,omitempty"`
+	HTTPSPort    *int                  `json:"httpsPort,omitempty"`
+	IP           *string               `json:"ip,omitempty"`
+	IP6          *string               `json:"ip6,omitempty"`
+	Location     *string               `json:"location,omitempty"`
+	Port         *int                  `json:"port,omitempty"`
+	Profile      *string               `json:"profile,omitempty"`
+	ServerStatus *CRConfigRouterStatus `json:"status,omitempty"`
+}
+
+type CRConfigServerStatus string
+
+type CRConfigTrafficOpsServer struct {
+	CacheGroup       *string               `json:"cacheGroup,omitempty"`
+	Fqdn             *string               `json:"fqdn,omitempty"`
+	HashCount        *int                  `json:"hashCount,omitempty"`
+	HashId           *string               `json:"hashId,omitempty"`
+	HttpsPort        *int                  `json:"httpsPort,omitempty"`
+	InterfaceName    *string               `json:"interfaceName,omitempty"`
+	Ip               *string               `json:"ip,omitempty"`
+	Ip6              *string               `json:"ip6,omitempty"`
+	LocationId       *string               `json:"locationId,omitempty"`
+	Port             *int                  `json:"port,omitempty"`
+	Profile          *string               `json:"profile,omitempty"`
+	ServerStatus     *CRConfigServerStatus `json:"status,omitempty"`
+	ServerType       *string               `json:"type,omitempty"`
+	DeliveryServices map[string][]string   `json:"deliveryServices,omitempty"`
+}
+
+//TODO: drichardson - reconcile this with the DeliveryService struct in deliveryservices.go
+type CRConfigDeliveryService struct {
+	CoverageZoneOnly    *string                          `json:"coverageZoneOnly,omitempty"`
+	Dispersion          *CRConfigDispersion              `json:"dispersion,omitempty"`
+	Domains             []string                         `json:"domains,omitempty"`
+	GeoLocationProvider *string                          `json:"geoLocationProvider,omitempty"`
+	MatchSets           []MatchSet                       `json:"matchSets,omitempty"`
+	MissLocation        *CRConfigLatitudeLongitude       `json:"missLocation,omitempty"`
+	Protocol            *CRConfigDeliveryServiceProtocol `json:"protocol,omitempty"`
+	RegionalGeoBlocking *string                          `json:"regionalGeoBlocking,omitempty"`
+	ResponseHeaders     map[string]string                `json:"responseHeaders,omitempty"`
+	Soa                 *SOA                             `json:"soa,omitempty"`
+	SSLEnabled          *string                          `json:"sslEnabled,omitempty"`
+	TTL                 *int                             `json:"ttl,omitempty"`
+	TTLs                *CRConfigTTL                     `json:"ttls,omitempty"`
+}
+
+type CRConfigDispersion struct {
+	Limit    int     `json:"limit,omitempty"`
+	Shuffled *string `json:"shuffled,omitempty"`
+}
+
+type CRConfigLatitudeLongitude struct {
+	Lat float64 `json:"latitude"`
+	Lon float64 `json:"longitude"`
+}
+
+type CRConfigDeliveryServiceProtocol struct {
+	AcceptHTTP      bool `json:"acceptHttp,string,omitempty"`
+	AcceptHTTPS     bool `json:"acceptHttps,string,omitempty"`
+	RedirectOnHTTPS bool `json:"redirectOnHttps,string,omitempty"`
+}
+
+type CRConfigMonitor struct {
+	FQDN         *string               `json:"fqdn,omitempty"`
+	HTTPSPort    *int                  `json:"httpsPort,omitempty"`
+	IP           *string               `json:"ip,omitempty"`
+	IP6          *string               `json:"ip6,omitempty"`
+	Location     *string               `json:"location,omitempty"`
+	Port         *int                  `json:"port,omitempty"`
+	Profile      *string               `json:"profile,omitempty"`
+	ServerStatus *CRConfigServerStatus `json:"status,omitempty"`
+}
+
+type CRConfigStats struct {
+	CDNName         *string `json:"CDN_name,omitempty"`
+	DateUnixSeconds *int64  `json:"date,omitempty"`
+	TMHost          *string `json:"tm_host,omitempty"`
+	TMPath          *string `json:"tm_path,omitempty"`
+	TMUser          *string `json:"tm_user,omitempty"`
+	TMVersion       *string `json:"tm_version,omitempty"`
+}

--- a/lib/go-tc/traffic_monitor.go
+++ b/lib/go-tc/traffic_monitor.go
@@ -66,8 +66,14 @@ type TrafficMonitor struct {
 // TMCacheGroup ...
 // !!! Note the lowercase!!! this is local to this file, there's a CacheGroup definition in cachegroup.go!
 type TMCacheGroup struct {
-	Name        string      `json:"name"`
-	Coordinates Coordinates `json:"coordinates"`
+	Name        string                `json:"name"`
+	Coordinates MonitoringCoordinates `json:"coordinates"`
+}
+
+// Coordinates ...
+type MonitoringCoordinates struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
 }
 
 // TMDeliveryService ...

--- a/lib/go-tc/traffic_router.go
+++ b/lib/go-tc/traffic_router.go
@@ -23,67 +23,6 @@ import (
 	"time"
 )
 
-// CRConfig is JSON-serializable as the CRConfig used by Traffic Control. However, it also contains diff timestamps, for the last update time of each field. These can be used to return only fields which have changed since a given time.
-type CRConfig struct {
-	Config               Config                       `json:"config,omitempty"`
-	ConfigTime           time.Time                    `json:"-"`
-	ContentServers       map[string]TrafficOpsServer  `json:"contentServers,omitempty"`
-	ContentServersTime   map[string]time.Time         `json:"-"`
-	ContentRouters       map[string]Router            `json:"contentRouters,omitempty"`
-	ContentRoutersTime   map[string]time.Time         `json:"-"`
-	DeliveryServices     map[string]DeliveryService   `json:"deliveryServices,omitempty"`
-	DeliveryServicesTime map[string]time.Time         `json:"-"`
-	EdgeLocations        map[string]LatitudeLongitude `json:"edgeLocations,omitempty"`
-	EdgeLocationsTime    map[string]time.Time         `json:"-"`
-	Monitors             map[string]Monitor           `json:"monitors,omitempty"`
-	MonitorsTime         map[string]time.Time         `json:"-"`
-	Stats                Stats                        `json:"stats,omitempty"`
-	StatsTime            time.Time                    `json:"-"`
-}
-
-type Config struct {
-	APICacheControlMaxAge                          *string   `json:"api.cache-control.max_age,omitempty"`
-	APICacheControlMaxAgeLastTime                  time.Time `json:"-"`
-	ConsistentDNSRouting                           *string   `json:"consistent.dns.routing,omitempty"`
-	ConsistentDNSRoutingTime                       time.Time `json:"-"`
-	CoverageZonePollingIntervalSeconds             *string   `json:"coveragezone.polling.interval,omitempty"`
-	CoverageZonePollingIntervalSecondsTime         time.Time `json:"-"`
-	CoverageZonePollingURL                         *string   `json:"coveragezone.polling.url,omitempty"`
-	CoverageZonePollingURLTime                     time.Time `json:"-"`
-	DNSSecDynamicResponseExpiration                *string   `json:"dnssec.dynamic.response.expiration,omitempty"`
-	DNSSecDynamicResponseExpirationTime            time.Time `json:"-"`
-	DNSSecEnabled                                  *string   `json:"dnssec.enabled,omitempty"`
-	DNSSecEnabledTime                              time.Time `json:"-"`
-	DomainName                                     *string   `json:"domain_name,omitempty"`
-	DomainNameTime                                 time.Time `json:"-"`
-	FederationMappingPollingIntervalSeconds        *string   `json:"federationmapping.polling.interval,omitempty"`
-	FederationMappingPollingIntervalSecondsTime    time.Time `json:"-"`
-	FederationMappingPollingURL                    *string   `json:"federationmapping.polling.url"`
-	FederationMappingPollingURLTime                time.Time `json:"-"`
-	GeoLocationPollingInterval                     *string   `json:"geolocation.polling.interval,omitempty"`
-	GeoLocationPollingIntervalTime                 time.Time `json:"-"`
-	GeoLocationPollingURL                          *string   `json:"geolocation.polling.url,omitempty"`
-	GeoLocationPollingURLTime                      time.Time `json:"-"`
-	KeyStoreMaintenanceIntervalSeconds             *string   `json:"keystore.maintenance.interval,omitempty"`
-	KeyStoreMaintenanceIntervalSecondsTime         time.Time `json:"-"`
-	NeustarPollingIntervalSeconds                  *string   `json:"neustar.polling.interval,omitempty"`
-	NeustarPollingIntervalSecondsTime              time.Time `json:"-"`
-	NeustarPollingURL                              *string   `json:"neustar.polling.url,omitempty"`
-	NeustarPollingURLTime                          time.Time `json:"-"`
-	SOA                                            *SOA      `json:"soa,omitempty"`
-	SOATime                                        time.Time `json:"-"`
-	DNSSecInceptionSeconds                         *string   `json:"dnssec.inception,omitempty"`
-	DNSSecInceptionSecondsTime                     time.Time `json:"-"`
-	Ttls                                           *TTL      `json:"ttls,omitempty"`
-	TtlsTime                                       time.Time `json:"-"`
-	Weight                                         *string   `json:"weight,omitempty"`
-	WeightTime                                     time.Time `json:"-"`
-	ZoneManagerCacheMaintenanceIntervalSeconds     *string   `json:"zonemanager.cache.maintenance.interval,omitempty"`
-	ZoneManagerCacheMaintenanceIntervalSecondsTime time.Time `json:"-"`
-	ZoneManagerThreadpoolScale                     *string   `json:"zonemanager.threadpool.scale,omitempty"`
-	ZoneManagerThreadpoolScaleTime                 time.Time `json:"-"`
-}
-
 type SOA struct {
 	Admin              *string `json:"admin,omitempty"`
 	AdminTime          time.Time
@@ -97,107 +36,10 @@ type SOA struct {
 	RetrySecondsTime   time.Time
 }
 
-type TTL struct {
-	ASeconds          *string `json:"A,omitempty"`
-	ASecondsTime      time.Time
-	AAAASeconds       *string `json:"AAAA,omitempty"`
-	AAAASecondsTime   time.Time
-	DNSkeySeconds     *string `json:"DNSKEY,omitempty"`
-	DNSkeySecondsTime time.Time
-	DSSeconds         *string `json:"DS,omitempty"`
-	DSSecondsTime     time.Time
-	NSSeconds         *string `json:"NS,omitempty"`
-	NSSecondsTime     time.Time
-	SOASeconds        *string `json:"SOA,omitempty"`
-	SOASecondsTime    time.Time
-}
-
-type Router struct {
-	APIPort          *string `json:"apiPort,omitempty"`
-	APIPortTime      time.Time
-	FQDN             *string `json:"fqdn,omitempty"`
-	FQDNTime         time.Time
-	HTTPSPort        *int `json:"httpsPort,omitempty"`
-	HTTPSPortTime    time.Time
-	IP               *string `json:"ip,omitempty"`
-	IPTime           time.Time
-	IP6              *string `json:"ip6,omitempty"`
-	IP6Time          time.Time
-	Location         *string `json:"location,omitempty"`
-	LocationTime     time.Time
-	Port             *int `json:"port,omitempty"`
-	PortTime         time.Time
-	Profile          *string `json:"profile,omitempty"`
-	ProfileTime      time.Time
-	ServerStatus     *ServerStatus `json:"status,omitempty"`
-	ServerStatusTime time.Time
-}
-
-type ServerStatus string
-
-type TrafficOpsServer struct {
-	CacheGroup        *string       `json:"cacheGroup,omitempty"`
-	CacheGroupTime    time.Time     `json:"-"`
-	Fqdn              *string       `json:"fqdn,omitempty"`
-	FqdnTime          time.Time     `json:"-"`
-	HashCount         *int          `json:"hashCount,omitempty"`
-	HashCountTime     time.Time     `json:"-"`
-	HashId            *string       `json:"hashId,omitempty"`
-	HashIdTime        time.Time     `json:"-"`
-	HttpsPort         *int          `json:"httpsPort,omitempty"`
-	HttpsPortTime     time.Time     `json:"-"`
-	InterfaceName     *string       `json:"interfaceName,omitempty"`
-	InterfaceNameTime time.Time     `json:"-"`
-	Ip                *string       `json:"ip,omitempty"`
-	IpTime            time.Time     `json:"-"`
-	Ip6               *string       `json:"ip6,omitempty"`
-	Ip6Time           time.Time     `json:"-"`
-	LocationId        *string       `json:"locationId,omitempty"`
-	LocationIdTime    time.Time     `json:"-"`
-	Port              *int          `json:"port,omitempty"`
-	PortTime          time.Time     `json:"-"`
-	Profile           *string       `json:"profile,omitempty"`
-	ProfileTime       time.Time     `json:"-"`
-	ServerStatus      *ServerStatus `json:"status,omitempty"`
-	ServerStatusTime  time.Time     `json:"-"`
-	ServerType        *string       `json:"type,omitempty"`
-	ServerTypeTime    time.Time     `json:"-"`
-}
-
-//TODO: drichardson - reconcile this with the DeliveryService struct in deliveryservices.go
-type DeliveryServiceRouter struct {
-	CoverageZoneOnly        *string                  `json:"coverageZoneOnly,omitempty"`
-	CoverageZoneOnlyTime    time.Time                `json:"-"`
-	Dispersion              *Dispersion              `json:"dispersion,omitempty"`
-	DispersionTime          time.Time                `json:"-"`
-	Domains                 []string                 `json:"domains,omitempty"`
-	DomainsTime             time.Time                `json:"-"`
-	GeoLocationProvider     *string                  `json:"geoLocationProvider,omitempty"`
-	GeoLocationProviderTime time.Time                `json:"-"`
-	MatchSets               []MatchSet               `json:"matchSets,omitempty"`
-	MatchSetsTime           time.Time                `json:"-"`
-	MissLocation            *LatitudeLongitude       `json:"missLocation,omitempty"`
-	MissLocationTime        time.Time                `json:"-"`
-	Protocol                *DeliveryServiceProtocol `json:"protocol,omitempty"`
-	ProtocolTime            time.Time                `json:"-"`
-	RegionalGeoBlocking     *string                  `json:"regionalGeoBlocking,omitempty"`
-	RegionalGeoBlockingTime time.Time                `json:"-"`
-	ResponseHeaders         map[string]string        `json:"responseHeaders,omitempty"`
-	ResponseHeadersTime     time.Time                `json:"-"`
-	Soa                     *SOA                     `json:"soa,omitempty"`
-	SoaTime                 time.Time                `json:"-"`
-	SSLEnabled              *string                  `json:"sslEnabled,omitempty"`
-	SSLEnabledTime          time.Time                `json:"-"`
-	TTL                     *int                     `json:"ttl,omitempty"`
-	TTLTime                 time.Time                `json:"-"`
-	TTLs                    *TTL                     `json:"ttls,omitempty"`
-	TTLsTime                time.Time                `json:"-"`
-}
-
 // MissLocation ...
 type MissLocation struct {
 	Latitude  float64 `json:"latitude"`
-	Longitude float64 `json:"longitudef"`
+	Longitude float64 `json:"longitude"`
 }
 
 // MatchSet ...
@@ -225,56 +67,6 @@ type TTLS struct {
 	SoaRecord  int `json:"SOA"`
 	NsRecord   int `json:"NS"`
 	AaaaRecord int `json:"AAAA"`
-}
-
-type Dispersion struct {
-	Limit    int     `json:"limit,omitempty"`
-	Shuffled *string `json:"shuffled,omitempty"`
-}
-
-type LatitudeLongitude struct {
-	Lat float64 `json:"latitude"`
-	Lon float64 `json:"longitude"`
-}
-
-type DeliveryServiceProtocol struct {
-	AcceptHTTP      bool `json:"acceptHttp,string,omitempty"`
-	AcceptHTTPS     bool `json:"acceptHttps,string,omitempty"`
-	RedirectOnHTTPS bool `json:"redirectOnHttps,string,omitempty"`
-}
-
-type Monitor struct {
-	FQDN             *string       `json:"fqdn,omitempty"`
-	FQDNTime         time.Time     `json:"-"`
-	HTTPSPort        *int          `json:"httpsPort,omitempty"`
-	HTTPSPortTime    time.Time     `json:"-"`
-	IP               *string       `json:"ip,omitempty"`
-	IPTime           time.Time     `json:"-"`
-	IP6              *string       `json:"ip6,omitempty"`
-	IP6Time          time.Time     `json:"-"`
-	Location         *string       `json:"location,omitempty"`
-	LocationTime     time.Time     `json:"-"`
-	Port             *int          `json:"port,omitempty"`
-	PortTime         time.Time     `json:"-"`
-	Profile          *string       `json:"profile,omitempty"`
-	ProfileTime      time.Time     `json:"-"`
-	ServerStatus     *ServerStatus `json:"status,omitempty"`
-	ServerStatusTime time.Time     `json:"-"`
-}
-
-type Stats struct {
-	CDNName             *string   `json:"CDN_name,omitempty"`
-	CDNNameTime         time.Time `json:"-"`
-	DateUnixSeconds     *int64    `json:"date,omitempty"`
-	DateUnixSecondsTime time.Time `json:"-"`
-	TMHost              *string   `json:"tm_host,omitempty"`
-	TMHostTime          time.Time `json:"-"`
-	TMPath              *string   `json:"tm_path,omitempty"`
-	TMPathTime          time.Time `json:"-"`
-	TMUser              *string   `json:"tm_user,omitempty"`
-	TMUserTime          time.Time `json:"-"`
-	TMVersion           *string   `json:"tm_version,omitempty"`
-	TMVersionTime       time.Time `json:"-"`
 }
 
 // TrafficRouter ...
@@ -334,12 +126,6 @@ type StaticDNS struct {
 	TTL   int    `json:"ttl"`
 	Name  string `json:"name"`
 	Type  string `json:"type"`
-}
-
-// Coordinates ...
-type Coordinates struct {
-	Latitude  float64 `json:"latitude"`
-	Longitude float64 `json:"longitude"`
 }
 
 // TrafficServer ...

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	ServeWriteTimeout            time.Duration `json:"-"`
 	HealthToStatRatio            uint64        `json:"health_to_stat_ratio"`
 	StaticFileDir                string        `json:"static_file_dir"`
+	CRConfigHistoryCount         uint64        `json:"crconfig_history_count"`
 }
 
 func (c Config) ErrorLog() log.LogLocation   { return log.LogLocation(c.LogLocationError) }
@@ -93,6 +94,7 @@ var DefaultConfig = Config{
 	ServeWriteTimeout:            10 * time.Second,
 	HealthToStatRatio:            4,
 	StaticFileDir:                StaticFileDir,
+	CRConfigHistoryCount:         20000,
 }
 
 // MarshalJSON marshals custom millisecond durations. Aliasing inspired by http://choly.ca/post/go-json-marshalling/

--- a/traffic_monitor/datareq/crconfighist.go
+++ b/traffic_monitor/datareq/crconfighist.go
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package datareq
+
+import (
+	"encoding/json"
+
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/towrap"
+)
+
+func srvAPICRConfigHist(toc towrap.ITrafficOpsSession) ([]byte, error) {
+	return json.Marshal(toc.CRConfigHistory())
+}

--- a/traffic_monitor/datareq/datareq.go
+++ b/traffic_monitor/datareq/datareq.go
@@ -125,6 +125,9 @@ func MakeDispatchMap(
 		"/api/monitor-config": wrap(WrapErr(errorCount, func() ([]byte, error) {
 			return srvMonitorConfig(monitorConfig)
 		}, ContentTypeJSON)),
+		"/api/crconfig-history": wrap(WrapErr(errorCount, func() ([]byte, error) {
+			return srvAPICRConfigHist(toSession)
+		}, ContentTypeJSON)),
 	}
 	return addTrailingSlashEndpoints(dispatchMap)
 }

--- a/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/manager/manager.go
@@ -45,7 +45,7 @@ import (
 // Start starts the poller and handler goroutines
 //
 func Start(opsConfigFile string, cfg config.Config, staticAppData config.StaticAppData, trafficMonitorConfigFileName string) error {
-	toSession := towrap.ITrafficOpsSession(towrap.NewTrafficOpsSessionThreadsafe(nil))
+	toSession := towrap.ITrafficOpsSession(towrap.NewTrafficOpsSessionThreadsafe(nil, cfg.CRConfigHistoryCount))
 	sharedClient := &http.Client{
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
 		Timeout:   cfg.HTTPTimeout,

--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -133,7 +133,7 @@ func StartOpsConfigManager(
 		useCache := false
 		trafficOpsRequestTimeout := time.Second * time.Duration(10)
 
-		realToSession, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
+		realToSession, _, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
 		if err != nil {
 			handleErr(fmt.Errorf("MonitorConfigPoller: error instantiating Session with traffic_ops: %s\n", err))
 			return

--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -133,9 +133,9 @@ func StartOpsConfigManager(
 		useCache := false
 		trafficOpsRequestTimeout := time.Second * time.Duration(10)
 
-		realToSession, _, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
+		realToSession, toAddr, err := to.LoginWithAgent(newOpsConfig.Url, newOpsConfig.Username, newOpsConfig.Password, newOpsConfig.Insecure, staticAppData.UserAgent, useCache, trafficOpsRequestTimeout)
 		if err != nil {
-			handleErr(fmt.Errorf("MonitorConfigPoller: error instantiating Session with traffic_ops: %s\n", err))
+			handleErr(fmt.Errorf("MonitorConfigPoller: error instantiating Session with traffic_ops (%v): %s\n", toAddr, err))
 			return
 		}
 		toSession.Set(realToSession)

--- a/traffic_monitor/static/index.html
+++ b/traffic_monitor/static/index.html
@@ -508,6 +508,7 @@ under the License.
 				<li class="endpoint"><a href="/api/bandwidth-kbps">/api/bandwidth-kbps</a></li>
 				<li class="endpoint"><a href="/api/bandwidth-capacity-kbps">/api/bandwidth-capacity-kbps</a></li>
 				<li class="endpoint"><a href="/api/monitor-config">/api/monitor-config</a></li>
+				<li class="endpoint"><a href="/api/crconfig-history">/api/crconfig-history</a></li>
 			</ul>
 		</div>
 

--- a/traffic_monitor/tools/nagios-validate-deliveryservices.go
+++ b/traffic_monitor/tools/nagios-validate-deliveryservices.go
@@ -43,7 +43,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_monitor/tools/nagios-validate-offline.go
+++ b/traffic_monitor/tools/nagios-validate-offline.go
@@ -43,7 +43,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_monitor/tools/nagios-validate-peerpoller.go
+++ b/traffic_monitor/tools/nagios-validate-peerpoller.go
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_monitor/tools/nagios-validate-queryinterval.go
+++ b/traffic_monitor/tools/nagios-validate-queryinterval.go
@@ -42,7 +42,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_monitor/tools/validator-service.go
+++ b/traffic_monitor/tools/validator-service.go
@@ -149,7 +149,7 @@ func main() {
 		return
 	}
 
-	toClient, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
+	toClient, _, err := to.LoginWithAgent(*toURI, *toUser, *toPass, true, UserAgent, false, tmcheck.RequestTimeout)
 	if err != nil {
 		fmt.Printf("Error logging in to Traffic Ops: %v\n", err)
 		return

--- a/traffic_ops/client/cachegroup.go
+++ b/traffic_ops/client/cachegroup.go
@@ -23,18 +23,25 @@ import (
 
 // CacheGroups gets the CacheGroups in an array of CacheGroup structs
 // (note CacheGroup used to be called location)
+// Deprecated: use GetCacheGroups.
 func (to *Session) CacheGroups() ([]tc.CacheGroup, error) {
+	cgs, _, err := to.GetCacheGroups()
+	return cgs, err
+}
+
+func (to *Session) GetCacheGroups() ([]tc.CacheGroup, ReqInf, error) {
 	url := "/api/1.2/cachegroups.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil) // TODO change to getBytesWithTTL, return CacheHitStatus
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.CacheGroupsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/cdn.go
+++ b/traffic_ops/client/cdn.go
@@ -22,50 +22,71 @@ import (
 	tc "github.com/apache/incubator-trafficcontrol/lib/go-tc"
 )
 
+// Deprecated: use GetCDNs.
 func (to *Session) CDNs() ([]tc.CDN, error) {
+	cdns, _, err := to.GetCDNs()
+	return cdns, err
+}
+
+func (to *Session) GetCDNs() ([]tc.CDN, ReqInf, error) {
 	url := "/api/1.2/cdns.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil) // TODO change to getBytesWithTTL, which caches
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.CDNsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }
 
 // CDNName gets an array of CDNs
+// Deprecated: use GetCDNName
 func (to *Session) CDNName(name string) ([]tc.CDN, error) {
+	n, _, err := to.GetCDNName(name)
+	return n, err
+}
+
+func (to *Session) GetCDNName(name string) ([]tc.CDN, ReqInf, error) {
 	url := fmt.Sprintf("/api/1.2/cdns/name/%s.json", name)
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil) // TODO change to getBytesWithTTL, return CacheHitStatus
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.CDNsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }
 
+// Deprecated: use GetCDNSSLKeys
 func (to *Session) CDNSSLKeys(name string) ([]tc.CDNSSLKeys, error) {
+	ks, _, err := to.GetCDNSSLKeys(name)
+	return ks, err
+}
+
+func (to *Session) GetCDNSSLKeys(name string) ([]tc.CDNSSLKeys, ReqInf, error) {
 	url := fmt.Sprintf("/api/1.2/cdns/name/%s/sslkeys.json", name)
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil) // TODO change to getBytesWithTTL, return CacheHitStatus
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.CDNSSLKeysResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/crconfig.go
+++ b/traffic_ops/client/crconfig.go
@@ -24,7 +24,7 @@ func (to *Session) CRConfigRaw(cdn string) ([]byte, error) {
 }
 
 // GetCRConfig returns the raw JSON bytes of the CRConfig from Traffic Ops, and whether the bytes were from the client's internal cache.
-func (to *Session) GetCRConfig(cdn string) ([]byte, CacheHitStatus, error) {
+func (to *Session) GetCRConfig(cdn string) ([]byte, ReqInf, error) {
 	url := fmt.Sprintf("/CRConfig-Snapshots/%s/CRConfig.json", cdn)
 	return to.getBytesWithTTL(url, tmPollingInterval)
 }

--- a/traffic_ops/client/delivery_service.go
+++ b/traffic_ops/client/delivery_service.go
@@ -23,36 +23,54 @@ import (
 )
 
 // DeliveryServices gets an array of DeliveryServices
+// Deprecated: use GetDeliveryServices
 func (to *Session) DeliveryServices() ([]tc.DeliveryService, error) {
-	var data tc.GetDeliveryServiceResponse
-	err := get(to, deliveryServicesEp(), &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data.Response, nil
+	dses, _, err := to.GetDeliveryServices()
+	return dses, err
 }
 
-// DeliveryServices gets an array of DeliveryServices
-func (to *Session) DeliveryServicesByServer(id int) ([]tc.DeliveryService, error) {
+func (to *Session) GetDeliveryServices() ([]tc.DeliveryService, ReqInf, error) {
 	var data tc.GetDeliveryServiceResponse
-	err := get(to, deliveryServicesByServerEp(strconv.Itoa(id)), &data)
+	reqInf, err := get(to, deliveryServicesEp(), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
+}
+
+// DeliveryServicesByServer gets an array of all DeliveryServices with the given server ID assigend.
+// Deprecated: use GetDeliveryServicesByServer
+func (to *Session) DeliveryServicesByServer(id int) ([]tc.DeliveryService, error) {
+	dses, _, err := to.GetDeliveryServicesByServer(id)
+	return dses, err
+}
+
+func (to *Session) GetDeliveryServicesByServer(id int) ([]tc.DeliveryService, ReqInf, error) {
+	var data tc.GetDeliveryServiceResponse
+	reqInf, err := get(to, deliveryServicesByServerEp(strconv.Itoa(id)), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
 }
 
 // DeliveryService gets the DeliveryService for the ID it's passed
+// Deprecated: use GetDeliveryService
 func (to *Session) DeliveryService(id string) (*tc.DeliveryService, error) {
+	ds, _, err := to.GetDeliveryService(id)
+	return ds, err
+}
+
+func (to *Session) GetDeliveryService(id string) (*tc.DeliveryService, ReqInf, error) {
 	var data tc.GetDeliveryServiceResponse
-	err := get(to, deliveryServiceEp(id), &data)
+	reqInf, err := get(to, deliveryServiceEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response[0], nil
+	return &data.Response[0], reqInf, nil
 }
 
 // CreateDeliveryService creates the DeliveryService it's passed
@@ -98,89 +116,136 @@ func (to *Session) DeleteDeliveryService(id string) (*tc.DeleteDeliveryServiceRe
 }
 
 // DeliveryServiceState gets the DeliveryServiceState for the ID it's passed
+// Deprecated: use GetDeliveryServiceState
 func (to *Session) DeliveryServiceState(id string) (*tc.DeliveryServiceState, error) {
+	dss, _, err := to.GetDeliveryServiceState(id)
+	return dss, err
+}
+
+func (to *Session) GetDeliveryServiceState(id string) (*tc.DeliveryServiceState, ReqInf, error) {
 	var data tc.DeliveryServiceStateResponse
-	err := get(to, deliveryServiceStateEp(id), &data)
+	reqInf, err := get(to, deliveryServiceStateEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceHealth gets the DeliveryServiceHealth for the ID it's passed
+// Deprecated: use GetDeliveryServiceHealth
 func (to *Session) DeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, error) {
+	dsh, _, err := to.GetDeliveryServiceHealth(id)
+	return dsh, err
+}
+
+func (to *Session) GetDeliveryServiceHealth(id string) (*tc.DeliveryServiceHealth, ReqInf, error) {
 	var data tc.DeliveryServiceHealthResponse
-	err := get(to, deliveryServiceHealthEp(id), &data)
+	reqInf, err := get(to, deliveryServiceHealthEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceCapacity gets the DeliveryServiceCapacity for the ID it's passed
+// Deprecated: use GetDeliveryServiceCapacity
 func (to *Session) DeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, error) {
+	dsc, _, err := to.GetDeliveryServiceCapacity(id)
+	return dsc, err
+}
+
+func (to *Session) GetDeliveryServiceCapacity(id string) (*tc.DeliveryServiceCapacity, ReqInf, error) {
 	var data tc.DeliveryServiceCapacityResponse
-	err := get(to, deliveryServiceCapacityEp(id), &data)
+	reqInf, err := get(to, deliveryServiceCapacityEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceRouting gets the DeliveryServiceRouting for the ID it's passed
+// Deprecated: use GetDeliveryServiceRouting
 func (to *Session) DeliveryServiceRouting(id string) (*tc.DeliveryServiceRouting, error) {
+	dsr, _, err := to.GetDeliveryServiceRouting(id)
+	return dsr, err
+}
+
+func (to *Session) GetDeliveryServiceRouting(id string) (*tc.DeliveryServiceRouting, ReqInf, error) {
 	var data tc.DeliveryServiceRoutingResponse
-	err := get(to, deliveryServiceRoutingEp(id), &data)
+	reqInf, err := get(to, deliveryServiceRoutingEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceServer gets the DeliveryServiceServer
+// Deprecated: use GetDeliveryServiceServer
 func (to *Session) DeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, error) {
-	var data tc.DeliveryServiceServerResponse
-	err := get(to, deliveryServiceServerEp(page, limit), &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data.Response, nil
+	dss, _, err := to.GetDeliveryServiceServer(page, limit)
+	return dss, err
 }
 
-// DeliveryServiceServer gets the DeliveryServiceServer
-func (to *Session) DeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, error) {
-	var data tc.DeliveryServiceRegexResponse
-	err := get(to, deliveryServiceRegexesEp(), &data)
+func (to *Session) GetDeliveryServiceServer(page, limit string) ([]tc.DeliveryServiceServer, ReqInf, error) {
+	var data tc.DeliveryServiceServerResponse
+	reqInf, err := get(to, deliveryServiceServerEp(page, limit), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
+}
+
+// DeliveryServiceRegexes gets the DeliveryService regexes
+// Deprecated: use GetDeliveryServiceRegexes
+func (to *Session) DeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, error) {
+	dsrs, _, err := to.GetDeliveryServiceRegexes()
+	return dsrs, err
+}
+func (to *Session) GetDeliveryServiceRegexes() ([]tc.DeliveryServiceRegexes, ReqInf, error) {
+	var data tc.DeliveryServiceRegexResponse
+	reqInf, err := get(to, deliveryServiceRegexesEp(), &data)
+	if err != nil {
+		return nil, reqInf, err
+	}
+
+	return data.Response, reqInf, nil
 }
 
 // DeliveryServiceSSLKeysByID gets the DeliveryServiceSSLKeys by ID
+// Deprecated: use GetDeliveryServiceSSLKeysByID
 func (to *Session) DeliveryServiceSSLKeysByID(id string) (*tc.DeliveryServiceSSLKeys, error) {
+	dsks, _, err := to.GetDeliveryServiceSSLKeysByID(id)
+	return dsks, err
+}
+
+func (to *Session) GetDeliveryServiceSSLKeysByID(id string) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
 	var data tc.DeliveryServiceSSLKeysResponse
-	err := get(to, deliveryServiceSSLKeysByIDEp(id), &data)
+	reqInf, err := get(to, deliveryServiceSSLKeysByIDEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }
 
 // DeliveryServiceSSLKeysByHostname gets the DeliveryServiceSSLKeys by Hostname
+// Deprecated: use GetDeliveryServiceSSLKeysByHostname
 func (to *Session) DeliveryServiceSSLKeysByHostname(hostname string) (*tc.DeliveryServiceSSLKeys, error) {
+	dsks, _, err := to.GetDeliveryServiceSSLKeysByHostname(hostname)
+	return dsks, err
+}
+
+func (to *Session) GetDeliveryServiceSSLKeysByHostname(hostname string) (*tc.DeliveryServiceSSLKeys, ReqInf, error) {
 	var data tc.DeliveryServiceSSLKeysResponse
-	err := get(to, deliveryServiceSSLKeysByHostnameEp(hostname), &data)
+	reqInf, err := get(to, deliveryServiceSSLKeysByHostnameEp(hostname), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }

--- a/traffic_ops/client/hardware.go
+++ b/traffic_ops/client/hardware.go
@@ -23,21 +23,28 @@ import (
 )
 
 // Hardware gets an array of Hardware
+// Deprecated: use GetHardware
 func (to *Session) Hardware(limit int) ([]tc.Hardware, error) {
+	h, _, err := to.GetHardware(limit)
+	return h, err
+}
+
+func (to *Session) GetHardware(limit int) ([]tc.Hardware, ReqInf, error) {
 	url := "/api/1.2/hwinfo.json"
 	if limit > 0 {
 		url += fmt.Sprintf("?limit=%v", limit)
 	}
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.HardwareResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/parameter.go
+++ b/traffic_ops/client/parameter.go
@@ -23,18 +23,25 @@ import (
 )
 
 // Parameters gets an array of parameter structs for the profile given
+// Deprecated: use GetParameters
 func (to *Session) Parameters(profileName string) ([]tc.Parameter, error) {
+	ps, _, err := to.GetParameters(profileName)
+	return ps, err
+}
+
+func (to *Session) GetParameters(profileName string) ([]tc.Parameter, ReqInf, error) {
 	url := fmt.Sprintf("/api/1.2/parameters/profile/%s.json", profileName)
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.ParametersResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/profile.go
+++ b/traffic_ops/client/profile.go
@@ -22,18 +22,25 @@ import (
 )
 
 // Profiles gets an array of Profiles
+// Deprecated: use GetProfiles
 func (to *Session) Profiles() ([]tc.Profile, error) {
+	ps, _, err := to.GetProfiles()
+	return ps, err
+}
+
+func (to *Session) GetProfiles() ([]tc.Profile, ReqInf, error) {
 	url := "/api/1.2/profiles.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.ProfilesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/stats_summary.go
+++ b/traffic_ops/client/stats_summary.go
@@ -21,7 +21,13 @@ import (
 )
 
 // SummaryStats ...
+// Deprecated: use GetSummaryStats
 func (to *Session) SummaryStats(cdn string, deliveryService string, statName string) ([]tc.StatsSummary, error) {
+	ss, _, err := to.GetSummaryStats(cdn, deliveryService, statName)
+	return ss, err
+}
+
+func (to *Session) GetSummaryStats(cdn string, deliveryService string, statName string) ([]tc.StatsSummary, ReqInf, error) {
 	var queryParams []string
 	if len(cdn) > 0 {
 		queryParams = append(queryParams, fmt.Sprintf("cdnName=%s", cdn))
@@ -45,61 +51,75 @@ func (to *Session) SummaryStats(cdn string, deliveryService string, statName str
 		queryURL += queryParamString
 	}
 
-	resp, err := to.request("GET", queryURL, nil)
+	resp, remoteAddr, err := to.request("GET", queryURL, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.StatsSummaryResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }
 
 // SummaryStatsLastUpdated ...
+// Deprecated: use GetSummaryStatsLastUpdated
 func (to *Session) SummaryStatsLastUpdated(statName string) (string, error) {
+	s, _, err := to.GetSummaryStatsLastUpdated(statName)
+	return s, err
+}
+
+func (to *Session) GetSummaryStatsLastUpdated(statName string) (string, ReqInf, error) {
 	queryURL := "/api/1.2/stats_summary.json?lastSummaryDate=true"
 	if len(statName) > 0 {
 		queryURL += fmt.Sprintf("?statName=%s", statName)
 	}
 
-	resp, err := to.request("GET", queryURL, nil)
+	resp, remoteAddr, err := to.request("GET", queryURL, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return "", err
+		return "", reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.LastUpdated
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return "", err
+		return "", reqInf, err
 	}
 
 	if len(data.Response.SummaryTime) > 0 {
-		return data.Response.SummaryTime, nil
+		return data.Response.SummaryTime, reqInf, nil
 	}
 	t := "1970-01-01 00:00:00"
-	return t, nil
+	return t, reqInf, nil
 }
 
 // AddSummaryStats ...
+// Deprecated: use DoAddSummaryStats
 func (to *Session) AddSummaryStats(statsSummary tc.StatsSummary) error {
+	_, err := to.DoAddSummaryStats(statsSummary)
+	return err
+}
+func (to *Session) DoAddSummaryStats(statsSummary tc.StatsSummary) (ReqInf, error) {
 	reqBody, err := json.Marshal(statsSummary)
 	if err != nil {
-		return err
+		return ReqInf{}, err
 	}
 
 	url := "/api/1.2/stats_summary/create"
-	resp, err := to.request("POST", url, reqBody)
+	resp, remoteAddr, err := to.request("POST", url, reqBody)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return err
+		return reqInf, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		err := fmt.Errorf("Response code = %s and Status = %s", strconv.Itoa(resp.StatusCode), resp.Status)
-		return err
+		return reqInf, err
 	}
-	return nil
+	return reqInf, nil
 }

--- a/traffic_ops/client/tenant.go
+++ b/traffic_ops/client/tenant.go
@@ -22,25 +22,25 @@ import (
 )
 
 // Tenants gets an array of Tenants
-func (to *Session) Tenants() ([]tc.Tenant, error) {
+func (to *Session) Tenants() ([]tc.Tenant, ReqInf, error) {
 	var data tc.GetTenantsResponse
-	err := get(to, tenantsEp(), &data)
+	reqInf, err := get(to, tenantsEp(), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }
 
 // Tenant gets the Tenant for the ID it's passed
-func (to *Session) Tenant(id string) (*tc.Tenant, error) {
+func (to *Session) Tenant(id string) (*tc.Tenant, ReqInf, error) {
 	var data tc.GetTenantsResponse
-	err := get(to, tenantEp(id), &data)
+	reqInf, err := get(to, tenantEp(id), &data)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response[0], nil
+	return &data.Response[0], reqInf, nil
 }
 
 // CreateTenant creates the Tenant it's passed

--- a/traffic_ops/client/traffic_monitor.go
+++ b/traffic_ops/client/traffic_monitor.go
@@ -27,31 +27,44 @@ import (
  */
 
 // TrafficMonitorConfigMap ...
+// Deprecated: use GetTrafficMonitorConfigMap
 func (to *Session) TrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, error) {
-	tmConfig, err := to.TrafficMonitorConfig(cdn)
+	m, _, err := to.GetTrafficMonitorConfigMap(cdn)
+	return m, err
+}
+
+func (to *Session) GetTrafficMonitorConfigMap(cdn string) (*tc.TrafficMonitorConfigMap, ReqInf, error) {
+	tmConfig, reqInf, err := to.GetTrafficMonitorConfig(cdn)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	tmConfigMap, err := tc.TrafficMonitorTransformToMap(tmConfig)
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
-	return tmConfigMap, nil
+	return tmConfigMap, reqInf, nil
 }
 
 // TrafficMonitorConfig ...
+// Deprecated: use GetTrafficMonitorConfig
 func (to *Session) TrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, error) {
+	c, _, err := to.GetTrafficMonitorConfig(cdn)
+	return c, err
+}
+
+func (to *Session) GetTrafficMonitorConfig(cdn string) (*tc.TrafficMonitorConfig, ReqInf, error) {
 	url := fmt.Sprintf("/api/1.2/cdns/%s/configs/monitoring.json", cdn)
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.TMConfigResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return &data.Response, nil
+	return &data.Response, reqInf, nil
 }

--- a/traffic_ops/client/type.go
+++ b/traffic_ops/client/type.go
@@ -24,22 +24,28 @@ import (
 
 // Types gets an array of Types.
 // optional parameter: userInTable
+// Deprecated: use GetTypes
 func (to *Session) Types(useInTable ...string) ([]tc.Type, error) {
+	t, _, err := to.GetTypes(useInTable...)
+	return t, err
+}
 
+func (to *Session) GetTypes(useInTable ...string) ([]tc.Type, ReqInf, error) {
 	if len(useInTable) > 1 {
-		return nil, errors.New("Please pass in a single value for the 'useInTable' parameter")
+		return nil, ReqInf{}, errors.New("Please pass in a single value for the 'useInTable' parameter")
 	}
 
 	url := "/api/1.2/types.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.TypeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
 	var types []tc.Type
@@ -53,5 +59,5 @@ func (to *Session) Types(useInTable ...string) ([]tc.Type, error) {
 		}
 	}
 
-	return types, nil
+	return types, reqInf, nil
 }

--- a/traffic_ops/client/user.go
+++ b/traffic_ops/client/user.go
@@ -22,18 +22,25 @@ import (
 )
 
 // Users gets an array of Users.
+// Deprecated: use GetUsers
 func (to *Session) Users() ([]tc.User, error) {
+	us, _, err := to.GetUsers()
+	return us, err
+}
+
+func (to *Session) GetUsers() ([]tc.User, ReqInf, error) {
 	url := "/api/1.2/users.json"
-	resp, err := to.request("GET", url, nil)
+	resp, remoteAddr, err := to.request("GET", url, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 	defer resp.Body.Close()
 
 	var data tc.UsersResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, err
+		return nil, reqInf, err
 	}
 
-	return data.Response, nil
+	return data.Response, reqInf, nil
 }

--- a/traffic_ops/client/util.go
+++ b/traffic_ops/client/util.go
@@ -17,32 +17,36 @@ package client
 
 import "encoding/json"
 
-func get(to *Session, endpoint string, respStruct interface{}) error {
+func get(to *Session, endpoint string, respStruct interface{}) (ReqInf, error) {
 	return makeReq(to, "GET", endpoint, nil, respStruct)
 }
 
 func post(to *Session, endpoint string, body []byte, respStruct interface{}) error {
-	return makeReq(to, "POST", endpoint, body, respStruct)
+	_, err := makeReq(to, "POST", endpoint, body, respStruct)
+	return err
 }
 
 func put(to *Session, endpoint string, body []byte, respStruct interface{}) error {
-	return makeReq(to, "PUT", endpoint, body, respStruct)
+	_, err := makeReq(to, "PUT", endpoint, body, respStruct)
+	return err
 }
 
 func del(to *Session, endpoint string, respStruct interface{}) error {
-	return makeReq(to, "DELETE", endpoint, nil, respStruct)
+	_, err := makeReq(to, "DELETE", endpoint, nil, respStruct)
+	return err
 }
 
-func makeReq(to *Session, method, endpoint string, body []byte, respStruct interface{}) error {
-	resp, err := to.request(method, endpoint, body)
+func makeReq(to *Session, method, endpoint string, body []byte, respStruct interface{}) (ReqInf, error) {
+	resp, remoteAddr, err := to.request(method, endpoint, body) // TODO change to getBytesWithTTL
+	reqInf := ReqInf{RemoteAddr: remoteAddr, CacheHitStatus: CacheHitStatusMiss}
 	if err != nil {
-		return err
+		return reqInf, err
 	}
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(respStruct); err != nil {
-		return err
+		return reqInf, err
 	}
 
-	return nil
+	return reqInf, nil
 }

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -416,7 +416,7 @@ func queryDB(con influx.Client, cmd string, database string) (res []influx.Resul
 }
 
 func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
-	to, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
+	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
 		log.Error(newErr)
@@ -430,7 +430,7 @@ func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
 
 func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 	var runningConfig RunningConfig
-	to, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
+	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
 	if err != nil {
 		msg := fmt.Sprintf("Error logging in to %v: %v", config.ToURL, err)
 		if init {


### PR DESCRIPTION
This makes it possible to debug Traffic Ops sending the wrong CRConfig, an older CRConfig, or the Traffic Ops FQDN resolving to a wrong IP (for example, if a GSLB was misconfigured).

This also adds an additional safeguard, in addition to the one in the Router, to make the Monitor reject a CRConfig it receives older than the one it has, or with the wrong CDN.

This depends on #1468 and should be merged after it.