### PR TITLE
[#1471] Fixing Traffic-Portal build base image on centos 7.4.1708 

### DIFF
--- a/infrastructure/docker/build/Dockerfile-traffic_portal
+++ b/infrastructure/docker/build/Dockerfile-traffic_portal
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FROM centos:7
+FROM centos:7.4.1708
 
 MAINTAINER Dan Kirkwood
 


### PR DESCRIPTION
avoiding openssl issues