### PR TITLE
[Issue 1797] [Issue 1568] TO golang incorrect time format in JSON

### DIFF
--- a/lib/go-tc/time.go
+++ b/lib/go-tc/time.go
@@ -21,7 +21,6 @@ package tc
 
 import (
 	"database/sql/driver"
-	"fmt"
 	"strings"
 	"time"
 )
@@ -32,7 +31,7 @@ type Time struct {
 }
 
 // TimeLayout is the format used in lastUpdated fields in Traffic Ops
-const TimeLayout = "2006-01-02 15:04:05+00"
+const TimeLayout = "2006-01-02 15:04:05-07"
 
 // Scan implements the database/sql Scanner interface.
 func (jt *Time) Scan(value interface{}) error {
@@ -48,15 +47,12 @@ func (jt Time) Value() (driver.Value, error) {
 	return jt.Time, nil
 }
 
-// MarshalJSON formats the Time field as Traffic Control expects it.
-func (t *Time) MarshalJSON() ([]byte, error) {
-	if t.Time.IsZero() {
-		return []byte("null"), nil
-	}
-	return []byte(fmt.Sprintf("\"%s\"", t.Time.Format(TimeLayout))), nil
+// MarshalJSON implements the json.Marshaller interface
+func (t Time) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + t.Time.Format(TimeLayout) + `"`), nil
 }
 
-// UnmarshalJSON reads time from JSON into Time var
+// UnmarshalJSON implements the json.Unmarshaller interface
 func (t *Time) UnmarshalJSON(b []byte) (err error) {
 	s := strings.Trim(string(b), "\"")
 	if s == "null" {

--- a/lib/go-tc/time_test.go
+++ b/lib/go-tc/time_test.go
@@ -20,6 +20,7 @@ package tc
  */
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -28,14 +29,15 @@ var jsonTests = []struct {
 	time Time
 	json string
 }{
-	{Time{Time: time.Date(9999, 4, 12, 23, 20, 50, 520*1e6, time.UTC)}, `"9999-04-12 23:20:50+00"`},
+	{Time{Time: time.Date(9999, 4, 12, 23, 20, 50, 520*1e6, time.Local)}, `"9999-04-12 23:20:50-07"`},
 	{Time{Time: time.Date(1996, 12, 19, 16, 39, 57, 0, time.UTC)}, `"1996-12-19 16:39:57+00"`},
 }
 
 // TestJSON tests that we get format tc uses for lastUpdated fields
 func TestJSON(t *testing.T) {
 	for _, tm := range jsonTests {
-		got, err := tm.time.MarshalJSON()
+		got, err := json.Marshal(tm.time)
+
 		if err != nil {
 			t.Errorf("MarshalJSON error: %+v", err)
 		}


### PR DESCRIPTION
The time layout was incorrect.

This fixes #1797
This fixes #1568 