### PR TITLE
update NOTICE with year range

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Traffic Control (incubating)
-Copyright 2017 The Apache Software Foundation
+Copyright 2016-2018 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
According to https://www.apache.org/legal/src-headers.html , copyright in the NOTICE file should be a "range of past and year(s) of distribution of the current and past versions of the product".

1.8.0 (Feb 2016) was our first release under the incubator,  so updating the copyright to 2016-2018.