### PR TITLE
Fix TO Go cookie to not pad base64

### DIFF
--- a/traffic_ops/tocookie/tocookie.go
+++ b/traffic_ops/tocookie/tocookie.go
@@ -85,7 +85,7 @@ func Parse(secret, cookie string) (*Cookie, error) {
 }
 
 func NewRawMsg(msg, key []byte) string {
-	base64Msg := base64.RawURLEncoding.WithPadding('-').EncodeToString(msg)
+	base64Msg := base64.RawURLEncoding.EncodeToString(msg)
 	mac := hmac.New(sha1.New, []byte(key))
 	mac.Write([]byte(base64Msg))
 	encMac := mac.Sum(nil)


### PR DESCRIPTION
This fixes tocookie for Go 1.9.

Go 1.9 makes a backwards-incompatible change, not permitting base64
encoding with the padding character in the alphabet.

We thought padding with '-' was necessary, as is Base64 URL Encoding,
which includes '-' in the alphabet. However, removing the padding
_seems_ to work. We should definitely watch this, and be aware any
reports of login failures with the new version are likely evidence
this is incorrect, and padding is necessary.

To someone in the future reading this, trying to fix logins: if
padding with '-' and URL-Base64-Encoding are both necessary, the
solution is to write a custom padding function, which checks the
length of the unpadded base64-encoded string, and appends 0, 1, or 2
'-' as necessary.