### PR TITLE
Adds cachegroups using mid as secondary to ip_allow.config

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1947,7 +1947,7 @@ sub ip_allow_data {
 
 
 	if ( $server_obj->type->name =~ m/^MID/ ) {
-		my @edge_locs = $self->db->resultset('Cachegroup')->search( { parent_cachegroup_id => $server_obj->cachegroup->id } )->get_column('id')->all();
+		my @edge_locs = $self->db->resultset('Cachegroup')->search( { -or => [ parent_cachegroup_id => $server_obj->cachegroup->id, secondary_parent_cachegroup_id => $server_obj->cachegroup->id ] } )->get_column('id')->all();
 		my %allow_locs;
 		foreach my $loc (@edge_locs) {
 			$allow_locs{$loc} = 1;
@@ -1961,7 +1961,7 @@ sub ip_allow_data {
 		my $rtype = &type_id( $self, 'RASCAL' );
 		push( @types, $rtype );
 		my $rs_allowed = $self->db->resultset('Server')->search( { 'me.type' => { -in => \@types } }, { prefetch => [ 'type', 'cachegroup' ] } );
-
+		
 		while ( my $allow_row = $rs_allowed->next ) {
 			if ( $allow_row->type->id == $rtype
 				|| ( defined( $allow_locs{ $allow_row->cachegroup->id } ) && $allow_locs{ $allow_row->cachegroup->id } == 1 ) )


### PR DESCRIPTION
This adds the IPs to ip_allow.config from any cachegroups using a mid as a secondary cachegroup.  Previously we only looked at primaries.