### PR TITLE
fix unit test

### DIFF
--- a/traffic_ops/traffic_ops_golang/routing_test.go
+++ b/traffic_ops/traffic_ops_golang/routing_test.go
@@ -110,7 +110,7 @@ func TestCreateRouteMap(t *testing.T) {
 }
 
 func getAuthWasCalled(ctx context.Context) string {
-	val := ctx.Value("authWasCalled")
+	val := ctx.Value(AuthWasCalled)
 	if val != nil {
 		return val.(string)
 	}


### PR DESCRIPTION
key used to store value in context not the same as one used to retrieve it.