### PR TITLE
remove preparation of update_status query

### DIFF
--- a/traffic_ops/traffic_ops_golang/servers_update_status.go
+++ b/traffic_ops/traffic_ops_golang/servers_update_status.go
@@ -76,24 +76,15 @@ func getServerUpdateStatus(hostName string, db *sqlx.DB) ([]tc.ServerUpdateStatu
 
 	updateStatuses := []tc.ServerUpdateStatus{}
 	var rows *sql.Rows
+	var err error
 	if hostName == "all" {
-		selectAll, err := db.Prepare(baseSelectStatement + groupBy)
-		if err != nil {
-			log.Error.Printf("could not prepare select server update status query: %s\n", err)
-			return nil, tc.DBError
-		}
-		rows, err = selectAll.Query()
+		rows, err = db.Query(baseSelectStatement + groupBy)
 		if err != nil {
 			log.Error.Printf("could not execute select server update status query: %s\n", err)
 			return nil, tc.DBError
 		}
 	} else {
-		selectStatement, err := db.Prepare(baseSelectStatement + ` WHERE s.host_name = $1` + groupBy)
-		if err != nil {
-			log.Error.Printf("could not prepare select server update status by hostname query: %s\n", err)
-			return nil, tc.DBError
-		}
-		rows, err = selectStatement.Query(hostName)
+		rows, err = db.Query(baseSelectStatement + ` WHERE s.host_name = $1` + groupBy, hostName)
 		if err != nil {
 			log.Error.Printf("could not execute select server update status by hostname query: %s\n", err)
 			return nil, tc.DBError


### PR DESCRIPTION
due to high concurrency this created a ballooning
memory footprint on the postgres server