### PR TITLE
Add tenancy package and implement tenancy checks on SSL API endpoints.

### DIFF
--- a/lib/go-tc/constants.go
+++ b/lib/go-tc/constants.go
@@ -52,10 +52,10 @@ const (
 	SystemError
 	DataConflictError
 	DataMissingError
-
+	ForbiddenError
 )
 
-var apiErrorTypes = []string{"noError","systemError","dataConflictError","dataMissingError"}
+var apiErrorTypes = []string{"noError", "systemError", "dataConflictError", "dataMissingError", "forbiddenError"}
 
 func (a ApiErrorType) String() string {
 	return apiErrorTypes[a]

--- a/traffic_ops/traffic_ops_golang/deliveryservices_keys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservices_keys.go
@@ -265,10 +265,19 @@ func addDeliveryServiceSSLKeysHandler(db *sqlx.DB, cfg Config) http.HandlerFunc 
 		}
 
 		// check user tenancy access to this resource.
-		hasAccess, err, httpStatus := tenant.HasDeliveryServiceTenant(*user, keysObj.DeliveryService, db)
+		hasAccess, err, apiStatus := tenant.HasTenant(*user, keysObj.DeliveryService, db)
 		if !hasAccess {
-			handleErr(httpStatus, err)
-			return
+			switch apiStatus {
+			case tc.SystemError:
+				handleErr(http.StatusInternalServerError, err)
+				return
+			case tc.DataMissingError:
+				handleErr(http.StatusBadRequest, err)
+				return
+			case tc.ForbiddenError:
+				handleErr(http.StatusForbidden, err)
+				return
+			}
 		}
 
 		var certChain string
@@ -402,10 +411,19 @@ func getDeliveryServiceSSLKeysByHostNameHandler(db *sqlx.DB, cfg Config) http.Ha
 			} else {
 				xmlID := xmlIDStr.String
 				// check user tenancy access to this resource.
-				hasAccess, err, httpStatus := tenant.HasDeliveryServiceTenant(*user, xmlID, db)
+				hasAccess, err, apiStatus := tenant.HasTenant(*user, xmlID, db)
 				if !hasAccess {
-					handleErr(httpStatus, err)
-					return
+					switch apiStatus {
+					case tc.SystemError:
+						handleErr(http.StatusInternalServerError, err)
+						return
+					case tc.DataMissingError:
+						handleErr(http.StatusBadRequest, err)
+						return
+					case tc.ForbiddenError:
+						handleErr(http.StatusForbidden, err)
+						return
+					}
 				}
 				respBytes, err = getDeliveryServiceSSLKeysByXMLID(xmlID, version, db, cfg)
 				if err != nil {
@@ -447,10 +465,19 @@ func getDeliveryServiceSSLKeysByXMLIDHandler(db *sqlx.DB, cfg Config) http.Handl
 		xmlID := pathParams["xmlID"]
 
 		// check user tenancy access to this resource.
-		hasAccess, err, httpStatus := tenant.HasDeliveryServiceTenant(*user, xmlID, db)
+		hasAccess, err, apiStatus := tenant.HasTenant(*user, xmlID, db)
 		if !hasAccess {
-			handleErr(httpStatus, err)
-			return
+			switch apiStatus {
+			case tc.SystemError:
+				handleErr(http.StatusInternalServerError, err)
+				return
+			case tc.DataMissingError:
+				handleErr(http.StatusBadRequest, err)
+				return
+			case tc.ForbiddenError:
+				handleErr(http.StatusForbidden, err)
+				return
+			}
 		}
 
 		respBytes, err = getDeliveryServiceSSLKeysByXMLID(xmlID, version, db, cfg)

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -97,7 +97,7 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		//SSLKeys deliveryservice endpoints here that are marked  marked as '-wip' need to have tenancy checks added
 		{1.2, http.MethodGet, `deliveryservices-wip/xmlId/{xmlID}/sslkeys$`, getDeliveryServiceSSLKeysByXmlIDHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		{1.2, http.MethodGet, `deliveryservices-wip/hostname/{hostName}/sslkeys$`, getDeliveryServiceSSLKeysByHostNameHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
-		{1.2, http.MethodPut, `deliveryservices-wip/hostname/{hostName}/sslkeys$`, addDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.2, http.MethodPost, `deliveryservices-wip/hostname/{hostName}/sslkeys/add$`, addDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		//Statuses
 		{1.2, http.MethodGet, `statuses/?(\.json)?$`, statusesHandler(d.DB), StatusesPrivLevel, Authenticated, nil},
 		{1.2, http.MethodGet, `statuses/{id}$`, statusesHandler(d.DB), StatusesPrivLevel, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -95,7 +95,7 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{1.2, http.MethodGet, `servers/{host_name}/update_status$`, getServerUpdateStatusHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//SSLKeys deliveryservice endpoints here that are marked  marked as '-wip' need to have tenancy checks added
-		{1.2, http.MethodGet, `deliveryservices-wip/xmlId/{xmlID}/sslkeys$`, getDeliveryServiceSSLKeysByXmlIDHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
+		{1.2, http.MethodGet, `deliveryservices-wip/xmlId/{xmlID}/sslkeys$`, getDeliveryServiceSSLKeysByXMLIDHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		{1.2, http.MethodGet, `deliveryservices-wip/hostname/{hostName}/sslkeys$`, getDeliveryServiceSSLKeysByHostNameHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		{1.2, http.MethodPost, `deliveryservices-wip/hostname/{hostName}/sslkeys/add$`, addDeliveryServiceSSLKeysHandler(d.DB, d.Config), auth.PrivLevelAdmin, Authenticated, nil},
 		//Statuses

--- a/traffic_ops/traffic_ops_golang/tenant/tenancy.go
+++ b/traffic_ops/traffic_ops_golang/tenant/tenancy.go
@@ -67,13 +67,13 @@ func GetDeliveryServiceTenantInfo(xmlId string, db *sqlx.DB) (*DeliveryServiceTe
 }
 
 // tenancy check wrapper for deliveryservice
-func UserHasDeliveryServiceTenantAccess(user auth.CurrentUser, dsXmlID string, db *sqlx.DB) (bool, error, int) {
-	dsInfo, err := GetDeliveryServiceTenantInfo(dsXmlID, db)
+func HasDeliveryServiceTenant(user auth.CurrentUser, XMLID string, db *sqlx.DB) (bool, error, int) {
+	dsInfo, err := GetDeliveryServiceTenantInfo(XMLID, db)
 	if err != nil {
 		if dsInfo == nil {
 			return false, fmt.Errorf("deliveryservice lookup failure: %v", err), http.StatusInternalServerError
 		} else {
-			return false, fmt.Errorf("no such deliveryservice: '%s'", dsXmlID), http.StatusBadRequest
+			return false, fmt.Errorf("no such deliveryservice: '%s'", XMLID), http.StatusBadRequest
 		}
 	}
 	hasAccess, err := dsInfo.IsTenantAuthorized(user, db)


### PR DESCRIPTION
This adds tenancy checks to the fetch and add traffic_ops_golang SSL API endpoints.  Fixes #1763 
