### PR TITLE
update user info query to not fail without tenancy info

### DIFF
--- a/traffic_ops/traffic_ops_golang/auth/tenancy.go
+++ b/traffic_ops/traffic_ops_golang/auth/tenancy.go
@@ -20,8 +20,6 @@ package auth
  */
 
 import (
-	"database/sql"
-
 	"github.com/apache/incubator-trafficcontrol/lib/go-log"
 	"github.com/jmoiron/sqlx"
 )
@@ -81,9 +79,6 @@ func IsResourceAuthorizedToUser(resourceTenantID int, user CurrentUser, db *sqlx
 	err := db.QueryRow(query, user.TenantID, resourceTenantID).Scan(&tenantID, &active, &useTenancy)
 
 	switch {
-	case err == sql.ErrNoRows:
-		log.Errorf("checking user tenant %v access on resourceTenant %v: user has no access", user.TenantID, resourceTenantID)
-		return false, nil
 	case err != nil:
 		log.Errorf("Error checking user tenant %v access on resourceTenant  %v: %v", user.TenantID, resourceTenantID, err.Error())
 		return false, err

--- a/traffic_ops/traffic_ops_golang/cdn/handlers.go
+++ b/traffic_ops/traffic_ops_golang/cdn/handlers.go
@@ -27,8 +27,8 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"github.com/apache/incubator-trafficcontrol/lib/go-log"
+	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/jmoiron/sqlx"

--- a/traffic_ops/traffic_ops_golang/routing.go
+++ b/traffic_ops/traffic_ops_golang/routing.go
@@ -191,7 +191,7 @@ func RegisterRoutes(d ServerData) error {
 }
 
 func prepareUserInfoStmt(db *sqlx.DB) (*sqlx.Stmt, error) {
-	return db.Preparex("SELECT r.priv_level, u.id, u.username, u.tenant_id FROM tm_user AS u JOIN role AS r ON u.role = r.id WHERE u.username = $1")
+	return db.Preparex("SELECT r.priv_level, u.id, u.username, COALESCE(u.tenant_id, -1) AS tenant_id FROM tm_user AS u JOIN role AS r ON u.role = r.id WHERE u.username = $1")
 }
 
 func use(h http.HandlerFunc, middlewares []Middleware) http.HandlerFunc {


### PR DESCRIPTION
fixes #1759 This updates the query to not fail if a user does not have tenancy info and updates the query used by IsResourceAuthorizedToUser to check the use_tenancy parameter (defaulting to false if missing)