### PR TITLE
Traffic Ops:  remove unused get_type call that makes extra sql queries

### DIFF
--- a/traffic_ops/app/lib/API/DeliveryService/Steering.pm
+++ b/traffic_ops/app/lib/API/DeliveryService/Steering.pm
@@ -92,8 +92,6 @@ sub find_steering {
 
         my $targets = $steering_entry->{"targets"};
 
-        my $type = $self->get_type($row->type);
-
         if ( $row->type eq "STEERING_ORDER" ) {
             push(@{$targets},{
             'deliveryService' => $row->target_xml_id,


### PR DESCRIPTION

That `get_type` call does an sql lookup to get the type name,  then never uses it..  Removed.