### PR TITLE
Cacheurl to cachekey - mid qstring drop and light refactor

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2479,7 +2479,7 @@ sub remap_dot_config {
 				$mid_remap{ $ds->{org} } .= " \@plugin=header_rewrite.so \@pparam=" . $ds->{mid_hdr_rw_file};
 			}
 			if ( $ds->{qstring_ignore} == 1 ) {
-				$mid_remap{ $remap->{org} } .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server));
+				$mid_remap{ $ds->{org} } .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server));
 			}
 			if ( defined( $ds->{cacheurl} ) && $ds->{cacheurl} ne "" ) {
 				$mid_remap{ $ds->{org} } .= " \@plugin=cacheurl.so \@pparam=" . $ds->{cacheurl_file};

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2479,7 +2479,7 @@ sub remap_dot_config {
 				$mid_remap{ $ds->{org} } .= " \@plugin=header_rewrite.so \@pparam=" . $ds->{mid_hdr_rw_file};
 			}
 			if ( $ds->{qstring_ignore} == 1 ) {
-				$mid_remap{ $ds->{org} } .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server));
+				$mid_remap{ $ds->{org} } .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version( $self, $server_obj ));
 			}
 			if ( defined( $ds->{cacheurl} ) && $ds->{cacheurl} ne "" ) {
 				$mid_remap{ $ds->{org} } .= " \@plugin=cacheurl.so \@pparam=" . $ds->{cacheurl_file};
@@ -2575,7 +2575,7 @@ sub build_remap_line {
 		}
 		else {
 			#If we are on ats 6 and later we want to use the cachekey plugin, otherwise we have to use cacheurl
-			$text .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server));
+			$text .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server_obj ));
 		}
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1373,37 +1373,6 @@ sub drop_qstring_dot_config {
 	return $text;
 }
 
-sub get_ats_major_version {
-	my $self 	 = shift;
-	my $server   = shift;
-
-	my $ats_ver =
-		$self->db->resultset('ProfileParameter')
-		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server_obj->profile->id },
-		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
-	if (!defined $ats_ver) {
-	        $ats_ver = "5";
-            $self->app->log->error("Parameter package.trafficserver missing for profile ".$server->profile->name . ". Assuming version $ats_ver");
-        }
-
-	my @ats_fields = split /\./, $ats_ver, 2;
-	my $ats_major_version = $ats_fields[0];
-
-	return $ats_major_version;
-}
-
-sub get_qstring_ignore_remap {
-	my $self	= shift;
-	my $ats_major_version = shift;
-
-	if ($ats_major_version >= 6) {
-		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/http:\\/\\/([^?]*)/http:\\/\\/\$1/";
-	}
-	else {
-		return " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";
-	}
-}
-
 sub logs_xml_dot_config {
 	my $self        = shift;
 	my $profile_obj = shift;
@@ -2510,7 +2479,7 @@ sub remap_dot_config {
 				$mid_remap{ $ds->{org} } .= " \@plugin=header_rewrite.so \@pparam=" . $ds->{mid_hdr_rw_file};
 			}
 			if ( $ds->{qstring_ignore} == 1 ) {
-				$mid_remap{ $remap->{org} } .= $self->get_qstring_ignore_remap($self->get_ats_major_version($server));
+				$mid_remap{ $remap->{org} } .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server));
 			}
 			if ( defined( $ds->{cacheurl} ) && $ds->{cacheurl} ne "" ) {
 				$mid_remap{ $ds->{org} } .= " \@plugin=cacheurl.so \@pparam=" . $ds->{cacheurl_file};
@@ -2606,7 +2575,7 @@ sub build_remap_line {
 		}
 		else {
 			#If we are on ats 6 and later we want to use the cachekey plugin, otherwise we have to use cacheurl
-			$text .= $self->get_qstring_ignore_remap($self->get_ats_major_version($server));
+			$text .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server));
 		}
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1385,7 +1385,9 @@ sub get_ats_major_version {
 	        $ats_ver = "5";
             $self->app->log->error("Parameter package.trafficserver missing for profile ".$server->profile->name . ". Assuming version $ats_ver");
         }
-	my $ats_major_version = substr( $ats_ver, 0, 1 );
+
+	my @ats_fields = split /\./, $ats_ver, 2;
+	my $ats_major_version = $ats_fields[0];
 
 	return $ats_major_version;
 }

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1373,6 +1373,35 @@ sub drop_qstring_dot_config {
 	return $text;
 }
 
+sub get_ats_major_version {
+	my $self 	 = shift;
+	my $server   = shift;
+
+	my $ats_ver =
+		$self->db->resultset('ProfileParameter')
+		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server_obj->profile->id },
+		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
+	if (!defined $ats_ver) {
+	        $ats_ver = "5";
+            $self->app->log->error("Parameter package.trafficserver missing for profile ".$server->profile->name . ". Assuming version $ats_ver");
+        }
+	my $ats_major_version = substr( $ats_ver, 0, 1 );
+
+	return $ats_major_version;
+}
+
+sub get_qstring_ignore_remap {
+	my $self	= shift;
+	my $ats_major_version = shift;
+
+	if ($ats_major_version >= 6) {
+		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/http:\\/\\/([^?]*)/http:\\/\\/\$1/";
+	}
+	else {
+		return " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";
+	}
+}
+
 sub logs_xml_dot_config {
 	my $self        = shift;
 	my $profile_obj = shift;
@@ -2479,7 +2508,7 @@ sub remap_dot_config {
 				$mid_remap{ $ds->{org} } .= " \@plugin=header_rewrite.so \@pparam=" . $ds->{mid_hdr_rw_file};
 			}
 			if ( $ds->{qstring_ignore} == 1 ) {
-				$mid_remap{ $ds->{org} } .= " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";
+				$mid_remap{ $remap->{org} } .= $self->get_qstring_ignore_remap($self->get_ats_major_version($server));
 			}
 			if ( defined( $ds->{cacheurl} ) && $ds->{cacheurl} ne "" ) {
 				$mid_remap{ $ds->{org} } .= " \@plugin=cacheurl.so \@pparam=" . $ds->{cacheurl_file};
@@ -2544,15 +2573,6 @@ sub build_remap_line {
 
 	my $dscp      = $remap->{dscp};
 	my $hostname  = $server_obj->host_name;
-	my $ats_ver =
-		$self->db->resultset('ProfileParameter')
-		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server_obj->profile->id },
-		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
-	if (!defined $ats_ver) {
-	        $ats_ver = "5";
-            $self->app->log->error("Parameter package.trafficserver missing for profile ".$server->profile->name . ". Assuming version $ats_ver");
-        }
-	my $ats_major_version = substr( $ats_ver, 0, 1 );
 	
 	$map_from =~ s/ccr/$hostname/;
 
@@ -2584,12 +2604,7 @@ sub build_remap_line {
 		}
 		else {
 			#If we are on ats 6 and later we want to use the cachekey plugin, otherwise we have to use cacheurl
-			if ($ats_major_version >= 6) {
-				$text .=" \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/http:\\/\\/([^?]*)/http:\\/\\/\$1/";
-			}
-			else {
-				$text .= " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";
-			}
+			$text .= $self->get_qstring_ignore_remap($self->get_ats_major_version($server));
 		}
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -160,6 +160,37 @@ sub server_data {
 	return $server;
 }
 
+sub get_ats_major_version {
+	my $self 	 = shift;
+	my $server   = shift;
+
+	my $ats_ver =
+		$self->db->resultset('ProfileParameter')
+		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server->profile->id },
+		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
+		
+	if (!defined $ats_ver) {
+	        $ats_ver = "5";
+            $self->app->log->error("Parameter package.trafficserver missing for profile ".$server->profile->name . ". Assuming version $ats_ver");
+        }
+
+	my $ats_major_version = substr( $ats_ver, 0, 1 );
+
+	return $ats_major_version;
+}
+
+sub get_qstring_ignore_remap {
+	my $self	= shift;
+	my $ats_major_version = shift;
+
+	if ($ats_major_version >= 6) {
+		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/http:\\/\\/([^?]*)/http:\\/\\/\$1/";
+	}
+	else {
+		return " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";
+	}
+}
+
 sub header_comment {
 	my $self      = shift;
 	my $host_name = shift;
@@ -972,7 +1003,7 @@ sub remap_dot_config {
 				$mid_remap{ $remap->{org} } .= " \@plugin=header_rewrite.so \@pparam=" . $remap->{mid_hdr_rw_file};
 			}
 			if ( $remap->{qstring_ignore} == 1 ) {
-				$mid_remap{ $remap->{org} } .= " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";
+				$mid_remap{ $remap->{org} } .= $self->get_qstring_ignore_remap($self->get_ats_major_version($server));
 			}
 			if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {
 				$mid_remap{ $remap->{org} } .= " \@plugin=cacheurl.so \@pparam=" . $remap->{cacheurl_file};
@@ -1021,16 +1052,6 @@ sub build_remap_line {
 
 	$map_from =~ s/ccr/$host_name/;
 
-	my $ats_ver =
-		$self->db->resultset('ProfileParameter')
-		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server->profile->id },
-		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
-	if (!defined $ats_ver) {
-	        $ats_ver = "5";
-            $self->app->log->error("Parameter package.trafficserver missing for profile ".$server->profile->name . ". Assuming version $ats_ver");
-        }
-	my $ats_major_version = substr( $ats_ver, 0, 1 );
-
 	if ( defined( $pdata->{'dscp_remap'} ) ) {
 		$text .= "map	" . $map_from . "     " . $map_to . " \@plugin=dscp_remap.so \@pparam=" . $dscp;
 	}
@@ -1059,12 +1080,7 @@ sub build_remap_line {
 		}
 		else {
 			#If we are on ats 6 and later we want to use the cachekey plugin, otherwise we have to use cacheurl
-			if ($ats_major_version >= 6) {
-				$text .=" \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/http:\\/\\/([^?]*)/http:\\/\\/\$1/";
-			}
-			else {
-				$text .= " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";
-			}
+			$text .= $self->get_qstring_ignore_remap($self->get_ats_major_version($server));
 		}
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -174,7 +174,8 @@ sub get_ats_major_version {
             $self->app->log->error("Parameter package.trafficserver missing for profile ".$server->profile->name . ". Assuming version $ats_ver");
         }
 
-	my $ats_major_version = substr( $ats_ver, 0, 1 );
+	my @ats_fields = split /\./, $ats_ver, 2;
+	my $ats_major_version = $ats_fields[0];
 
 	return $ats_major_version;
 }

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -160,38 +160,6 @@ sub server_data {
 	return $server;
 }
 
-sub get_ats_major_version {
-	my $self 	 = shift;
-	my $server   = shift;
-
-	my $ats_ver =
-		$self->db->resultset('ProfileParameter')
-		->search( { 'parameter.name' => 'trafficserver', 'parameter.config_file' => 'package', 'profile.id' => $server->profile->id },
-		{ prefetch => [ 'profile', 'parameter' ] } )->get_column('parameter.value')->single();
-		
-	if (!defined $ats_ver) {
-	        $ats_ver = "5";
-            $self->app->log->error("Parameter package.trafficserver missing for profile ".$server->profile->name . ". Assuming version $ats_ver");
-        }
-
-	my @ats_fields = split /\./, $ats_ver, 2;
-	my $ats_major_version = $ats_fields[0];
-
-	return $ats_major_version;
-}
-
-sub get_qstring_ignore_remap {
-	my $self	= shift;
-	my $ats_major_version = shift;
-
-	if ($ats_major_version >= 6) {
-		return " \@plugin=cachekey.so \@pparam=--separator= \@pparam=--remove-all-params=true \@pparam=--remove-path=true \@pparam=--capture-prefix-uri=/http:\\/\\/([^?]*)/http:\\/\\/\$1/";
-	}
-	else {
-		return " \@plugin=cacheurl.so \@pparam=cacheurl_qstring.config";
-	}
-}
-
 sub header_comment {
 	my $self      = shift;
 	my $host_name = shift;
@@ -1004,7 +972,7 @@ sub remap_dot_config {
 				$mid_remap{ $remap->{org} } .= " \@plugin=header_rewrite.so \@pparam=" . $remap->{mid_hdr_rw_file};
 			}
 			if ( $remap->{qstring_ignore} == 1 ) {
-				$mid_remap{ $remap->{org} } .= $self->get_qstring_ignore_remap($self->get_ats_major_version($server));
+				$mid_remap{ $remap->{org} } .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server));
 			}
 			if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {
 				$mid_remap{ $remap->{org} } .= " \@plugin=cacheurl.so \@pparam=" . $remap->{cacheurl_file};
@@ -1081,7 +1049,7 @@ sub build_remap_line {
 		}
 		else {
 			#If we are on ats 6 and later we want to use the cachekey plugin, otherwise we have to use cacheurl
-			$text .= $self->get_qstring_ignore_remap($self->get_ats_major_version($server));
+			$text .= UI::DeliveryService::get_qstring_ignore_remap(UI::DeliveryService::get_ats_major_version($self, $server));
 		}
 	}
 	if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {


### PR DESCRIPTION
PR 1588 addressed the edges using qstring_drop=1, this handles the mids. Also moved the ats version checking and remap line generation in to functions