### PR TITLE
Adding execution of db_admin patch to postinstall

### DIFF
--- a/traffic_ops/install/bin/_postinstall
+++ b/traffic_ops/install/bin/_postinstall
@@ -585,6 +585,7 @@ QUERY
     }
     invoke_db_admin_pl("migrate");
     invoke_db_admin_pl("seed");
+    invoke_db_admin_pl("patch");
 
     # Skip the insert if the admin 'username' is already there.
     my $hashed_passwd = hash_pass( $adminconf->{"password"} );


### PR DESCRIPTION
Without this, there would be no prefix configured on the delivery service during an upgrade.
Closes #1630 