### PR TITLE
Add doc badge, repoint docs in README - this fixes #1625

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@
 Apache Traffic Control (incubating) is an Open Source implementation of a Content Delivery Network.
 
 #### Documentation
-* [Intro](http://traffic-control-cdn.readthedocs.io/en/latest//index.html)
-* [CDN Basics](http://traffic-control-cdn.readthedocs.io/en/latest//basics/index.html)
-* [Traffic Control Overview](http://traffic-control-cdn.readthedocs.io/en/latest//overview/index.html)
-* [Administrator's Guide](http://traffic-control-cdn.readthedocs.io/en/latest//admin/index.html)
-* [Developer's Guide](http://traffic-control-cdn.readthedocs.io/en/latest//development/index.html)
+* [Intro](http://traffic-control-cdn.readthedocs.io/en/latest/index.html)
+* [CDN Basics](http://traffic-control-cdn.readthedocs.io/en/latest/basics/index.html)
+* [Traffic Control Overview](http://traffic-control-cdn.readthedocs.io/en/latest/overview/index.html)
+* [Administrator's Guide](http://traffic-control-cdn.readthedocs.io/en/latest/admin/index.html)
+* [Developer's Guide](http://traffic-control-cdn.readthedocs.io/en/latest/development/index.html)
 
 ####  Questions, Comments, Bugs and More
-* [Frequently Asked Questions](http://traffic-control-cdn.readthedocs.io/en/latest//faq/index.html)
+* [Frequently Asked Questions](http://traffic-control-cdn.readthedocs.io/en/latest/faq/index.html)
 * [Found a bug or file a feature request](https://github.com/apache/incubator-trafficcontrol/issues)
 * [Subscribe to our users list](mailto:users-subscribe@trafficcontrol.incubator.apache.org)
 * [Subscribe to our dev list](mailto:dev-subscribe@trafficcontrol.incubator.apache.org)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Apache Traffic Control (incubating) is an Open Source implementation of a Conten
 * [Administrator's Guide](http://traffic-control-cdn.readthedocs.io/en/latest//admin/index.html)
 * [Developer's Guide](http://traffic-control-cdn.readthedocs.io/en/latest//development/index.html)
 
-####Questions, Comments, Bugs and More
+####  Questions, Comments, Bugs and More
 * [Frequently Asked Questions](http://traffic-control-cdn.readthedocs.io/en/latest//faq/index.html)
 * [Found a bug or file a feature request](https://github.com/apache/incubator-trafficcontrol/issues)
 * [Subscribe to our users list](mailto:users-subscribe@trafficcontrol.incubator.apache.org)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@
     under the License.
 -->
 
-Build: [![Build Status](https://builds.apache.org/buildStatus/icon?job=incubator-trafficcontrol-master-build)](https://builds.apache.org/view/Incubator%20Projects/job/incubator-trafficcontrol-master-build/)
-
-Documentation: [![Documentation Status](https://readthedocs.org/projects/traffic-control-cdn/badge/?version=latest)](http://traffic-control-cdn.readthedocs.io/en/latest/?badge=latest)
+[![Build Status](https://builds.apache.org/buildStatus/icon?job=incubator-trafficcontrol-master-build)](https://builds.apache.org/view/Incubator%20Projects/job/incubator-trafficcontrol-master-build/) [![Documentation Status](https://readthedocs.org/projects/traffic-control-cdn/badge/?version=latest)](http://traffic-control-cdn.readthedocs.io/en/latest/?badge=latest)
 
 Apache Traffic Control (incubating) is an Open Source implementation of a Content Delivery Network.
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@
 
 Build: [![Build Status](https://builds.apache.org/buildStatus/icon?job=incubator-trafficcontrol-master-build)](https://builds.apache.org/view/Incubator%20Projects/job/incubator-trafficcontrol-master-build/)
 
+Documentation: [![Documentation Status](https://readthedocs.org/projects/traffic-control-cdn/badge/?version=latest)](http://traffic-control-cdn.readthedocs.io/en/latest/?badge=latest)
+
 Apache Traffic Control (incubating) is an Open Source implementation of a Content Delivery Network.
 
 #### Documentation
-* [Intro](http://trafficcontrol.apache.org/docs/latest/index.html)
-* [CDN Basics](http://trafficcontrol.apache.org/docs/latest/basics/index.html)
-* [Traffic Control Overview](http://trafficcontrol.apache.org/docs/latest/overview/index.html)
-* [Administrator's Guide](http://trafficcontrol.apache.org/docs/latest/admin/index.html)
-* [Developer's Guide](http://trafficcontrol.apache.org/docs/latest/development/index.html)
+* [Intro](http://traffic-control-cdn.readthedocs.io/en/latest//index.html)
+* [CDN Basics](http://traffic-control-cdn.readthedocs.io/en/latest//basics/index.html)
+* [Traffic Control Overview](http://traffic-control-cdn.readthedocs.io/en/latest//overview/index.html)
+* [Administrator's Guide](http://traffic-control-cdn.readthedocs.io/en/latest//admin/index.html)
+* [Developer's Guide](http://traffic-control-cdn.readthedocs.io/en/latest//development/index.html)
 
 ####Questions, Comments, Bugs and More
-* [Frequently Asked Questions](http://trafficcontrol.apache.org/docs/latest/faq/index.html)
+* [Frequently Asked Questions](http://traffic-control-cdn.readthedocs.io/en/latest//faq/index.html)
 * [Found a bug or file a feature request](https://github.com/apache/incubator-trafficcontrol/issues)
 * [Subscribe to our users list](mailto:users-subscribe@trafficcontrol.incubator.apache.org)
 * [Subscribe to our dev list](mailto:dev-subscribe@trafficcontrol.incubator.apache.org)


### PR DESCRIPTION
I setup the readthedocs config with a generic account that I will share with the rest of the committers out-of-band. Every merged commit will automatically trigger a build on `latest`, and the badge here will show the build status. 

New released versions need to be activated in the readthedocs web UI. 

I will update the https://trafficcontrol.incubator.apache.org/ website to point to these doc endpoints later.
