### PR TITLE
Integration test framework

### DIFF
--- a/infrastructure/test/integration/README.md
+++ b/infrastructure/test/integration/README.md
@@ -1,0 +1,40 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Docker Integration Tests
+
+The Docker Integration Tests are designed to run in a Docker container with Traffic Ops. Traffic Ops has the locations of all other CDN components.
+
+Thus, an integration test for Traffic Ops should simply query `localhost`; an integration test for any other component should get that component's IP from Traffic Ops, and subsequently query that IP.
+
+# Running the Integration Tests
+
+To run the integration tests, set up Traffic Ops in Docker (see https://github.com/apache/incubator-trafficcontrol/tree/master/infrastructure/docker/README.md), and run `run-docker-integration-test.sh`.
+
+# Creating a Test
+
+To create a new integration test, create an executable file -- it can be a shell script, Go binary, Perl script, etc -- and place it in `/infrastructure/test/integration/docker-integration-tests/`.
+
+Your executable should:
+* Query Traffic Ops at localhost
+* Query any other components at their IPs, which can be queried from Traffic Ops at `https://localhost/api/1.2/servers`
+  * If you're not using a Traffic Ops client, you'll need to send a login cookie; for an example of how to get the cookie, see https://github.com/apache/incubator-trafficcontrol/tree/master/infrastructure/docker/traffic_ops/run.sh
+* Return 0 and print nothing for success; return a nonzero code and print the error on failure
+
+That's it! The `run-docker-integration-test.sh` script will automatically run your executable in the Docker Traffic Ops container, and report its failures.

--- a/infrastructure/test/integration/docker-integration-tests/single-traffic-ops-query.sh
+++ b/infrastructure/test/integration/docker-integration-tests/single-traffic-ops-query.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+output=$(curl -Lvsk https://localhost 2>&1)
+code=$?
+
+if [ "$code" -ne 0 ]; then
+	echo "single traffic ops query failed with code $code output ::: ${output} :::"
+	exit $code
+else
+	exit 0
+fi

--- a/infrastructure/test/integration/run-docker-integration-test.sh
+++ b/infrastructure/test/integration/run-docker-integration-test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+TEST_DIR=$1
+
+if [[ -z  $TEST_DIR ]]; then
+	echo "Usage: ./run-docker-integration-test.sh integration/test/directory"
+	echo "Example: ./run-docker-integration-test.sh ./docker-integration-tests"
+	exit 2
+fi
+
+TEST_FILES=
+for filename in ${TEST_DIR}/*; do
+	if [[ -x "$filename" ]]; then
+		TEST_FILES="$TEST_FILES:$filename"
+	fi
+done
+
+EXIT_CODE=0
+
+ORIG_IFS=$IFS
+IFS=:
+for filepath in $TEST_FILES; do
+		if [[ ! -z  $filepath ]]; then
+				filename=$(basename $filepath)
+				docker cp $filepath traffic_ops:/
+				docker exec -it traffic_ops "/$filename"
+				code=$?
+				if [ "$code" -ne 0 ]; then
+						EXIT_CODE=1
+				fi
+				docker exec -it traffic_ops rm "/$filename"
+		fi
+done
+IFS=$ORIG_IFS
+
+exit $EXIT_CODE


### PR DESCRIPTION
This is a very simple integration test framework, which can be integrated into a build server. See the `README.md` for how it works, and how to write tests.

If this grows over a few hundred lines, it should be rewritten in something other than Bash.

This depends on  #1586 and should be merged after it.