### PR TITLE
Traffic Router - remove org.apache.wicket.ajax.json dependency

### DIFF
--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -296,13 +296,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- WICKET DEPENDENCIES -->
-		<dependency>
-			<groupId>org.apache.wicket</groupId>
-			<artifactId>wicket-core</artifactId>
-			<version>${wicket.version}</version>
-		</dependency>
-
 		<dependency>
 			<groupId>com.googlecode.java-ipv6</groupId>
 			<artifactId>java-ipv6</artifactId>

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 
+import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtilsException;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
@@ -173,8 +174,8 @@ public abstract class AbstractServiceUpdater {
 		return true;
 	}
 
-	abstract public boolean verifyDatabase(final File dbFile) throws IOException;
-	abstract public boolean loadDatabase() throws IOException;
+	abstract public boolean verifyDatabase(final File dbFile) throws IOException, JsonUtilsException;
+	abstract public boolean loadDatabase() throws IOException, JsonUtilsException;
 
 	public void setDatabaseName(final String databaseName) {
 		this.databaseName = databaseName;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -35,7 +35,6 @@ import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
-import org.apache.wicket.ajax.json.JSONException;
 
 import com.comcast.cdn.traffic_control.traffic_router.core.router.TrafficRouterManager;
 
@@ -174,8 +173,8 @@ public abstract class AbstractServiceUpdater {
 		return true;
 	}
 
-	abstract public boolean verifyDatabase(final File dbFile) throws IOException, JSONException;
-	abstract public boolean loadDatabase() throws IOException, JSONException;
+	abstract public boolean verifyDatabase(final File dbFile) throws IOException;
+	abstract public boolean loadDatabase() throws IOException;
 
 	public void setDatabaseName(final String databaseName) {
 		this.databaseName = databaseName;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
@@ -39,24 +39,14 @@ public class FederationMappingBuilder {
         final ComparableTreeSet<CidrAddress> network = new ComparableTreeSet<CidrAddress>();
         if (jsonNode.has("resolve4")) {
             final JsonNode networkList = JsonUtils.getJsonNode(jsonNode, "resolve4");
+            network.addAll(buildAddresses(networkList));
 
-            try {
-                network.addAll(buildAddresses(networkList));
-            }
-            catch (Exception e) {
-                LOGGER.warn("Failed getting ipv4 address array likely due to bad json data: " + e.getMessage());
-            }
         }
 
         final ComparableTreeSet<CidrAddress> network6 = new ComparableTreeSet<CidrAddress>();
         if (jsonNode.has("resolve6")) {
             final JsonNode network6List = JsonUtils.getJsonNode(jsonNode, "resolve6");
-            try {
-                network6.addAll(buildAddresses(network6List));
-            }
-            catch (Exception e) {
-                LOGGER.warn("Failed getting ipv6 address array likely due to bad json data: " + e.getMessage());
-            }
+            network6.addAll(buildAddresses(network6List));
         }
 
         return new FederationMapping(cname, ttl, network, network6);

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
@@ -18,6 +18,7 @@ package com.comcast.cdn.traffic_control.traffic_router.core.loc;
 import com.comcast.cdn.traffic_control.traffic_router.core.util.CidrAddress;
 import com.comcast.cdn.traffic_control.traffic_router.core.util.ComparableTreeSet;
 import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtils;
+import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtilsException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -28,16 +29,16 @@ import java.io.IOException;
 public class FederationMappingBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(FederationMappingBuilder.class);
 
-    public FederationMapping fromJSON(final String json) throws IOException {
+    public FederationMapping fromJSON(final String json) throws JsonUtilsException, IOException {
         final ObjectMapper mapper = new ObjectMapper();
         final JsonNode jsonNode = mapper.readTree(json);
 
-        final String cname = JsonUtils.getString(jsonNode, "cname", "");
-        final int ttl = JsonUtils.getInt(jsonNode, "ttl", 0);
+        final String cname = JsonUtils.getString(jsonNode, "cname");
+        final int ttl = JsonUtils.getInt(jsonNode, "ttl");
 
         final ComparableTreeSet<CidrAddress> network = new ComparableTreeSet<CidrAddress>();
         if (jsonNode.has("resolve4")) {
-            final JsonNode networkList = jsonNode.get("resolve4");
+            final JsonNode networkList = JsonUtils.getJsonNode(jsonNode, "resolve4");
 
             try {
                 network.addAll(buildAddresses(networkList));
@@ -49,7 +50,7 @@ public class FederationMappingBuilder {
 
         final ComparableTreeSet<CidrAddress> network6 = new ComparableTreeSet<CidrAddress>();
         if (jsonNode.has("resolve6")) {
-            final JsonNode network6List = jsonNode.get("resolve6");
+            final JsonNode network6List = JsonUtils.getJsonNode(jsonNode, "resolve6");
             try {
                 network6.addAll(buildAddresses(network6List));
             }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
@@ -17,6 +17,7 @@ package com.comcast.cdn.traffic_control.traffic_router.core.loc;
 
 import com.comcast.cdn.traffic_control.traffic_router.core.util.CidrAddress;
 import com.comcast.cdn.traffic_control.traffic_router.core.util.ComparableTreeSet;
+import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -27,13 +28,12 @@ import java.io.IOException;
 public class FederationMappingBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(FederationMappingBuilder.class);
 
-    @SuppressWarnings("PMD.NPathComplexity")
     public FederationMapping fromJSON(final String json) throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
         final JsonNode jsonNode = mapper.readTree(json);
 
-        final String cname = jsonNode.has("cname") ? jsonNode.get("cname").asText() : "";
-        final int ttl = jsonNode.has("ttl") ? jsonNode.get("ttl").asInt() : 0;
+        final String cname = JsonUtils.getString(jsonNode, "cname", "");
+        final int ttl = JsonUtils.getInt(jsonNode, "ttl", 0);
 
         final ComparableTreeSet<CidrAddress> network = new ComparableTreeSet<CidrAddress>();
         if (jsonNode.has("resolve4")) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilder.java
@@ -15,6 +15,7 @@
 
 package com.comcast.cdn.traffic_control.traffic_router.core.loc;
 
+import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -32,7 +33,7 @@ public class FederationsBuilder {
         final JsonNode federationList = jsonObject.get("response");
 
         for (final JsonNode currFederation : federationList) {
-            final String deliveryService = currFederation.has("deliveryService") ? currFederation.get("deliveryService").asText() : "";
+            final String deliveryService = JsonUtils.getString(currFederation, "deliveryService", "");
 
             final List<FederationMapping> mappings = new ArrayList<FederationMapping>();
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilder.java
@@ -16,6 +16,7 @@
 package com.comcast.cdn.traffic_control.traffic_router.core.loc;
 
 import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtils;
+import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtilsException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -25,19 +26,19 @@ import java.util.List;
 
 public class FederationsBuilder {
 
-    public List<Federation> fromJSON(final String jsonString) throws IOException {
+    public List<Federation> fromJSON(final String jsonString) throws JsonUtilsException, IOException {
         final List<Federation> federations = new ArrayList<Federation>();
 
         final ObjectMapper mapper = new ObjectMapper();
         final JsonNode jsonObject = mapper.readTree(jsonString);
-        final JsonNode federationList = jsonObject.get("response");
+        final JsonNode federationList = JsonUtils.getJsonNode(jsonObject, "response");
 
         for (final JsonNode currFederation : federationList) {
-            final String deliveryService = JsonUtils.getString(currFederation, "deliveryService", "");
+            final String deliveryService = JsonUtils.getString(currFederation, "deliveryService");
 
             final List<FederationMapping> mappings = new ArrayList<FederationMapping>();
 
-            final JsonNode mappingsList = currFederation.get("mappings");
+            final JsonNode mappingsList = JsonUtils.getJsonNode(currFederation, "mappings");
             final FederationMappingBuilder federationMappingBuilder = new FederationMappingBuilder();
 
             for (final JsonNode mapping : mappingsList) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNode.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNode.java
@@ -64,7 +64,6 @@ public class NetworkNode implements Comparable<NetworkNode> {
     public static NetworkNode generateTree(final File f, final boolean verifyOnly) throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
         return generateTree(mapper.readTree(f), verifyOnly);
-        //return generateTree(new JSONObject(new JSONTokener(new FileReader(f))), verifyOnly);
     }
 
     @SuppressWarnings("PMD.CyclomaticComplexity")

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNode.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNode.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 
 
 import com.comcast.cdn.traffic_control.traffic_router.core.util.CidrAddress;
+import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtils;
+import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtilsException;
 import com.comcast.cdn.traffic_control.traffic_router.geolocation.Geolocation;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -69,14 +71,14 @@ public class NetworkNode implements Comparable<NetworkNode> {
     @SuppressWarnings("PMD.CyclomaticComplexity")
     public static NetworkNode generateTree(final JsonNode json, final boolean verifyOnly) {
         try {
-            final JsonNode coverageZones = json.get("coverageZones");
+            final JsonNode coverageZones = JsonUtils.getJsonNode(json, "coverageZones");
 
             final SuperNode root = new SuperNode();
 
             final Iterator<String> czIter = coverageZones.fieldNames();
             while (czIter.hasNext()) {
                 final String loc = czIter.next();
-                final JsonNode locData = coverageZones.get(loc);
+                final JsonNode locData = JsonUtils.getJsonNode(coverageZones, loc);
                 final JsonNode coordinates = locData.get("coordinates");
                 Geolocation geolocation = null;
 
@@ -87,7 +89,7 @@ public class NetworkNode implements Comparable<NetworkNode> {
                 }
 
                 try {
-                    for (final JsonNode network6 : locData.get("network6")) {
+                    for (final JsonNode network6 : JsonUtils.getJsonNode(locData, "network6")) {
                         final String ip = network6.asText();
 
                         try {
@@ -97,12 +99,12 @@ public class NetworkNode implements Comparable<NetworkNode> {
                             return null;
                         }
                     }
-                } catch (Exception ex) {
+                } catch (JsonUtilsException ex) {
                     LOGGER.warn("An exception was caught while accessing the network6 key of " + loc + " in the incoming coverage zone file: " + ex.getMessage());
                 }
 
                 try {
-                    for (final JsonNode network : locData.get("network")) {
+                    for (final JsonNode network : JsonUtils.getJsonNode(locData, "network")) {
                         final String ip = network.asText();
 
                         try {
@@ -112,7 +114,7 @@ public class NetworkNode implements Comparable<NetworkNode> {
                             return null;
                         }
                     }
-                } catch (Exception ex) {
+                } catch (JsonUtilsException ex) {
                     LOGGER.warn("An exception was caught while accessing the network key of " + loc + " in the incoming coverage zone file: " + ex.getMessage());
                 }
             }
@@ -122,6 +124,8 @@ public class NetworkNode implements Comparable<NetworkNode> {
             }
 
             return root;
+        } catch (JsonUtilsException ex) {
+            LOGGER.warn(ex, ex);
         } catch (NetworkNodeException ex) {
             LOGGER.fatal(ex, ex);
         }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkUpdater.java
@@ -18,7 +18,6 @@ package com.comcast.cdn.traffic_control.traffic_router.core.loc;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.wicket.ajax.json.JSONException;
 
 public class NetworkUpdater extends AbstractServiceUpdater {
 
@@ -29,7 +28,7 @@ public class NetworkUpdater extends AbstractServiceUpdater {
 	}
 
 	@Override
-	public boolean loadDatabase() throws IOException, JSONException {
+	public boolean loadDatabase() throws IOException {
 		final File existingDB = databasesDirectory.resolve(databaseName).toFile();
 
 		if (!existingDB.exists() || !existingDB.canRead()) {
@@ -40,7 +39,7 @@ public class NetworkUpdater extends AbstractServiceUpdater {
 	}
 
 	@Override
-	public boolean verifyDatabase(final File dbFile) throws IOException, JSONException {
+	public boolean verifyDatabase(final File dbFile) throws IOException {
 		if (!dbFile.exists() || !dbFile.canRead()) {
 			return false;
 		}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
@@ -176,31 +176,31 @@ public final class RegionalGeo {
         final RegionalGeo regionalGeo = new RegionalGeo();
         regionalGeo.setFallback(true);
         try {
-            final JsonNode dsvcsJson = json.get("deliveryServices");
+            final JsonNode dsvcsJson = JsonUtils.getJsonNode(json, "deliveryServices");
             LOGGER.info("RegionalGeo: parse json with rule count " + dsvcsJson.size());
 
             for (final JsonNode ruleJson : dsvcsJson) {
 
-                final String dsvcId = JsonUtils.getString(ruleJson, "deliveryServiceId", "");
+                final String dsvcId = JsonUtils.getString(ruleJson, "deliveryServiceId");
                 if (dsvcId.trim().isEmpty()) {
                     LOGGER.error("RegionalGeo ERR: deliveryServiceId empty");
                     return null;
                 }
 
-                final String urlRegex = JsonUtils.getString(ruleJson, "urlRegex", "");
+                final String urlRegex = JsonUtils.getString(ruleJson, "urlRegex");
                 if (urlRegex.trim().isEmpty()) {
                     LOGGER.error("RegionalGeo ERR: urlRegex empty");
                     return null;
                 }
 
-                final String redirectUrl = JsonUtils.getString(ruleJson, "redirectUrl", "");
+                final String redirectUrl = JsonUtils.getString(ruleJson, "redirectUrl");
                 if (redirectUrl.trim().isEmpty()) {
                     LOGGER.error("RegionalGeo ERR: redirectUrl empty");
                     return null;
                 }
 
                 // FSAs (postal codes)
-                final JsonNode locationJson = ruleJson.get("geoLocation");
+                final JsonNode locationJson = JsonUtils.getJsonNode(ruleJson, "geoLocation");
                 final Set<String> postals = new HashSet<String>();
                 final RegionalGeoRule.PostalsType postalsType = parseLocationJson(locationJson, postals);
                 if (postalsType == RegionalGeoRule.PostalsType.UNDEFINED) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import com.comcast.cdn.traffic_control.traffic_router.core.util.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.log4j.Logger;
@@ -180,19 +181,19 @@ public final class RegionalGeo {
 
             for (final JsonNode ruleJson : dsvcsJson) {
 
-                final String dsvcId = ruleJson.has("deliveryServiceId") ? ruleJson.get("deliveryServiceId").asText() : "";
+                final String dsvcId = JsonUtils.getString(ruleJson, "deliveryServiceId", "");
                 if (dsvcId.trim().isEmpty()) {
                     LOGGER.error("RegionalGeo ERR: deliveryServiceId empty");
                     return null;
                 }
 
-                final String urlRegex = ruleJson.has("urlRegex") ? ruleJson.get("urlRegex").asText() : "";
+                final String urlRegex = JsonUtils.getString(ruleJson, "urlRegex", "");
                 if (urlRegex.trim().isEmpty()) {
                     LOGGER.error("RegionalGeo ERR: urlRegex empty");
                     return null;
                 }
 
-                final String redirectUrl = ruleJson.has("redirectUrl") ? ruleJson.get("redirectUrl").asText() : "";
+                final String redirectUrl = JsonUtils.getString(ruleJson, "redirectUrl", "");
                 if (redirectUrl.trim().isEmpty()) {
                     LOGGER.error("RegionalGeo ERR: redirectUrl empty");
                     return null;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
@@ -89,7 +89,7 @@ public abstract class AbstractResourceWatcher extends AbstractServiceUpdater {
 	abstract protected boolean verifyData(final String data);
 
 	@Override
-	public boolean loadDatabase() throws IOException, org.apache.wicket.ajax.json.JSONException {
+	public boolean loadDatabase() throws IOException {
 		final File existingDB = databasesDirectory.resolve(databaseName).toFile();
 
 		if (!existingDB.exists() || !existingDB.canRead()) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/PeriodicResourceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/PeriodicResourceUpdater.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
-import org.apache.wicket.ajax.json.JSONException;
 
 import com.ning.http.client.AsyncCompletionHandler;
 import com.ning.http.client.AsyncHttpClient;
@@ -249,7 +248,7 @@ public class PeriodicResourceUpdater {
 		}
 
 		@Override
-		public Integer onCompleted(final Response response) throws JSONException, IOException {
+		public Integer onCompleted(final Response response) throws IOException {
 			// Do something with the Response
 			final int code = response.getStatusCode();
 

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdaterTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdaterTest.java
@@ -15,7 +15,6 @@
 
 package com.comcast.cdn.traffic_control.traffic_router.core.loc;
 
-import org.apache.wicket.ajax.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -91,12 +90,12 @@ public class AbstractServiceUpdaterTest {
 
 	class Updater extends AbstractServiceUpdater {
 		@Override
-		public boolean verifyDatabase(File dbFile) throws IOException, JSONException {
+		public boolean verifyDatabase(File dbFile) throws IOException {
 			return false;
 		}
 
 		@Override
-		public boolean loadDatabase() throws IOException, JSONException {
+		public boolean loadDatabase() throws IOException {
 			return false;
 		}
 

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilderTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilderTest.java
@@ -30,10 +30,10 @@ public class FederationMappingBuilderTest {
         FederationMappingBuilder federationMappingBuilder = new FederationMappingBuilder();
 
         String json = "{ " +
-            "'cname' : 'cname1', " +
-            "'ttl' : '86400', " +
-            "'resolve4' : [ '192.168.56.78/24', '192.168.45.67/24' ], " +
-            "'resolve6' : [ 'fdfe:dcba:9876:5::/64', 'fd12:3456:789a:1::/64' ] " +
+            "\"cname\" : \"cname1\", " +
+            "\"ttl\" : \"86400\", " +
+            "\"resolve4\" : [ \"192.168.56.78/24\", \"192.168.45.67/24\" ], " +
+            "\"resolve6\" : [ \"fdfe:dcba:9876:5::/64\", \"fd12:3456:789a:1::/64\" ] " +
         "}";
 
         FederationMapping federationMapping = federationMappingBuilder.fromJSON(json);
@@ -53,8 +53,8 @@ public class FederationMappingBuilderTest {
         FederationMappingBuilder federationMappingBuilder = new FederationMappingBuilder();
 
         String json = "{ " +
-                "'cname' : 'cname1', " +
-                "'ttl' : '86400' " +
+                "\"cname\" : \"cname1\", " +
+                "\"ttl\" : \"86400\" " +
                 "}";
 
         FederationMapping federationMapping = federationMappingBuilder.fromJSON(json);

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilderTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilderTest.java
@@ -29,21 +29,21 @@ public class FederationsBuilderTest {
     public void itConsumesValidJSON() throws Exception {
         FederationsBuilder federationsBuilder = new FederationsBuilder();
 
-        String json = "{ response: [ " +
+        String json = "{ \"response\": [ " +
             "{ " +
-                "'deliveryService' : 'kable-town-01', " +
-                "'mappings' : [ " +
-                    "{ 'cname' : 'cname1', " +
-                        "'ttl' : '86400', " +
-                        "'resolve4' : [ '192.168.56.78/24', '192.168.45.67/24' ], " +
-                        "'resolve6' : [ 'fdfe:dcba:9876:5::/64', 'fd12:3456:789a:1::/64' ] " +
+                "\"deliveryService\" : \"kable-town-01\", " +
+                "\"mappings\" : [ " +
+                    "{ \"cname\" : \"cname1\", " +
+                        "\"ttl\" : \"86400\", " +
+                        "\"resolve4\" : [ \"192.168.56.78/24\", \"192.168.45.67/24\" ], " +
+                        "\"resolve6\" : [ \"fdfe:dcba:9876:5::/64\", \"fd12:3456:789a:1::/64\" ] " +
                     "}, " +
-                    "{ 'cname' : 'cname2', 'ttl' : '86400' } " +
+                    "{ \"cname\" : \"cname2\", \"ttl\" : \"86400\" } " +
                 "] " +
             "}, " +
             "{ " +
-                "'deliveryService' : 'kable-town-02', " +
-                "'mappings' : [ { 'cname' : 'cname4' , 'ttl' : '86400' } ]" +
+                "\"deliveryService\" : \"kable-town-02\", " +
+                "\"mappings\" : [ { \"cname\" : \"cname4\" , \"ttl\" : \"86400\" } ]" +
             "} " +
         "] }";
 

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNodeUnitTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNodeUnitTest.java
@@ -15,8 +15,8 @@
 
 package com.comcast.cdn.traffic_control.traffic_router.core.loc;
 
-import org.apache.wicket.ajax.json.JSONObject;
-import org.apache.wicket.ajax.json.JSONTokener;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 
@@ -99,8 +99,8 @@ public class NetworkNodeUnitTest {
             "}" +
             "}";
 
-        JSONTokener jsonTokener = new JSONTokener(czmapString);
-        final JSONObject json = new JSONObject(jsonTokener);
+        final ObjectMapper mapper = new ObjectMapper();
+        final JsonNode json = mapper.readTree(czmapString);
         NetworkNode networkNode = NetworkNode.generateTree(json, false);
         NetworkNode foundNetworkNode = networkNode.getNetwork("1234:5678::1");
 
@@ -146,8 +146,8 @@ public class NetworkNodeUnitTest {
             "}" +
             "}";
 
-        JSONTokener jsonTokener = new JSONTokener(czmapString);
-        final JSONObject json = new JSONObject(jsonTokener);
+        final ObjectMapper mapper = new ObjectMapper();
+        final JsonNode json = mapper.readTree(czmapString);
         NetworkNode networkNode = NetworkNode.generateTree(json, false);
         NetworkNode foundNetworkNode = networkNode.getNetwork("192.168.55.2");
 
@@ -167,8 +167,8 @@ public class NetworkNodeUnitTest {
             "}" +
             "}";
 
-        JSONTokener jsonTokener = new JSONTokener(czmapString);
-        final JSONObject json = new JSONObject(jsonTokener);
+        final ObjectMapper mapper = new ObjectMapper();
+        final JsonNode json = mapper.readTree(czmapString);
         assertThat(NetworkNode.generateTree(json, false), equalTo(null));
     }
 
@@ -185,8 +185,8 @@ public class NetworkNodeUnitTest {
             "}" +
             "}";
 
-        JSONTokener jsonTokener = new JSONTokener(czmapString);
-        final JSONObject json = new JSONObject(jsonTokener);
+        final ObjectMapper mapper = new ObjectMapper();
+        final JsonNode json = mapper.readTree(czmapString);
         assertThat(NetworkNode.generateTree(json, false), equalTo(null));
     }
 }

--- a/traffic_router/pom.xml
+++ b/traffic_router/pom.xml
@@ -33,7 +33,6 @@
 	<properties>
 		<deploy.dir>/opt/traffic_router</deploy.dir>
 		<spring.version>4.2.5.RELEASE</spring.version>
-		<wicket.version>6.0.0</wicket.version>
 		<log4j.version>1.2.17</log4j.version>
 		<junit.version>4.12</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
Replaced org.apache.wicket.ajax.json (Apache Wicket) imports with com.fasterxml.jackson.databind (jackson) and made the necessary code conversions. This is related to issue #956 and PR #1726.