### PR TITLE
Fix /riak/stats API endpoint

### DIFF
--- a/traffic_ops/app/lib/API/Riak.pm
+++ b/traffic_ops/app/lib/API/Riak.pm
@@ -25,9 +25,8 @@ use Data::Dumper;
 sub stats {
 	my $self = shift;
 
-	#my $response = $self->riak_stats();
-	my $response = $self->riak_stats();
-	my $content  = $response->{_content};
+	my $response = $self->riak_stats()->{'response'};
+	my $content  = $response->content;
 	return $self->success( decode_json($content) );
 }
 


### PR DESCRIPTION
Unwrap the response object similar to the ping endpoint.

Fixes #1428 