### PR TITLE
fixes missing cachekey parameters in remap.config

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1210,6 +1210,12 @@ sub remap_ds_data {
 				my $fname = "cacheurl_" . $ds_xml_id . ".config";
 				$response_obj->{dslist}->[$j]->{"cacheurl_file"} = $fname;
 			}
+			if ( defined( $dsinfo->profile ) ) {
+				my $dsparamrs = $self->db->resultset('ProfileParameter')->search( { profile => $dsinfo->profile }, { prefetch => [ 'profile', 'parameter' ] } );
+				while ( my $prow = $dsparamrs->next ) {
+					$response_obj->{dslist}->[$j]->{'param'}->{ $prow->parameter->config_file }->{ $prow->parameter->name } = $prow->parameter->value;
+				}
+			}
 
 			$j++;
 		}


### PR DESCRIPTION
The streamlined remap_ds_data function removed the parameter lookup for non-mid hosts.  Normally this would be fine as DS parameters were mid-only, but cachekey breaks that pattern.  Added a param lookup to non-mid hosts.