### PR TITLE
Add logging.config support for ATS 7.1.x

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1381,7 +1381,7 @@ sub logging_dot_config {
 	my $filename    = shift;
 
 	my $data = $self->profile_param_data( $profile_obj->id, "logging.config" );
-	#my $data   = $self->param_data( $server, $filename );
+
 	# This is an LUA file, so we need to massage the header a bit for LUA commenting.
 	my $text = "-- " . $self->header_comment( $profile_obj->name );
 	$text =~ s/# //;
@@ -1398,10 +1398,8 @@ sub logging_dot_config {
 		}
 
 		my $log_format_name = $data->{$log_format_field . ".Name"} || "";
-			$self->app->log->debug("log name is: $log_format_name");
 		if ( length($log_format_name) > 0 ) {
 			my $format = $data->{$log_format_field . ".Format"};
-			$self->app->log->debug("format is: $format");
 			$format =~ s/"/\\\"/g;
 			$text .= $log_format_name . " = format {\n";
 			$text .= "	Format = '" . $format . " '\n";
@@ -1417,7 +1415,7 @@ sub logging_dot_config {
 			my $log_object_rolling_size_mb      = $data->{$log_object_field . ".RollingSizeMb"}      || "";
 			my $log_object_header               = $data->{$log_object_field . ".Header"}             || "";
 
-			$text .= "log.ascii {\n";
+			$text .= "\nlog.ascii {\n";
 			$text .= "  Format = " . $log_format_name . ",\n";
 			$text .= "  Filename = '" . $log_object_filename . "',\n";
 			$text .= "  RollingEnabled = " . $log_object_rolling_enabled . ",\n" unless defined();

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -29,6 +29,7 @@ use URI;
 
 my $dispatch_table ||= {
 	"logs_xml.config"         => sub { logs_xml_dot_config(@_) },
+	"logging.config"		  => sub { logging_dot_config(@_) },
 	"cacheurl.config"         => sub { cacheurl_dot_config(@_) },
 	"records.config"          => sub { generic_config(@_) },
 	"plugin.config"           => sub { generic_config(@_) },
@@ -634,6 +635,59 @@ sub facts {
 	my $server = $self->server_data($id);
 	my $text   = $self->header_comment( $server->host_name );
 	$text .= "profile:" . $server->profile->name . "\n";
+
+	return $text;
+}
+
+sub logging_dot_config {
+	my $self     = shift;
+	my $id       = shift;
+	my $filename = shift;
+
+	my $server = $self->server_data($id);
+	#my $data   = $self->param_data( $server, $filename );
+	my $data   = $self->param_data( $server, "logs_xml.config" );
+	my $text   = "-- Generated for " . $server->host_name . " by " . &name_version_string($self) . " - Do not edit!! --\n";
+
+	my $max_log_objects = 10;
+	for ( my $i = 0; $i < $max_log_objects; $i = $i + 1 ) {
+		my $log_format_field = "LogFormat";
+		my $log_object_field = "LogObject";
+		if ( $i > 0 ) {
+			$log_format_field = $log_format_field . "$i";
+			$log_object_field = $log_object_field . "$i";
+		}
+
+		my $log_format_name = $data->{$log_format_field . ".Name"} || "";
+			$self->app->log->debug("log name is: $log_format_name");
+		if ( length($log_format_name) > 0 ) {
+			my $format = $data->{$log_format_field . ".Format"};
+			$self->app->log->debug("format is: $format");
+			$format =~ s/"/\\\"/g;
+			$text .= $log_format_name . " = format {\n";
+			$text .= "	Format = '" . $format . " '\n";
+			$text .= "}\n";
+		}
+
+		my $log_object_filename = $data->{$log_object_field . ".Filename"} || "";
+		if ( length($log_object_filename) > 0 ) {
+			my $log_object_format               = $data->{$log_object_field . ".Format"}             || "";
+			my $log_object_rolling_enabled      = $data->{$log_object_field . ".RollingEnabled"}     || "";
+			my $log_object_rolling_interval_sec = $data->{$log_object_field . ".RollingIntervalSec"} || "";
+			my $log_object_rolling_offset_hr    = $data->{$log_object_field . ".RollingOffsetHr"}    || "";
+			my $log_object_rolling_size_mb      = $data->{$log_object_field . ".RollingSizeMb"}      || "";
+			my $log_object_header               = $data->{$log_object_field . ".Header"}             || "";
+
+			$text .= "log.ascii {\n";
+			$text .= "  Format = " . $log_format_name . ",\n";
+			$text .= "  Filename = '" . $log_object_filename . "',\n";
+			$text .= "  RollingEnabled = " . $log_object_rolling_enabled . ",\n" unless defined();
+			$text .= "  RollingIntervalSec = " . $log_object_rolling_interval_sec . ",\n";
+			$text .= "  RollingOffsetHr = " . $log_object_rolling_offset_hr . ",\n";
+			$text .= "  RollingSizeMb = " . $log_object_rolling_size_mb . "\n";
+			$text .= "}\n";
+		}
+	}
 
 	return $text;
 }

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -645,8 +645,8 @@ sub logging_dot_config {
 	my $filename = shift;
 
 	my $server = $self->server_data($id);
-	#my $data   = $self->param_data( $server, $filename );
-	my $data   = $self->param_data( $server, "logs_xml.config" );
+	my $data   = $self->param_data( $server, $filename );
+
 	my $text   = "-- Generated for " . $server->host_name . " by " . &name_version_string($self) . " - Do not edit!! --\n";
 
 	my $max_log_objects = 10;
@@ -659,10 +659,8 @@ sub logging_dot_config {
 		}
 
 		my $log_format_name = $data->{$log_format_field . ".Name"} || "";
-			$self->app->log->debug("log name is: $log_format_name");
 		if ( length($log_format_name) > 0 ) {
 			my $format = $data->{$log_format_field . ".Format"};
-			$self->app->log->debug("format is: $format");
 			$format =~ s/"/\\\"/g;
 			$text .= $log_format_name . " = format {\n";
 			$text .= "	Format = '" . $format . " '\n";
@@ -678,7 +676,7 @@ sub logging_dot_config {
 			my $log_object_rolling_size_mb      = $data->{$log_object_field . ".RollingSizeMb"}      || "";
 			my $log_object_header               = $data->{$log_object_field . ".Header"}             || "";
 
-			$text .= "log.ascii {\n";
+			$text .= "\nlog.ascii {\n";
 			$text .= "  Format = " . $log_format_name . ",\n";
 			$text .= "  Filename = '" . $log_object_filename . "',\n";
 			$text .= "  RollingEnabled = " . $log_object_rolling_enabled . ",\n" unless defined();


### PR DESCRIPTION
ATS 7.1.x changed the logging format from logs_xml.config to a new lua based logging.config. These changes generate the new file, and continue to use the same terminology from the previous logs_xml.config since most of the fields transfer over