### PR TITLE
adds ip_allow.config to syncds updates

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1073,6 +1073,7 @@ sub process_config_files {
 				|| $file eq "parent.config"
 				|| $file eq "cache.config"
 				|| $file eq "hosting.config"
+				|| $file eq "ip_allow.config"
 				|| $file =~ m/url\_sig\_(.*)\.config$/
 				|| $file =~ m/uri\_signing\_(.*)\.config$/
 				|| $file =~ m/hdr\_rw\_(.*)\.config$/


### PR DESCRIPTION
ip_allow.config does not require anything more than a traffic_line -x to update trafficserver, so there's no reason not to have it in a syncds run.