### PR TITLE
DeepCachingType -- "NEVER" is now default

### DIFF
--- a/lib/go-tc/enum.go
+++ b/lib/go-tc/enum.go
@@ -29,6 +29,7 @@ package tc
  */
 
 import (
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -232,4 +233,9 @@ func (t *DeepCachingType) UnmarshalJSON(data []byte) error {
 		return errors.New(string(data) + " is not a DeepCachingType")
 	}
 	return nil
+}
+
+// MarshalJSON marshals into a JSON representation
+func (t DeepCachingType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }

--- a/lib/go-tc/enum.go
+++ b/lib/go-tc/enum.go
@@ -189,8 +189,8 @@ func CacheStatusFromString(s string) CacheStatus {
 type DeepCachingType string
 
 const (
+	DeepCachingTypeNever   = DeepCachingType("") // default value
 	DeepCachingTypeAlways  = DeepCachingType("ALWAYS")
-	DeepCachingTypeNever   = DeepCachingType("NEVER")
 	DeepCachingTypeInvalid = DeepCachingType("INVALID")
 )
 
@@ -200,7 +200,7 @@ func (t DeepCachingType) String() string {
 	case DeepCachingTypeAlways:
 		return string(t)
 	case DeepCachingTypeNever:
-		return string(t)
+		return "NEVER"
 	default:
 		return "INVALID"
 	}

--- a/lib/go-tc/enum.go
+++ b/lib/go-tc/enum.go
@@ -191,7 +191,7 @@ type DeepCachingType string
 const (
 	DeepCachingTypeAlways  = DeepCachingType("ALWAYS")
 	DeepCachingTypeNever   = DeepCachingType("NEVER")
-	DeepCachingTypeInvalid = DeepCachingType("")
+	DeepCachingTypeInvalid = DeepCachingType("INVALID")
 )
 
 // String returns a string representation of this deep caching type
@@ -212,6 +212,9 @@ func DeepCachingTypeFromString(s string) DeepCachingType {
 	case "always":
 		return DeepCachingTypeAlways
 	case "never":
+		return DeepCachingTypeNever
+	case "":
+		// default when omitted
 		return DeepCachingTypeNever
 	default:
 		return DeepCachingTypeInvalid

--- a/lib/go-tc/enum_test.go
+++ b/lib/go-tc/enum_test.go
@@ -1,0 +1,75 @@
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDeepCachingType(t *testing.T) {
+	var d DeepCachingType
+	c := d.String()
+	if c != "NEVER" {
+		t.Errorf(`Default "%s" expected to be "NEVER"`, c)
+	}
+
+	tests := map[string]string{
+		"":            "NEVER",
+		"NEVER":       "NEVER",
+		"ALWAYS":      "ALWAYS",
+		"never":       "NEVER",
+		"always":      "ALWAYS",
+		"Never":       "NEVER",
+		"AlwayS":      "ALWAYS",
+		" ":           "INVALID",
+		"NEVERALWAYS": "INVALID",
+		"ALWAYSNEVER": "INVALID",
+	}
+
+	for in, exp := range tests {
+		dc := DeepCachingTypeFromString(in)
+		got, err := json.Marshal(dc)
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+
+		if string(got) != `"`+exp+`"` {
+			t.Errorf("for %s,  expected %s,  got %s", in, exp, got)
+		}
+		var new DeepCachingType
+		json.Unmarshal(got, &new)
+		if new != dc {
+			t.Errorf("Expected %v,  got %v", dc, new)
+		}
+	}
+
+	// make sure we get the right default when marshalled within a new delivery service
+	var ds DeliveryService
+	txt, err := json.MarshalIndent(ds, ``, `  `)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	t.Log(string(txt))
+	c = ds.DeepCachingType.String()
+	if c != "NEVER" {
+		t.Errorf(`Default "%s" expected to be "NEVER"`, c)
+	}
+}


### PR DESCRIPTION
When creating a new deliveryservice, the new DeepCachingType entry should have a reasonable default that's not invalid.

@rawlinp this is what I was suggesting...