### PR TITLE
add crypto to .rat-excludes

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -60,3 +60,4 @@ backoff(?:                           MIT. Properly docuemented in LICENSE ){0}
 riak-go-client(?:                    Apache 2.0. Properly docuemented in LICENSE ){0}
 protobuf(?:                          Go BSD. Properly documented in LICENSE ){0}
 go-jwx(?:                            `MIT. Properly docuemented in LICENSE ){0}
+crypto(?:                            Go BSD. Properly documented in LICENSE ){0}


### PR DESCRIPTION
additional crypto lib in `traffic_ops_golang/vendor` is properly licensed,  but `rat` needs extra info to skip it..