### PR TITLE
Remove Duplicate Headers on Steering DS Responses

### DIFF
--- a/traffic_ops/app/db/migrations/20180130000000_update_client_steering_headers.sql
+++ b/traffic_ops/app/db/migrations/20180130000000_update_client_steering_headers.sql
@@ -1,0 +1,28 @@
+/*
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+UPDATE deliveryservice
+SET tr_response_headers = subquery.tr_response_headers
+FROM (SELECT ds.id, ds.tr_response_headers, st.deliveryservice
+  FROM deliveryservice ds JOIN steering_target st ON ds.id = st.target
+  WHERE ds.tr_response_headers IS NOT NULL)
+AS subquery
+  WHERE subquery.deliveryservice = deliveryservice.id
+  AND type = (SELECT id from type where name = 'CLIENT_STEERING');
+
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back

--- a/traffic_ops/app/templates/delivery_service/add.html.ep
+++ b/traffic_ops/app/templates/delivery_service/add.html.ep
@@ -253,7 +253,11 @@
             $('#origin_shield_row').hide(speed);
             $('#active_row').show(speed);
             $('#ds_regexp_table').show(speed);
-            $('#tr_response_headers').hide(speed);
+            if (type_selected.match(/CLIENT_STEERING$/)) {
+                $('#tr_response_headers').show(speed);
+            } else {
+                $('#tr_response_headers').hide(speed);
+            }
             $('#multi_site_origin_row').hide(speed);
             $('#multi_site_origin_algorithm_row').hide(speed);
             $('#initial_dispersion_row').hide(speed);

--- a/traffic_ops/app/templates/delivery_service/edit.html.ep
+++ b/traffic_ops/app/templates/delivery_service/edit.html.ep
@@ -345,7 +345,11 @@ function setup_form(speed) {
             $('#origin_shield_row').hide(speed);
             $('#active_row').show(speed);
             $('#ds_regexp_table').show(speed);
-            $('#tr_response_headers').hide(speed);
+            if (type_selected.match(/CLIENT_STEERING$/)) {
+                $('#tr_response_headers').show(speed);
+            } else {
+                $('#tr_response_headers').hide(speed);
+            }
             $('#multi_site_origin_row').hide(speed);
             $('#multi_site_origin_algorithm_row').hide(speed);
             $('#initial_dispersion_row').hide(speed);

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -69,6 +69,16 @@ var FormDeliveryServiceController = function(deliveryService, type, types, $scop
         return currentType.name.indexOf(category) != -1;
     });
 
+    $scope.clientSteeringType = _.findWhere(types, {name: "CLIENT_STEERING"});
+    $scope.isClientSteering = function(ds) {
+        if (ds.typeId == $scope.clientSteeringType.id) {
+            return true;
+        } else {
+            ds.trResponseHeaders = "";
+            return false;
+        }
+    };
+
     $scope.falseTrue = [
         { value: true, label: 'true' },
         { value: false, label: 'false' }

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -219,7 +219,7 @@ under the License.
                      ng-if="isClientSteering(deliveryService)">
                     <label class="control-label col-md-2 col-sm-2 col-xs-12">Traffic Router Additional Response Headers</label>
                     <div class="col-md-10 col-sm-10 col-xs-12">
-                        <input name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" ng-maxlength="1024" autofocus>
+                        <input name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" ng-maxlength="1024">
                         <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trResponseHeaders, 'maxlength')">Too Long</small>
                         <span ng-show="hasError(deliveryServiceForm.trResponseHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -215,6 +215,16 @@ under the License.
                     </div>
                 </div>
 
+                <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.trResponseHeaders), 'has-feedback': hasError(deliveryServiceForm.trResponseHeaders)}"
+                     ng-if="isClientSteering(deliveryService)">
+                    <label class="control-label col-md-2 col-sm-2 col-xs-12">Traffic Router Additional Response Headers</label>
+                    <div class="col-md-10 col-sm-10 col-xs-12">
+                        <input name="trResponseHeaders" type="text" class="form-control" ng-model="deliveryService.trResponseHeaders" ng-maxlength="1024" autofocus>
+                        <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.trResponseHeaders, 'maxlength')">Too Long</small>
+                        <span ng-show="hasError(deliveryServiceForm.trResponseHeaders)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                    </div>
+                </div>
+
                 <div class="form-group" ng-class="{'has-error': hasError(deliveryServiceForm.ccrDnsTtl), 'has-feedback': hasError(deliveryServiceForm.ccrDnsTtl)}">
                     <label class="control-label col-md-2 col-sm-2 col-xs-12">Delivery Service DNS TTL</label>
                     <div class="col-md-10 col-sm-10 col-xs-12">

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/http/RouterFilter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/http/RouterFilter.java
@@ -123,8 +123,8 @@ public class RouterFilter extends OncePerRequestFilter {
 	}
 
 	private void setMultiResponse(final HTTPRouteResult routeResult, final HttpServletRequest httpServletRequest, final HttpServletResponse response, final HTTPAccessRecord.Builder httpAccessRecordBuilder) throws IOException {
-		for (final DeliveryService deliveryService : routeResult.getDeliveryServices()) {
-			final Map<String, String> responseHeaders = deliveryService.getResponseHeaders();
+		if (routeResult.getDeliveryService() != null) {
+			final Map<String, String> responseHeaders = routeResult.getDeliveryService().getResponseHeaders();
 
 			for (final String key : responseHeaders.keySet()) {
 				// if two DSs append the same header, the last one wins; no way around it unless we enforce unique response headers between subordinate DSs

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -487,6 +487,7 @@ public class TrafficRouter {
 			return null;
 		}
 
+		routeResult.setDeliveryService(entryDeliveryService);
 		for (final DeliveryService deliveryService : deliveryServices) {
 			if (deliveryService.isRegionalGeoEnabled()) {
 				LOGGER.error("Regional Geo Blocking is not supported with multi-route delivery services.. skipping " + entryDeliveryService.getId() + "/" + deliveryService.getId());
@@ -495,7 +496,6 @@ public class TrafficRouter {
 
 			if (deliveryService.isAvailable()) {
 				final List<Cache> caches = selectCaches(request, deliveryService, track);
-				routeResult.addDeliveryService(deliveryService);
 
 				if (caches != null && !caches.isEmpty()) {
 					final Cache cache = consistentHasher.selectHashable(caches, deliveryService.getDispersion(), request.getPath());


### PR DESCRIPTION
Modified client steering delivery services to use own response headers instead of propagating up response headers from subordinate delivery services. Updated TO and TP UIs to have field "Traffic Router Additional Response Headers" for client steering delivery services. This resolves [TC-544] #986 