### PR TITLE
Cosmetic change to Traffic Monitor event log types

### DIFF
--- a/traffic_monitor/ds/stat.go
+++ b/traffic_monitor/ds/stat.go
@@ -277,7 +277,7 @@ func addDSPerSecStats(dsName tc.DeliveryServiceName, stat dsdata.Stat, lastStats
 			Description: desc,
 			Name:        dsName.String(),
 			Hostname:    dsName.String(),
-			Type:        "Delivery Service",
+			Type:        "DELIVERYSERVICE",
 			Available:   stat.CommonStats.IsAvailable.Value,
 		}
 	}

--- a/traffic_monitor/manager/peer.go
+++ b/traffic_monitor/manager/peer.go
@@ -52,6 +52,6 @@ func comparePeerState(events health.ThreadsafeEvents, result peer.Result, peerSt
 			description = "Peer is unreachable"
 		}
 
-		events.Add(health.Event{Time: health.Time(result.Time), Description: description, Name: result.ID.String(), Hostname: result.ID.String(), Type: "Peer", Available: result.Available})
+		events.Add(health.Event{Time: health.Time(result.Time), Description: description, Name: result.ID.String(), Hostname: result.ID.String(), Type: "PEER", Available: result.Available})
 	}
 }


### PR DESCRIPTION
Align all five event types, currently:

- EDGE
- MID
- INVALIDCACHETYPE
- "Delivery Service"
- Peer

to:

- EDGE
- MID
- INVALIDCACHETYPE
- DELIVERYSERVICE
- PEER

The whitespace in Delivery Service is breaking the log format, as it is unquoted.