### PR TITLE
Make Traffic Router ignore ANY_MAP Delivery Services

### DIFF
--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -273,7 +273,8 @@ sub gen_crconfig_json {
     my $rs_ds = $self->db->resultset('Deliveryservice')->search(
         {
 			'me.cdn_id' => $cdn_id,
-            'active'     => 1
+            'active'     => 1,
+            'type.name' => { '!=', [ 'ANY_MAP' ] }
         },
         { prefetch => [ 'deliveryservice_servers', 'deliveryservice_regexes', 'type' ] }
     );


### PR DESCRIPTION
Delivery Services of type ANY_MAP should be completely ignored by
Traffic Router, even if they're set to 'active'. An active ANY_MAP DS is
treated like an HTTP DS to the Traffic Router (which is bad).

In practice ANY_MAP DSes have been set to inactive (which makes them
ignored by TR but still able to add "raw remap text" lines to
remap.config), but this makes it so that even if they're set to active
they're still ignored by TR.