### PR TITLE
[Issue-1679] - preserve traffic_portal_properties.json on upgrade

### DIFF
--- a/traffic_portal/build/traffic_portal.spec
+++ b/traffic_portal/build/traffic_portal.spec
@@ -81,6 +81,7 @@ tar -xzvf $RPM_SOURCE_DIR/traffic_portal-%{version}.tgz
 %attr(755,root,root) /etc/init.d/traffic_portal
 %attr(755,root,root) %{traffic_portal_home}/node_modules/forever/bin/*
 %config(noreplace)/etc/traffic_portal/conf/config.js
+%config(noreplace)%{traffic_portal_home}/public/traffic_portal_properties.json
 %dir /var/log/traffic_portal
 %{traffic_portal_home}/*
 /etc/logrotate.d/traffic_portal


### PR DESCRIPTION
Rather than stomping traffic_portal_properties.json every time the Traffic Portal is upgraded, preserve it and create  traffic_portal_properties.json.rpmnew and allow the administrator to modify traffic_portal_properties.json if necessary.

fixes #1679 
