### PR TITLE
TC-197 work around for Filer descriptor leak Issue #916

### DIFF
--- a/traffic_router/core/src/main/opt/tomcat/conf/server.xml
+++ b/traffic_router/core/src/main/opt/tomcat/conf/server.xml
@@ -32,11 +32,11 @@
 		at /docs/config/service.html -->
 
 	<Service name="traffic_router_core">
-		<Connector port="80" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
+		<Connector port="80" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidProtocol" maxThreads="10000"
 				   connectionTimeout="20000" mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="Port"/>
-		<Connector port="3333" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
+		<Connector port="3333" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidProtocol" maxThreads="10000"
 				   connectionTimeout="20000" mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="ApiPort"/>
-		<Connector port="443" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol" maxThreads="10000"
+		<Connector port="443" protocol="com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidProtocol" maxThreads="10000"
 				   scheme="https" secure="true" SSLEnabled="true"
 				   clientAuth="false" sslProtocol="TLS"
 				   connectionTimeout="20000" mbeanPath="traffic-router:name=languidState" readyAttribute="Ready" portAttribute="SecurePort"/>


### PR DESCRIPTION
@dneuman64 @elsloo @limited 
https://github.com/apache/incubator-trafficcontrol/issues/916

Removing the Nio from the 3 locations in the server.xml:

com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidNioProtocol

to 

com.comcast.cdn.traffic_control.traffic_router.protocol.LanguidProtocol
