### PR TITLE
TR: Log WARN rather than FATAL when a polling URL param isn't set

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -125,9 +125,15 @@ public abstract class AbstractServiceUpdater {
 		File newDB = null;
 		boolean isModified = true;
 
+		final String databaseURL = getDataBaseURL();
+		if (databaseURL == null) {
+			LOGGER.warn("[" + getClass().getSimpleName() + "] Skipping download/update: database URL is null");
+			return false;
+		}
+
 		try {
 			try {
-				newDB = downloadDatabase(getDataBaseURL(), existingDB);
+				newDB = downloadDatabase(databaseURL, existingDB);
 				trafficRouterManager.trackEvent("last" + getClass().getSimpleName() + "Check");
 
 				// if the remote db's timestamp is less than or equal to ours, the above returns existingDB

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdaterTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdaterTest.java
@@ -78,6 +78,7 @@ public class AbstractServiceUpdaterTest {
 	public void itUsesETag() throws Exception {
 		Updater updater = new Updater();
 		updater.setDatabasesDirectory(databasesDirectory);
+		updater.dataBaseURL = "http://www.example.com";
 		updater.updateDatabase();
 
 		verify(connection, times(0)).setRequestProperty(eq("If-None-Match"), anyString());


### PR DESCRIPTION
For example, deepcoveragezone.polling.url can remain unset if the CDN
operator doesn't want to use the Deep Caching feature. Rather than
logging FATAL with a stacktrace, just log it as a warning.