### PR TITLE
The RIAK DefaultNodeManager can get into an infinite loop

### DIFF
--- a/traffic_ops/traffic_ops_golang/riak.go
+++ b/traffic_ops/traffic_ops_golang/riak.go
@@ -42,6 +42,9 @@ const SSLKeysBucket = "ssl"
 // 5 second timeout
 const timeOut = time.Second * 5
 
+// maximum command execution attempts
+const MaxCommandExecutionAttempts = 5
+
 type StorageCluster interface {
 	Start() error
 	Stop() error
@@ -187,7 +190,8 @@ func getRiakCluster(db *sqlx.DB, cfg Config) (StorageCluster, error) {
 	}
 
 	opts := &riak.ClusterOptions{
-		Nodes: nodes,
+		Nodes:             nodes,
+		ExecutionAttempts: MaxCommandExecutionAttempts,
 	}
 
 	cluster, err := riak.NewCluster(opts)


### PR DESCRIPTION
Ran into a problem here when no node could successfully execute the command
without error.  Got into an infinite loop here due to using self signed certs
on all the nodes without properly setting up TLS to accept in-secure certs.
 
Returning the error here to the cluster allows to it re-queue this command and track
the number of execution attempts.  Once the configured 'ExecutionAttempts' has been
exceeded. The cluster then returns the error to the client.