### PR TITLE
ATS traffic_line to traffic_ctl conversion

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -766,7 +766,7 @@ sub send_update_to_trops {
 }
 
 sub get_print_current_client_connections {
-	my $cmd                 = $TRAFFIC_CTL . " -r proxy.process.http.current_client_connections";
+	my $cmd                 = $TRAFFIC_CTL . " metric get proxy.process.http.current_client_connections";
 	my $current_connections = `$cmd 2>/dev/null`;
 	chomp($current_connections);
 	( $log_level >> $DEBUG ) && print "DEBUG There are currently $current_connections connections.\n";


### PR DESCRIPTION
The ATS command traffic_line has been deprecated. With ATS 7 it no longer exists, so we need to move to the new traffic_ctl to do config updates.

This changes all usages of traffic_line to traffic_ctl and updates arguments as necessary