### PR TITLE
[Issue-1749] clean up system_info endpoint -- don't depend on parameters code

### DIFF
--- a/traffic_ops/traffic_ops_golang/system_info.go
+++ b/traffic_ops/traffic_ops_golang/system_info.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	log "github.com/apache/incubator-trafficcontrol/lib/go-log"
 	tc "github.com/apache/incubator-trafficcontrol/lib/go-tc"
@@ -50,8 +49,7 @@ func systemInfoHandler(db *sqlx.DB) http.HandlerFunc {
 		}
 		privLevel := user.PrivLevel
 
-		q := r.URL.Query()
-		resp, err := getSystemInfoResponse(q, db, privLevel)
+		resp, err := getSystemInfoResponse(db, privLevel)
 		if err != nil {
 			handleErr(err, http.StatusInternalServerError)
 			return
@@ -67,8 +65,8 @@ func systemInfoHandler(db *sqlx.DB) http.HandlerFunc {
 		fmt.Fprintf(w, "%s", respBts)
 	}
 }
-func getSystemInfoResponse(q url.Values, db *sqlx.DB, privLevel int) (*tc.SystemInfoResponse, error) {
-	info, err := getSystemInfo(q, db, privLevel)
+func getSystemInfoResponse(db *sqlx.DB, privLevel int) (*tc.SystemInfoResponse, error) {
+	info, err := getSystemInfo(db, privLevel)
 	if err != nil {
 		return nil, fmt.Errorf("getting SystemInfo: %v", err)
 	}
@@ -78,20 +76,37 @@ func getSystemInfoResponse(q url.Values, db *sqlx.DB, privLevel int) (*tc.System
 	return &resp, nil
 }
 
-func getSystemInfo(_ url.Values, db *sqlx.DB, privLevel int) (map[string]string, error) {
+func getSystemInfo(db *sqlx.DB, privLevel int) (map[string]string, error) {
 	// system info returns all global parameters
-	// no parameters on the url, but use that mechanism to get the right params from the db
+	query := `SELECT
+p.name,
+p.secure,
+p.value
+FROM parameter p
+WHERE p.config_file='global'`
 
-	v := url.Values{}
-	v.Set("config_file", "global")
-	params, err := getParameters(v, db, SystemInfoPrivLevel)
+	rows, err := db.Queryx(query)
+
+	if err != nil {
+		return nil, fmt.Errorf("querying: %v", err)
+	}
+	defer rows.Close()
+
+	info := make(map[string]string)
+	for rows.Next() {
+		p := tc.Parameter{}
+		if err = rows.StructScan(&p); err != nil {
+			return nil, fmt.Errorf("getting system_info: %v", err)
+		}
+		if p.Secure && privLevel < auth.PrivLevelAdmin {
+			// Secure params only visible to admin
+			continue
+		}
+		info[p.Name] = p.Value
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	info := make(map[string]string, len(params))
-	for _, p := range params {
-		info[p.Name] = p.Value
-	}
 	return info, nil
 }

--- a/traffic_ops/traffic_ops_golang/system_info_test.go
+++ b/traffic_ops/traffic_ops_golang/system_info_test.go
@@ -20,13 +20,13 @@ package main
  */
 
 import (
-	"net/url"
 	"testing"
 	"time"
 
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	"encoding/json"
+
 	tc "github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/test"
@@ -82,10 +82,8 @@ func TestGetSystemInfo(t *testing.T) {
 		)
 	}
 
-	mock.ExpectQuery("SELECT.*WHERE p.config_file='?").WillReturnRows(rows)
-	v := url.Values{}
-
-	sysinfo, err := getSystemInfo(v, db, auth.PrivLevelReadOnly)
+	mock.ExpectQuery("SELECT.*WHERE p.config_file='global'").WillReturnRows(rows)
+	sysinfo, err := getSystemInfo(db, auth.PrivLevelReadOnly)
 	if err != nil {
 		t.Errorf("getSystemInfo expected: nil error, actual: %v", err)
 	}


### PR DESCRIPTION
Fixes #1749 -- now independent of parameters endpoint code.  And simplifies db select call.