### PR TITLE
change max_dns_answers default to 5

### DIFF
--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -213,7 +213,7 @@ CREATE TABLE deliveryservice (
     long_desc text,
     long_desc_1 text,
     long_desc_2 text,
-    max_dns_answers bigint DEFAULT '0'::bigint,
+    max_dns_answers bigint DEFAULT '5'::bigint,
     info_url text,
     miss_lat numeric,
     miss_long numeric,

--- a/traffic_ops/app/db/migrations/20171204000000_alter_max_dns_answers_default.sql
+++ b/traffic_ops/app/db/migrations/20171204000000_alter_max_dns_answers_default.sql
@@ -1,0 +1,22 @@
+/*
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE deliveryservice ALTER COLUMN max_dns_answers SET DEFAULT '5'::bigint;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+ALTER TABLE deliveryservice ALTER COLUMN max_dns_answers SET DEFAULT '0'::bigint;


### PR DESCRIPTION
a default of 0 (unlimited) caused problems for large deployments