### PR TITLE
Add Traffic Monitor testcaches Tool

### DIFF
--- a/traffic_monitor/tools/testcaches/README.md
+++ b/traffic_monitor/tools/testcaches/README.md
@@ -1,0 +1,13 @@
+# testcaches
+
+The `testcaches` tool simulates multiple ATS caches' `_astats` endpoints.
+
+Its primary goal is for testing the Monitor under load, but it may be useful for testing other components.
+
+A list of parameters can be seen by running `./testcaches -h`. There are only three: the first port to use, the number of ports to use, and the number of remaps (delivery services) to serve in each fake server.
+
+Each port is a unique fake server, with distinct incrementing stats.
+
+When run with no parameters, it defaults to ports 40000-40999 and 1000 remaps.
+
+Stats are served at the regular ATS `stats_over_http` endpoint, `_astats`. For example, if it's serving on port 40000, it can be reached via `curl http://localhost:40000/_astats`. It also respects the `?application=system` query parameter, and will serve only system stats (the Monitor "health check" [as opposed to the "stat check"]). For example, `curl http://localhost:40000/_astats?application=system`.

--- a/traffic_monitor/tools/testcaches/fakesrvr/fakesrvr.go
+++ b/traffic_monitor/tools/testcaches/fakesrvr/fakesrvr.go
@@ -1,0 +1,92 @@
+package fakesrvr
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/tools/testcaches/fakesrvrdata"
+)
+
+func News(portStart int, numPorts int, remaps []string) ([]*http.Server, error) {
+	servers := []*http.Server{}
+	for i := 0; i < numPorts; i++ {
+		port := portStart + i
+		server, err := New(port, remaps)
+		if err != nil {
+			// TODO stop all servers already created?
+			return nil, errors.New("making server on port " + strconv.Itoa(port) + ": " + err.Error())
+		}
+		servers = append(servers, server)
+	}
+	return servers, nil
+}
+
+func New(port int, remaps []string) (*http.Server, error) {
+	serverData, remapIncrements := newData(remaps)
+	fakeServerThs, err := fakesrvrdata.Run(serverData, remapIncrements)
+	if err != nil {
+		return nil, errors.New("running FakeServer: " + err.Error())
+	}
+	fmt.Println("Starting Serving on port " + strconv.Itoa(port)) // debug
+	srvr := Serve(port, fakeServerThs)
+	fmt.Println("Serving on port " + strconv.Itoa(port)) // debug
+	return srvr, nil
+}
+
+func newData(remaps []string) (fakesrvrdata.FakeServerData, map[string]fakesrvrdata.BytesPerSec) {
+	serverDataRemap := map[string]fakesrvrdata.FakeRemap{}
+	for _, remap := range remaps {
+		serverDataRemap[remap] = fakesrvrdata.FakeRemap{}
+	}
+	serverData := fakesrvrdata.FakeServerData{
+		ATS: fakesrvrdata.FakeATS{
+			Server: "6.2.2",
+			Remaps: serverDataRemap,
+		},
+		System: fakesrvrdata.FakeSystem{
+			Name:       "bond0",
+			Speed:      20000,
+			ProcNetDev: fakesrvrdata.FakeProcNetDev{Interface: "bond0"},
+			ProcLoadAvg: fakesrvrdata.FakeProcLoadAvg{
+				CPU1m:        4.52,
+				CPU5m:        4.64,
+				CPU10m:       4.47,
+				RunningProcs: 2,
+				TotalProcs:   1592,
+				LastPIDUsed:  32174,
+			},
+			ConfgiReloadRequests: 10,
+			LastReloadRequest:    1512768709,
+			ConfigReloads:        1,
+			LastReload:           1512678516,
+			AstatsLoad:           1512678516,
+			Something:            "here",
+		},
+	}
+
+	remapIncrements := map[string]fakesrvrdata.BytesPerSec{}
+	for i, remap := range remaps {
+		scale := uint64(float64(i) / float64(len(remaps)) * 100.0)
+		remapIncrements[remap] = fakesrvrdata.BytesPerSec{
+			Min: fakesrvrdata.FakeRemap{
+				InBytes:   1,
+				OutBytes:  1,
+				Status2xx: 1,
+				Status3xx: 0,
+				Status4xx: 0,
+				Status5xx: 0,
+			},
+			Max: fakesrvrdata.FakeRemap{
+				InBytes:   scale/2 + 1,
+				OutBytes:  scale + 1,
+				Status2xx: scale/10 + 1,
+				Status3xx: scale / 40,
+				Status4xx: scale / 20,
+				Status5xx: scale / 60,
+			},
+		}
+	}
+	return serverData, remapIncrements
+}

--- a/traffic_monitor/tools/testcaches/fakesrvr/server.go
+++ b/traffic_monitor/tools/testcaches/fakesrvr/server.go
@@ -1,0 +1,57 @@
+package fakesrvr
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/tools/testcaches/fakesrvrdata"
+)
+
+// TODO config?
+const readTimeout = time.Second * 10
+const writeTimeout = time.Second * 10
+
+func reqIsApplicationSystem(r *http.Request) bool {
+	return r.URL.Query().Get("application") == "system"
+}
+
+func astatsHandler(fakeSrvrDataThs fakesrvrdata.Ths) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		srvr := (*fakesrvrdata.FakeServerData)(fakeSrvrDataThs.Get())
+		// TODO cast to System, if query string `application=system`
+		b := []byte{}
+		err := error(nil)
+		if reqIsApplicationSystem(r) {
+			system := srvr.GetSystem()
+			b, err = json.MarshalIndent(&system, "", "  ") // TODO debug, change to Marshal
+		} else {
+			b, err = json.MarshalIndent(&srvr, "", "  ") // TODO debug, change to Marshal
+		}
+		if err != nil {
+			w.Write([]byte(`{"error": "marshalling: ` + err.Error() + `"}`)) // TODO escape error for JSON
+		}
+		w.Write(b)
+	}
+}
+
+func Serve(port int, fakeSrvrData fakesrvrdata.Ths) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_astats", astatsHandler(fakeSrvrData))
+	server := &http.Server{
+		Addr:           ":" + strconv.Itoa(port),
+		Handler:        mux,
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
+		MaxHeaderBytes: 1 << 20,
+	}
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			// TODO pass the error somewhere, somehow?
+			fmt.Println("Error serving on port " + strconv.Itoa(port) + ": " + err.Error())
+		}
+	}()
+	return server
+}

--- a/traffic_monitor/tools/testcaches/fakesrvrdata/fakesrvrdata.go
+++ b/traffic_monitor/tools/testcaches/fakesrvrdata/fakesrvrdata.go
@@ -1,0 +1,168 @@
+package fakesrvrdata
+
+import (
+	"bytes"
+	"strconv"
+)
+
+type ThsT *FakeServerData
+
+type FakeServerData struct {
+	ATS    FakeATS    `json:"ats"`
+	System FakeSystem `json:"system"`
+}
+
+// GetSystem returns a FakeServerSystem, which can be serialized as the JSON response of Astats with an "application=system" query
+func (s *FakeServerData) GetSystem() FakeServerSystem {
+	return FakeServerSystem{
+		ATS: FakeSystemATS{
+			Server: s.ATS.Server,
+		},
+		System: s.System,
+	}
+}
+
+type FakeATS struct {
+	Server string `json:"server"`
+	Remaps map[string]FakeRemap
+}
+
+func copyRemaps(old map[string]FakeRemap) map[string]FakeRemap {
+	new := make(map[string]FakeRemap, len(old))
+	for k, v := range old {
+		new[k] = v
+	}
+	return new
+}
+
+type FakeRemap struct {
+	InBytes   uint64
+	OutBytes  uint64
+	Status2xx uint64
+	Status3xx uint64
+	Status4xx uint64
+	Status5xx uint64
+}
+
+func (a FakeATS) MarshalJSON() ([]byte, error) {
+	// `copy` is faster than bytes.Buffer, if we precompute the length, which is possible but not trivial.
+	var b bytes.Buffer
+	b.WriteString("{")
+	for remapName, remap := range a.Remaps {
+		b.WriteString(`"plugin.remap_stats.`)
+		b.WriteString(remapName)
+		b.WriteString(`.in_bytes": `)
+		b.WriteString(strconv.FormatUint(remap.InBytes, 10))
+		b.WriteString(",")
+		b.WriteString(`"plugin.remap_stats.`)
+		b.WriteString(remapName)
+		b.WriteString(`.out_bytes": `)
+		b.WriteString(strconv.FormatUint(remap.OutBytes, 10))
+		b.WriteString(",")
+		b.WriteString(`"plugin.remap_stats.`)
+		b.WriteString(remapName)
+		b.WriteString(`.status_2xx": `)
+		b.WriteString(strconv.FormatUint(remap.Status2xx, 10))
+		b.WriteString(",")
+		b.WriteString(`"plugin.remap_stats.`)
+		b.WriteString(remapName)
+		b.WriteString(`.status_3xx": `)
+		b.WriteString(strconv.FormatUint(remap.Status3xx, 10))
+		b.WriteString(",")
+		b.WriteString(`"plugin.remap_stats.`)
+		b.WriteString(remapName)
+		b.WriteString(`.status_4xx": `)
+		b.WriteString(strconv.FormatUint(remap.Status4xx, 10))
+		b.WriteString(",")
+		b.WriteString(`"plugin.remap_stats.`)
+		b.WriteString(remapName)
+		b.WriteString(`.status_5xx": `)
+		b.WriteString(strconv.FormatUint(remap.Status5xx, 10))
+		b.WriteString(",")
+	}
+	b.WriteString(`"server": "`)
+	b.WriteString(a.Server)
+	b.WriteString(`"}`)
+	return b.Bytes(), nil
+}
+
+type FakeServerSystem struct {
+	ATS    FakeSystemATS `json:"ats"`
+	System FakeSystem    `json:"system"`
+}
+
+type FakeSystemATS struct {
+	Server string `json:"server"`
+}
+
+type FakeSystem struct {
+	Name                 string          `json:"inf.name"`
+	Speed                int             `json:"inf.speed"`
+	ProcNetDev           FakeProcNetDev  `json:"proc.net.dev"`
+	ProcLoadAvg          FakeProcLoadAvg `json:"proc.loadavg"`
+	ConfgiReloadRequests uint64          `json:"configReloadRequests"`
+	LastReloadRequest    uint64          `json:"lastReloadRequest"`
+	ConfigReloads        uint64          `json:"configReloads"`
+	LastReload           uint64          `json:"lastReload"`
+	AstatsLoad           uint64          `json:"astatsLoad"`
+	Something            string          `json:"something"`
+}
+
+type FakeProcLoadAvg struct {
+	CPU1m        float64
+	CPU5m        float64
+	CPU10m       float64
+	RunningProcs int
+	TotalProcs   int
+	LastPIDUsed  int
+}
+
+func (p FakeProcLoadAvg) MarshalJSON() ([]byte, error) {
+	return []byte("\"" +
+		strconv.FormatFloat(p.CPU1m, 'f', -1, 64) + " " +
+		strconv.FormatFloat(p.CPU5m, 'f', -1, 64) + " " +
+		strconv.FormatFloat(p.CPU10m, 'f', -1, 64) + " " +
+		strconv.Itoa(p.RunningProcs) + "/" +
+		strconv.Itoa(p.TotalProcs) + " " +
+		strconv.Itoa(p.LastPIDUsed) + "\""), nil
+}
+
+type FakeProcNetDev struct {
+	Interface      string
+	RcvBytes       uint64
+	RcvPackets     uint64
+	RcvErrs        uint64
+	RcvDropped     uint64
+	RcvFIFOErrs    uint64
+	RcvFrameErrs   uint64
+	RcvCompressed  uint64
+	RcvMulticast   uint64
+	SndBytes       uint64
+	SndPackets     uint64
+	SndErrs        uint64
+	SndDropped     uint64
+	SndFIFOErrs    uint64
+	SndCollisions  uint64
+	SndCarrierErrs uint64
+	SndCompressed  uint64
+}
+
+func (p FakeProcNetDev) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + p.Interface + ": " +
+		strconv.FormatUint(p.RcvBytes, 10) + " " +
+		strconv.FormatUint(p.RcvPackets, 10) + " " +
+		strconv.FormatUint(p.RcvErrs, 10) + " " +
+		strconv.FormatUint(p.RcvDropped, 10) + " " +
+		strconv.FormatUint(p.RcvFIFOErrs, 10) + " " +
+		strconv.FormatUint(p.RcvFrameErrs, 10) + " " +
+		strconv.FormatUint(p.RcvCompressed, 10) + " " +
+		strconv.FormatUint(p.RcvMulticast, 10) + " " +
+		strconv.FormatUint(p.SndBytes, 10) + " " +
+		strconv.FormatUint(p.SndPackets, 10) + " " +
+		strconv.FormatUint(p.SndErrs, 10) + " " +
+		strconv.FormatUint(p.SndDropped, 10) + " " +
+		strconv.FormatUint(p.SndFIFOErrs, 10) + " " +
+		strconv.FormatUint(p.SndCollisions, 10) + " " +
+		strconv.FormatUint(p.SndCarrierErrs, 10) + " " +
+		strconv.FormatUint(p.SndCompressed, 10) + "\""), nil
+}

--- a/traffic_monitor/tools/testcaches/fakesrvrdata/run.go
+++ b/traffic_monitor/tools/testcaches/fakesrvrdata/run.go
@@ -1,0 +1,96 @@
+package fakesrvrdata
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+)
+
+type BytesPerSec struct { // TODO change to PerMin? PerHour? (to allow, e.g. one 5xx per hour)
+	Min FakeRemap
+	Max FakeRemap
+}
+
+// runValidate verifies the FakeServerData Remaps match the RemapIncrements
+func runValidate(s *FakeServerData, remapIncrements map[string]BytesPerSec) error {
+	for r, _ := range s.ATS.Remaps {
+		if _, ok := remapIncrements[r]; !ok {
+			return errors.New("remap increments missing server remap '" + r + "'")
+		}
+	}
+	for r, bps := range remapIncrements {
+		if _, ok := s.ATS.Remaps[r]; !ok {
+			return errors.New("remap increments has remap not in server '" + r + "'")
+		}
+		if bps.Min.InBytes > bps.Max.InBytes || bps.Min.InBytes < 0 {
+			return errors.New("invalid remap increments InBytes: must be Max >= Min >= 0)")
+		}
+		if bps.Min.OutBytes > bps.Max.OutBytes || bps.Min.OutBytes < 0 {
+			return errors.New("invalid remap increments OutBytes: must be Max >= Min >= 0)")
+		}
+		if bps.Min.Status2xx > bps.Max.Status2xx || bps.Min.Status2xx < 0 {
+			return errors.New("invalid remap increments Status2xx: must be Max >= Min >= 0)")
+		}
+		if bps.Min.Status3xx > bps.Max.Status3xx || bps.Min.Status3xx < 0 {
+			return errors.New("invalid remap increments Status3xx: must be Max >= Min >= 0)")
+		}
+		if bps.Min.Status4xx > bps.Max.Status4xx || bps.Min.Status4xx < 0 {
+			return errors.New("invalid remap increments Status4xx: must be Max >= Min >= 0)")
+		}
+		if bps.Min.Status5xx > bps.Max.Status5xx || bps.Min.Status5xx < 0 {
+			return errors.New("invalid remap increments Status5xx: must be Max >= Min >= 0)")
+		}
+	}
+	return nil
+}
+
+// Run takes a FakeServerData and a config, and starts running it, incrementing stats per the config. Returns a Threadsafe accessor to the running FakeServerData pointer, whose value may be accessed, but MUST NOT be modified.
+// TODO add increments for Rcv,SndPackets, ProcLoadAvg variance, ConfigReloads
+func Run(s FakeServerData, remapIncrements map[string]BytesPerSec) (Ths, error) {
+	// TODO seed rand? Param?
+	if err := runValidate(&s, remapIncrements); err != nil {
+		return Ths{}, errors.New("invalid configuration: " + err.Error())
+	}
+	ths := NewThs()
+	ths.Set(&s)
+	go run(ths, remapIncrements)
+	return ths, nil
+}
+
+// run starts a goroutine incrementing the FakeServerData's values according to the remapIncrements. Never returns.
+func run(srvrThs Ths, remapIncrements map[string]BytesPerSec) {
+	tickSecs := uint64(1) // adjustable for performance (i.e. a higher number is less CPU work)
+	for {
+		time.Sleep(time.Second * time.Duration(tickSecs))
+		srvr := srvrThs.Get()
+		newRemaps := copyRemaps(srvr.ATS.Remaps)
+		for remap, increments := range remapIncrements {
+			srvrRemap := newRemaps[remap]
+			if increments.Min.InBytes != increments.Min.InBytes {
+				i := uint64(rand.Int63n(int64((increments.Max.InBytes-increments.Min.InBytes)*tickSecs))) + (increments.Min.InBytes * tickSecs)
+				srvrRemap.InBytes += i
+				srvr.System.ProcNetDev.RcvBytes += i
+			}
+			if increments.Min.OutBytes != increments.Max.OutBytes {
+				i := uint64(rand.Int63n(int64((increments.Max.OutBytes-increments.Min.OutBytes)*tickSecs))) + (increments.Min.OutBytes * tickSecs)
+				srvrRemap.OutBytes += i
+				srvr.System.ProcNetDev.SndBytes += i
+			}
+			if increments.Min.Status2xx != increments.Max.Status2xx {
+				srvrRemap.Status2xx += uint64(rand.Int63n(int64((increments.Max.Status2xx-increments.Min.Status2xx)*tickSecs))) + (increments.Min.Status2xx * tickSecs)
+			}
+			if increments.Min.Status3xx != increments.Max.Status3xx {
+				srvrRemap.Status3xx += uint64(rand.Int63n(int64((increments.Max.Status3xx-increments.Min.Status3xx)*tickSecs))) + (increments.Min.Status3xx * tickSecs)
+			}
+			if increments.Min.Status4xx != increments.Max.Status4xx {
+				srvrRemap.Status4xx += uint64(rand.Int63n(int64((increments.Max.Status4xx-increments.Min.Status4xx)*tickSecs))) + (increments.Min.Status4xx * tickSecs)
+			}
+			if increments.Min.Status5xx != increments.Max.Status5xx {
+				srvrRemap.Status5xx += uint64(rand.Int63n(int64((increments.Max.Status5xx-increments.Min.Status5xx)*tickSecs))) + (increments.Min.Status5xx * tickSecs)
+			}
+			newRemaps[remap] = srvrRemap
+		}
+		srvr.ATS.Remaps = newRemaps
+		srvrThs.Set(srvr)
+	}
+}

--- a/traffic_monitor/tools/testcaches/fakesrvrdata/ths.go
+++ b/traffic_monitor/tools/testcaches/fakesrvrdata/ths.go
@@ -1,0 +1,28 @@
+package fakesrvrdata
+
+import (
+	"sync"
+)
+
+// Ths provides threadsafe access to a ThsT pointer. Note the object itself is not safe for multiple access, and must not be mutated, either by the original owner after calling Set, or by future users who call Get. If you need to mutate, perform a deep copy.
+type Ths struct {
+	v *ThsT
+	m *sync.RWMutex
+}
+
+func NewThs() Ths {
+	v := ThsT(nil)
+	return Ths{m: &sync.RWMutex{}, v: &v}
+}
+
+func (t Ths) Set(v ThsT) {
+	t.m.Lock()
+	defer t.m.Unlock()
+	*t.v = v
+}
+
+func (t Ths) Get() ThsT {
+	t.m.RLock()
+	defer t.m.RUnlock()
+	return *t.v
+}

--- a/traffic_monitor/tools/testcaches/testcaches.go
+++ b/traffic_monitor/tools/testcaches/testcaches.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/apache/incubator-trafficcontrol/traffic_monitor/tools/testcaches/fakesrvr"
+)
+
+func makeFakeRemaps(n int) []string {
+	remaps := []string{}
+	for i := 0; i < n; i++ {
+		remaps = append(remaps, "num"+strconv.Itoa(i)+".example.net")
+	}
+	return remaps
+}
+
+func main() {
+	portStart := flag.Int("portStart", 40000, "Starting port in range")
+	numPorts := flag.Int("numPorts", 1000, "Number of ports to serve")
+	numRemaps := flag.Int("numRemaps", 1000, "Number of remaps to serve")
+	flag.Parse()
+	if *portStart < 0 || *portStart > 65535 {
+		fmt.Println("portStart must be 0-65535")
+		return
+	} else if *numPorts < 0 || *portStart+*numPorts > 65535 {
+		fmt.Println("numPorts must be > 0 and portStart+numPorts < 65535")
+		return
+	} else if *numRemaps < 0 {
+		fmt.Println("numRemaps must be > 0")
+		return
+	}
+
+	remaps := makeFakeRemaps(*numRemaps)
+	servers, err := fakesrvr.News(*portStart, *numPorts, remaps)
+	if err != nil {
+		fmt.Println("Error making FakeServers: " + err.Error())
+		return
+	}
+	servers = servers // debug
+	for {
+		// TODO handle sighup to die
+		time.Sleep(time.Hour)
+	}
+}


### PR DESCRIPTION
Adds Monitor testcaches tool, to serve fake ATS astats data for
multiple servers, for load testing the Monitor.