### PR TITLE
Add Traffic Ops parent.config parameter to skip caches

### DIFF
--- a/docs/source/admin/traffic_ops/configuration.rst
+++ b/docs/source/admin/traffic_ops/configuration.rst
@@ -227,6 +227,21 @@ Below is a list of Traffic Server plugins that need to be configured in the para
 |                  |               | Value is left blank.                                 |                                                                                                            |
 +------------------+---------------+------------------------------------------------------+------------------------------------------------------------------------------------------------------------+
 
+Below is a list of cache parameters for special configuration, which are unlikely to need changes, but may be useful in particular circumstances:
+
++--------------------------+-------------------+-------------------------------------------------------------------------------------------------------------------------+
+|           Name           |    Config file    |                                                       Description                                                       |
++==========================+===================+=========================================================================================================================+
+| not_a_parent             | parent.config     | This is a boolean flag and is considered true if it exists and has any value except 'false'.                            |
+|                          |                   | This prevents servers with this parameter in their profile from being inserted into the parent.config generated for     |
+|                          |                   | servers with this server's cachegroup as a parent of their cachegroup. This is primarily useful for when edge caches    |
+|                          |                   | are configured to have a cachegroup of other edge caches as parents (a highly unusual configuration), and it is         |
+|                          |                   | necessary to exclude some, but not all, edges in the parent cachegroup from the parent.config (for example, because they|
+|                          |                   | lack necessary capabilities), but still have all edges in the same cachegroup in order to take traffic from ordinary    |
+|                          |                   | delivery services at that cachegroup's geo location. Once again, this is a highly unusual scenario, and under ordinary  |
+|                          |                   | circumstances this parameter should not exist.                                                                          |
++--------------------------+-------------------+-------------------------------------------------------------------------------------------------------------------------+
+
 
 Regions, Locations and Cache Groups
 ===================================

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -389,6 +389,9 @@ sub parent_data {
 	foreach my $prefix ( keys %deliveryservices ) {
 		foreach my $row ( @{ $deliveryservices{$prefix} } ) {
 			my $pid              = $row->profile->id;
+                        if ( $profile_cache{$pid}->{not_a_parent} ne 'false' ) {
+                            next;
+                        }
 			my $ds_domain        = $profile_cache{$pid}->{domain_name};
 			my $weight           = $profile_cache{$pid}->{weight};
 			my $port             = $profile_cache{$pid}->{port};
@@ -461,6 +464,7 @@ sub cachegroup_profiles {
 				port           => $self->profile_param_value( $pid, 'parent.config', 'port', undef ),
 				use_ip_address => $self->profile_param_value( $pid, 'parent.config', 'use_ip_address', 0 ),
 				rank           => $self->profile_param_value( $pid, 'parent.config', 'rank', 1 ),
+				not_a_parent   => $self->profile_param_value( $pid, 'parent.config', 'not_a_parent', 'false' ),
 			};
 		}
 	}


### PR DESCRIPTION
We need this, in order to be able to assign Edges whose parent cachegroup has other Edges, and to have some edges in that cachegroup being assigned as parents, but some not (because some lack necessary capabilities, namely disk and forward proxy configuration).

I don't like it, but it's functionality we need, and the only alternative is a large refactor of how TO profiles/parameters/edges/mids work, which we don't immediately need the flexibility from or have the time for. 

This way, the magic parameter defaults to false, and doesn't change existing behavior.