### PR TITLE
[Issue-1697] - removes hardcoded offline status id

### DIFF
--- a/traffic_portal/app/src/common/modules/form/server/FormServerController.js
+++ b/traffic_portal/app/src/common/modules/form/server/FormServerController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var FormServerController = function(server, $scope, $location, $state, $uibModal, formUtils, locationUtils, serverUtils, serverService, cacheGroupService, cdnService, physLocationService, profileService, statusService, typeService, messageModel) {
+var FormServerController = function(server, $scope, $location, $state, $uibModal, formUtils, locationUtils, serverUtils, serverService, cacheGroupService, cdnService, physLocationService, profileService, typeService, messageModel) {
 
     var getPhysLocations = function() {
         physLocationService.getPhysLocations()
@@ -44,13 +44,6 @@ var FormServerController = function(server, $scope, $location, $state, $uibModal
         cdnService.getCDNs(true)
             .then(function(result) {
                 $scope.cdns = result;
-            });
-    };
-
-    var getStatuses = function() {
-        statusService.getStatuses()
-            .then(function(result) {
-                $scope.statuses = result;
             });
     };
 
@@ -161,12 +154,11 @@ var FormServerController = function(server, $scope, $location, $state, $uibModal
         getCacheGroups();
         getTypes();
         getCDNs();
-        getStatuses();
         getProfiles(($scope.server.cdnId) ? $scope.server.cdnId : 0); // hacky but does the job. only when a cdn is selected can we fetch the appropriate profiles. otherwise, show no profiles.
     };
     init();
 
 };
 
-FormServerController.$inject = ['server', '$scope', '$location', '$state', '$uibModal', 'formUtils', 'locationUtils', 'serverUtils', 'serverService', 'cacheGroupService', 'cdnService', 'physLocationService', 'profileService', 'statusService', 'typeService', 'messageModel'];
+FormServerController.$inject = ['server', '$scope', '$location', '$state', '$uibModal', 'formUtils', 'locationUtils', 'serverUtils', 'serverService', 'cacheGroupService', 'cdnService', 'physLocationService', 'profileService', 'typeService', 'messageModel'];
 module.exports = FormServerController;

--- a/traffic_portal/app/src/common/modules/form/server/edit/FormEditServerController.js
+++ b/traffic_portal/app/src/common/modules/form/server/edit/FormEditServerController.js
@@ -17,10 +17,17 @@
  * under the License.
  */
 
-var FormEditServerController = function(server, $scope, $controller, $uibModal, $anchorScroll, locationUtils, serverService) {
+var FormEditServerController = function(server, $scope, $controller, $uibModal, $anchorScroll, locationUtils, serverService, statusService) {
 
     // extends the FormServerController to inherit common methods
     angular.extend(this, $controller('FormServerController', { server: server, $scope: $scope }));
+
+    var getStatuses = function() {
+        statusService.getStatuses()
+            .then(function(result) {
+                $scope.statuses = result;
+            });
+    };
 
     var deleteServer = function(server) {
         serverService.deleteServer(server.id)
@@ -66,7 +73,12 @@ var FormEditServerController = function(server, $scope, $controller, $uibModal, 
         });
     };
 
+    var init = function () {
+        getStatuses();
+    };
+    init();
+
 };
 
-FormEditServerController.$inject = ['server', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'serverService'];
+FormEditServerController.$inject = ['server', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'serverService', 'statusService'];
 module.exports = FormEditServerController;

--- a/traffic_portal/app/src/common/modules/form/server/new/FormNewServerController.js
+++ b/traffic_portal/app/src/common/modules/form/server/new/FormNewServerController.js
@@ -17,10 +17,20 @@
  * under the License.
  */
 
-var FormNewServerController = function(server, $scope, $controller, serverService) {
+var FormNewServerController = function(server, $scope, $controller, serverService, statusService) {
 
     // extends the FormServerController to inherit common methods
     angular.extend(this, $controller('FormServerController', { server: server, $scope: $scope }));
+
+    var getStatuses = function() {
+        statusService.getStatuses()
+            .then(function(result) {
+                $scope.statuses = result;
+                // new servers are set to OFFLINE by default
+                var offlineStatus = _.find(result, function(status){ return status.name == 'OFFLINE' });
+                $scope.server.statusId = offlineStatus.id;
+            });
+    };
 
     $scope.serverName = 'New';
 
@@ -33,7 +43,12 @@ var FormNewServerController = function(server, $scope, $controller, serverServic
         serverService.createServer(server);
     };
 
+    var init = function () {
+        getStatuses();
+    };
+    init();
+
 };
 
-FormNewServerController.$inject = ['server', '$scope', '$controller', 'serverService'];
+FormNewServerController.$inject = ['server', '$scope', '$controller', 'serverService', 'statusService'];
 module.exports = FormNewServerController;

--- a/traffic_portal/app/src/modules/private/servers/new/index.js
+++ b/traffic_portal/app/src/modules/private/servers/new/index.js
@@ -29,8 +29,7 @@ module.exports = angular.module('trafficPortal.private.servers.new', [])
                         resolve: {
                             server: function() {
                                 return {
-                                    updPending: false,
-                                    statusId: 1 // todo: 1 is the ID of OFFLINE, need to get the ID dynamically
+                                    updPending: false
                                 };
                             }
                         }


### PR DESCRIPTION
New servers are set to OFFLINE therefore on a new server you need to set statusId = [the ID of the OFFLINE status]

so now, i call GET /api/statuses and find the OFFLINE one and use that ID...

fixes #1697 