### PR TITLE
Add note to docs about requiring postgres timezone to be UTC

### DIFF
--- a/docs/source/admin/traffic_ops/installation.rst
+++ b/docs/source/admin/traffic_ops/installation.rst
@@ -54,7 +54,7 @@ To begin the install:
 
     host  all   all     99.33.99.1/32 md5
 
-  to the appropriate section of this file. Edit the ``/var/lib/pgsql/9.6/data/postgresql.conf`` file to add the approriate listen_addresses or ``listen_addresses = '*'``,  and start the database: ::
+  to the appropriate section of this file. Edit the ``/var/lib/pgsql/9.6/data/postgresql.conf`` file to add the approriate listen_addresses or ``listen_addresses = '*'``, set ``timezone = 'UTC'``,  and start the database: ::
 
     pg-$ exit
     pg-# systemctl enable postgresql-9.6

--- a/docs/source/development/traffic_ops_api/v12/deliveryservice.rst
+++ b/docs/source/development/traffic_ops_api/v12/deliveryservice.rst
@@ -2142,11 +2142,13 @@ URL Sig Keys
   | protocol               | yes|no   | - 0: serve with http:// at EDGE                                                                         |
   |                        |          | - 1: serve with https:// at EDGE                                                                        |
   |                        |          | - 2: serve with both http:// and https:// at EDGE                                                       |
+  |                        |          |                                                                                                         |
   |                        |          | Required for DNS*, HTTP* or *STEERING* delivery services.                                               |
   +------------------------+----------+---------------------------------------------------------------------------------------------------------+
   | qstringIgnore          | yes|no   | - 0: no special query string handling; it is for use in the cache-key and pass up to origin.            |
   |                        |          | - 1: ignore query string in cache-key, but pass it up to parent and or origin.                          |
   |                        |          | - 2: drop query string at edge, and do not use it in the cache-key.                                     |
+  |                        |          |                                                                                                         |
   |                        |          | Required for DNS* and HTTP* delivery services.                                                          |
   +------------------------+----------+---------------------------------------------------------------------------------------------------------+
   | rangeRequestHandling   | yes|no   | How to treat range requests (required for DNS* and HTTP* delivery services):                            |
@@ -2550,11 +2552,13 @@ URL Sig Keys
   | protocol               | yes|no   | - 0: serve with http:// at EDGE                                                                         |
   |                        |          | - 1: serve with https:// at EDGE                                                                        |
   |                        |          | - 2: serve with both http:// and https:// at EDGE                                                       |
+  |                        |          |                                                                                                         |
   |                        |          | Required for DNS*, HTTP* or *STEERING* delivery services.                                               |
   +------------------------+----------+---------------------------------------------------------------------------------------------------------+
   | qstringIgnore          | yes|no   | - 0: no special query string handling; it is for use in the cache-key and pass up to origin.            |
   |                        |          | - 1: ignore query string in cache-key, but pass it up to parent and or origin.                          |
   |                        |          | - 2: drop query string at edge, and do not use it in the cache-key.                                     |
+  |                        |          |                                                                                                         |
   |                        |          | Required for DNS* and HTTP* delivery services.                                                          |
   +------------------------+----------+---------------------------------------------------------------------------------------------------------+
   | rangeRequestHandling   | yes|no   | How to treat range requests (required for DNS* and HTTP* delivery services):                            |


### PR DESCRIPTION
If the timezone is not UTC, the Golang Traffic Ops Client will fail to parse the `last_updated` timestamps into a `time.Time`, which will make anything using the golang TO client fail (e.g. the Traffic Monitor) when making API requests.