### PR TITLE
Configure the error and info loggers on the riak package.

### DIFF
--- a/traffic_ops/etc/init.d/traffic_ops
+++ b/traffic_ops/etc/init.d/traffic_ops
@@ -41,6 +41,11 @@ TO_EXT_PRIVATE_LIB="/opt/traffic_ops_extensions/private/lib"; export TO_PRIVATE_
 PERL5LIB=$TO_EXT_PRIVATE_LIB:$TO_DIR/lib:$TO_DIR/local/lib/perl5:$PERL5LIB; export PERL5LIB
 
 PIDFILE="/var/run/traffic_ops.pid"
+
+# uncomment this for riak client debug logging to the defined info log location.
+# logs to stdout if the info log location is not defined in the cdn.conf
+#RIAK_GO_CLIENT_DEBUG="true"; export RIAK_GO_CLIENT_DEBUG
+
 # source function library
 . /etc/rc.d/init.d/functions
 


### PR DESCRIPTION
This change is to configure the info and error loggers on the riak client package so that the traffic_ops log files are used by this package.  This will help to identify riak node problems.  

This will help to mitigate an issue seen by @smalenfant recently when using riak nodes configured with self signed TLS certificates.