### PR TITLE
Fix swapped arguments to QueryRow() in IsResourceAuthorizedToUser()

### DIFF
--- a/traffic_ops/traffic_ops_golang/auth/tenancy.go
+++ b/traffic_ops/traffic_ops_golang/auth/tenancy.go
@@ -70,7 +70,7 @@ func IsResourceAuthorizedToUser(resourceTenantID int, user CurrentUser, db *sqlx
 	var tenantId int
 	var active bool
 
-	err := db.QueryRow(query, resourceTenantID, user.TenantID).Scan(&tenantId, &active)
+	err := db.QueryRow(query, user.TenantID, resourceTenantID).Scan(&tenantId, &active)
 
 	switch {
 	case err == sql.ErrNoRows:


### PR DESCRIPTION
The user.TenantID and resourceTenantID arguments to QueryRow() were inadvertently swapped.  Therefore IsResourceAuthorizedToUser() always returns false.