### PR TITLE
Change cdn.name to cdn.domain_name in DeliveryServiceInfoForDomainList

### DIFF
--- a/traffic_ops/app/lib/Schema/Result/DeliveryServiceInfoForDomainList.pm
+++ b/traffic_ops/app/lib/Schema/Result/DeliveryServiceInfoForDomainList.pm
@@ -52,7 +52,7 @@ SELECT
     regex.pattern,
     retype.name AS re_type,
     dstype.name AS ds_type,
-    cdn.name AS domain_name,
+    cdn.domain_name AS domain_name,
     deliveryservice_regex.set_number,
     deliveryservice.edge_header_rewrite,
     deliveryservice.mid_header_rewrite,


### PR DESCRIPTION
Looks like this is a typo - I'm trying to get the Delivery Service domain name on the mid cache and it's coming out as the CDN name...