### PR TITLE
Adding TXT Records support

### DIFF
--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -396,6 +396,7 @@ insert into type (name, description, use_in_table) values ('RESOLVE6', 'federati
 insert into type (name, description, use_in_table) values ('A_RECORD', 'Static DNS A entry', 'staticdnsentry') ON CONFLICT (name) DO NOTHING;
 insert into type (name, description, use_in_table) values ('AAAA_RECORD', 'Static DNS AAAA entry', 'staticdnsentry') ON CONFLICT (name) DO NOTHING;
 insert into type (name, description, use_in_table) values ('CNAME_RECORD', 'Static DNS CNAME entry', 'staticdnsentry') ON CONFLICT (name) DO NOTHING;
+insert into type (name, description, use_in_table) values ('TXT_RECORD', 'Static DNS TXT entry', 'staticdnsentry') ON CONFLICT (name) DO NOTHING;
 
 --steering_target types
 insert into type (name, description, use_in_table) values ('STEERING_WEIGHT', 'Weighted steering target', 'steering_target') ON CONFLICT (name) DO NOTHING;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -55,6 +55,7 @@ import org.xbill.DNS.Record;
 import org.xbill.DNS.SOARecord;
 import org.xbill.DNS.SetResponse;
 import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.TXTRecord;
 import org.xbill.DNS.Type;
 import org.xbill.DNS.Zone;
 
@@ -488,6 +489,7 @@ public class ZoneManager extends Resolver {
 		return records;
 	}
 
+	@SuppressWarnings("PMD.CyclomaticComplexity")
 	private static void addStaticDnsEntries(final List<Record> list, final DeliveryService ds, final String domain)
 			throws TextParseException, UnknownHostException {
 		if (ds != null && ds.getStaticDnsEntries() != null) {
@@ -505,13 +507,19 @@ public class ZoneManager extends Resolver {
 					if (ttl == 0) {
 						ttl = ZoneUtils.getLong(ds.getTtls(), type, 60);
 					}
-
-					if ("A".equals(type)) {
-						list.add(new ARecord(name, DClass.IN, ttl, InetAddress.getByName(value)));
-					} else if (AAAA.equals(type)) {
-						list.add(new AAAARecord(name, DClass.IN, ttl, InetAddress.getByName(value)));
-					} else if ("CNAME".equals(type)) {
-						list.add(new CNAMERecord(name, DClass.IN, ttl, new Name(value)));
+					switch(type) {
+						case "A": 
+							list.add(new ARecord(name, DClass.IN, ttl, InetAddress.getByName(value)));
+							break;
+						case "AAAA": 
+							list.add(new AAAARecord(name, DClass.IN, ttl, InetAddress.getByName(value)));
+							break;
+						case "CNAME":
+							list.add(new CNAMERecord(name, DClass.IN, ttl, new Name(value)));
+							break;
+						case "TXT":
+							list.add(new TXTRecord(name, DClass.IN, ttl, new String(value)));
+							break;
 					}
 				} catch (JSONException e) {
 					LOGGER.error(e);

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/keys/ZoneTestRecords.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/keys/ZoneTestRecords.java
@@ -25,6 +25,7 @@ import org.xbill.DNS.DNSKEYRecord;
 import org.xbill.DNS.NSRecord;
 import org.xbill.DNS.Name;
 import org.xbill.DNS.Record;
+import org.xbill.DNS.TXTRecord;
 import org.xbill.DNS.SOARecord;
 
 import java.net.Inet6Address;
@@ -103,6 +104,8 @@ public class ZoneTestRecords {
 		Name webMirror = new Name("mirror.www.example.com.");
 		Name ftpMirror = new Name("mirror.ftp.example.com.");
 
+		String txtRecord = new String("dead0123456789");
+
 		records = new ArrayList<>(Arrays.asList(
 			new AAAARecord(webServer, DClass.IN, threeDays.getSeconds(), Inet6Address.getByName("2001:db8::5:6:7:8")),
 			new AAAARecord(ftpServer, DClass.IN, threeDays.getSeconds(), Inet6Address.getByName("2001:db8::12:34:56:78")),
@@ -118,6 +121,7 @@ public class ZoneTestRecords {
 			new AAAARecord(ftpServer, DClass.IN, threeDays.getSeconds(), Inet6Address.getByName("2001:db8::21:43:65:87")),
 			new CNAMERecord(webMirror, DClass.IN, tenYears.getSeconds(), webServer),
 			new CNAMERecord(ftpMirror, DClass.IN, tenYears.getSeconds(), ftpServer)
+			new TXTRecord(txtRecord, DClass.IN, tenYears.getSeconds(), txtRecord)
 		));
 
 		if (makeNewKeyPairs) {


### PR DESCRIPTION
This adds TXT Record support to Traffic Router. To enable, you must also add a `TXT` Type in Traffic Ops and add your static record under your delivery service.

Added the feature so it could be used with Let's Encrypt (TBD).