### PR TITLE
[Issue-1493] Specify bypass URL port in CrConfig only if explicitly set

### DIFF
--- a/traffic_ops/app/lib/API/Cdn.pm
+++ b/traffic_ops/app/lib/API/Cdn.pm
@@ -922,17 +922,17 @@ sub gen_traffic_router_config {
 				&& $row->http_bypass_fqdn ne "" )
 			{
 				my $full = $row->http_bypass_fqdn;
-				my $port;
 				my $fqdn;
 				if ( $full =~ m/\:/ ) {
+					my $port;
 					( $fqdn, $port ) = split( /\:/, $full );
+					# Specify port number only if explicitly set by the DS 'Bypass FQDN' field - issue 1493
+					$bypass_destination->{'port'} = int($port);
 				}
 				else {
 					$fqdn = $full;
-					$port = 80;
 				}
 				$bypass_destination->{'fqdn'} = $fqdn;
-				$bypass_destination->{'port'} = int($port);
 			}
 		}
 		$delivery_service->{'bypassDestination'} = $bypass_destination;

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -463,17 +463,17 @@ sub gen_crconfig_json {
                 && $row->http_bypass_fqdn ne "" )
             {
                 my $full = $row->http_bypass_fqdn;
-                my $port;
                 my $fqdn;
                 if ( $full =~ m/\:/ ) {
+                    my $port;
                     ( $fqdn, $port ) = split( /\:/, $full );
+                    # Specify port number only if explicitly set by the DS 'Bypass FQDN' field - issue 1493
+                    $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'bypassDestination'}->{'HTTP'}->{'port'} = $port;
                 }
                 else {
                     $fqdn = $full;
-                    $port = '80';
                 }
                 $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'bypassDestination'}->{'HTTP'}->{'fqdn'} = $fqdn;
-                $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'bypassDestination'}->{'HTTP'}->{'port'} = $port;
             }
 
             $data_obj->{'deliveryServices'}->{ $row->xml_id }->{'regionalGeoBlocking'} = $row->regional_geo_blocking ? 'true' : 'false';


### PR DESCRIPTION
This fix makes Traffic Ops specify the 'port' field in the 'bypass' section of
CrConfig only if explicitly set in the DS 'Bypass FQDN' field (By using the format 'fqdn:port').
(Relevant for HTTP DSes only)

Before the fix, if a port was not explicitly set in the DS 'Bypass FQDN' field,
Ops specified a value of 80 to the 'port' field in CrConfig, making HTTPS requests that
go to bypass being redirected to https://<bypass-fqdn>:80/... , which is
certainly not right.

Resolves: #1493 TR redirects to Bypass FQDN with port 80 for HTTPS DSes