### PR TITLE
Added maxmind.default.override parameter to CRConfig to handle maxmind default locations

### DIFF
--- a/docs/source/admin/traffic_ops/configuration.rst
+++ b/docs/source/admin/traffic_ops/configuration.rst
@@ -158,6 +158,9 @@ Many of the settings for the different servers in a Traffic Control CDN are cont
 +--------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------+
 | geolocation6.polling.url | CRConfig.json | The location to get the IPv6 GeoLiteCity database from.                                                                               |
 +--------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------+
+| geolocation.default /    | CRConfig.json | The country code and destination geo coordinates to use when the geo database service returns a default location.                     |
+| override                 |               | Format: <CountryCode>;<Lat>,<Long>   Ex: US;37.751,-97.822                                                                            |
++--------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------+
 
 These parameters should be set to reflect the local environment.
 

--- a/docs/source/admin/traffic_ops/configuration.rst
+++ b/docs/source/admin/traffic_ops/configuration.rst
@@ -158,8 +158,8 @@ Many of the settings for the different servers in a Traffic Control CDN are cont
 +--------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------+
 | geolocation6.polling.url | CRConfig.json | The location to get the IPv6 GeoLiteCity database from.                                                                               |
 +--------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------+
-| geolocation.default /    | CRConfig.json | The country code and destination geo coordinates to use when the geo database service returns a default location.                     |
-| override                 |               | Format: <CountryCode>;<Lat>,<Long>   Ex: US;37.751,-97.822                                                                            |
+| maxmind.default.override | CRConfig.json | The destination geo coordinates to use for client location when maxmind returns a default location that matches the country code.     |
+|                          |               | Format: <CountryCode>;<Lat>,<Long>   Ex: US;37.751,-97.822                                                                            |
 +--------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------+
 
 These parameters should be set to reflect the local environment.

--- a/docs/source/admin/traffic_ops/configuration.rst
+++ b/docs/source/admin/traffic_ops/configuration.rst
@@ -159,6 +159,7 @@ Many of the settings for the different servers in a Traffic Control CDN are cont
 | geolocation6.polling.url | CRConfig.json | The location to get the IPv6 GeoLiteCity database from.                                                                               |
 +--------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------+
 | maxmind.default.override | CRConfig.json | The destination geo coordinates to use for client location when maxmind returns a default location that matches the country code.     |
+|                          |               | This parameter can be specified multiple times with different values to support default overrides for multiple countries.             |
 |                          |               | Format: <CountryCode>;<Lat>,<Long>   Ex: US;37.751,-97.822                                                                            |
 +--------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------+
 

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -153,18 +153,18 @@ sub gen_crconfig_json {
             }
             $data_obj->{'config'}->{'requestHeaders'} = $headers;
         }
-        elsif ( $param eq 'geolocation.default.override' ) {
+        elsif ( $param eq 'maxmind.default.override' ) {
             ( my $country_code, my $coordinates ) = split( /\;/, $row->parameter->value );
             ( my $lat, my $long ) = split( /\,/, $coordinates );
             my $geolocation = {
                 'countryCode' => "$country_code",
-                'lat' => "$lat",
-                'long' => "$long"
+                'lat' => $lat + 0,
+                'long' => $long + 0
             };
-            if ( !$data_obj->{'config'}->{'geolocationOverride'} ) {
-                $data_obj->{'config'}->{'geolocationOverride'} = [];
+            if ( !$data_obj->{'config'}->{'maxmindDefaultOverride'} ) {
+                $data_obj->{'config'}->{'maxmindDefaultOverride'} = [];
             }
-            push ( $data_obj->{'config'}->{'geolocationOverride'}, $geolocation );
+            push ( $data_obj->{'config'}->{'maxmindDefaultOverride'}, $geolocation );
         }
         elsif ( !exists $requested_param_names{$param} ) {
             $data_obj->{'config'}->{$param} = $row->parameter->value;

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -153,6 +153,19 @@ sub gen_crconfig_json {
             }
             $data_obj->{'config'}->{'requestHeaders'} = $headers;
         }
+        elsif ( $param eq 'geolocation.default.override' ) {
+            ( my $country_code, my $coordinates ) = split( /\;/, $row->parameter->value );
+            ( my $lat, my $long ) = split( /\,/, $coordinates );
+            my $geolocation = {
+                'CountryCode' => "$country_code",
+                'Lat' => "$lat",
+                'Long' => "$long"
+            };
+            if ( !$data_obj->{'config'}->{'geolocationOverride'} ) {
+                $data_obj->{'config'}->{'geolocationOverride'} = [];
+            }
+            push ( $data_obj->{'config'}->{'geolocationOverride'}, $geolocation );
+        }
         elsif ( !exists $requested_param_names{$param} ) {
             $data_obj->{'config'}->{$param} = $row->parameter->value;
         }

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -157,9 +157,9 @@ sub gen_crconfig_json {
             ( my $country_code, my $coordinates ) = split( /\;/, $row->parameter->value );
             ( my $lat, my $long ) = split( /\,/, $coordinates );
             my $geolocation = {
-                'CountryCode' => "$country_code",
-                'Lat' => "$lat",
-                'Long' => "$long"
+                'countryCode' => "$country_code",
+                'lat' => "$lat",
+                'long' => "$long"
             };
             if ( !$data_obj->{'config'}->{'geolocationOverride'} ) {
                 $data_obj->{'config'}->{'geolocationOverride'} = [];

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -162,9 +162,9 @@ sub gen_crconfig_json {
                 'long' => $long + 0
             };
             if ( !$data_obj->{'config'}->{'maxmindDefaultOverride'} ) {
-                $data_obj->{'config'}->{'maxmindDefaultOverride'} = [];
+                @{ $data_obj->{'config'}->{'maxmindDefaultOverride'} } = ();
             }
-            push ( $data_obj->{'config'}->{'maxmindDefaultOverride'}, $geolocation );
+            push ( @{ $data_obj->{'config'}->{'maxmindDefaultOverride'} }, $geolocation );
         }
         elsif ( !exists $requested_param_names{$param} ) {
             $data_obj->{'config'}->{$param} = $row->parameter->value;
@@ -681,11 +681,21 @@ sub crconfig_strings {
             foreach my $key ( sort keys %{ $config_json->{'config'}->{$cfg} } ) {
                 $string .= "|$key:" . $config_json->{'config'}->{$cfg}->{$key};
             }
+            push( @config_strings, $string );
+        }
+        elsif ( $cfg eq 'maxmindDefaultOverride' ) {
+            foreach my $element ( @{ $config_json->{'config'}->{$cfg} } ) {
+                $string = "|param:$cfg";
+                foreach my $key ( sort keys %{ $element } ) {
+                    $string .= "|$key:" . $element->{$key};
+                }
+                push( @config_strings, $string );
+            }
         }
         else {
             $string = "|param:$cfg|value:" . $config_json->{'config'}->{$cfg} . "|";
+            push( @config_strings, $string );
         }
-        push( @config_strings, $string );
     }
     foreach my $rascal ( sort keys %{ $config_json->{'monitors'} } ) {
         my $return = &stringify_rascal( $config_json->{'monitors'}->{$rascal} );

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
@@ -151,7 +151,7 @@ public class MaxmindGeolocationService implements GeolocationService {
 		}
 
 		if (geolocation.getCity() == null && geolocation.getPostalCode() == null && response.getSubdivisions().isEmpty()) {
-			geolocation.setIsDefault(true);
+			geolocation.setDefaultLocation(true);
 		}
 
 		return geolocation;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
@@ -150,6 +150,10 @@ public class MaxmindGeolocationService implements GeolocationService {
 			geolocation.setCountryName(response.getCountry().getName());
 		}
 
+		if (geolocation.getCity() == null && geolocation.getPostalCode() == null && response.getSubdivisions().isEmpty()) {
+			geolocation.setIsDefault(true);
+		}
+
 		return geolocation;
 	}
 }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -105,7 +105,7 @@ public class TrafficRouter {
 
 		if (cr.getConfig() != null) {
 			// geolocationOverride: {countryCode: , lat: , long: }
-			final JsonNode geolocations = cr.getConfig().get("geolocationOverride");
+			final JsonNode geolocations = cr.getConfig().get("maxmindDefaultOverride");
 			if (geolocations != null) {
 				for (final JsonNode geolocation : geolocations) {
 					final String countryCode = JsonUtils.optString(geolocation, "countryCode");

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -104,13 +104,13 @@ public class TrafficRouter {
 		this.zoneManager = new ZoneManager(this, statTracker, trafficOpsUtils, trafficRouterManager);
 
 		if (cr.getConfig() != null) {
-			// geolocationOverride: {CountryCode: , Lat: , Long: }
+			// geolocationOverride: {countryCode: , lat: , long: }
 			final JsonNode geolocations = cr.getConfig().get("geolocationOverride");
 			if (geolocations != null) {
 				for (final JsonNode geolocation : geolocations) {
-					final String countryCode = JsonUtils.optString(geolocation, "CountryCode");
-					final double lat = JsonUtils.optDouble(geolocation, "Lat");
-					final double longitude = JsonUtils.optDouble(geolocation, "Long");
+					final String countryCode = JsonUtils.optString(geolocation, "countryCode");
+					final double lat = JsonUtils.optDouble(geolocation, "lat");
+					final double longitude = JsonUtils.optDouble(geolocation, "long");
 					defaultGeolocations.put(countryCode, new Geolocation(lat, longitude));
 				}
 			}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -104,7 +104,7 @@ public class TrafficRouter {
 		this.zoneManager = new ZoneManager(this, statTracker, trafficOpsUtils, trafficRouterManager);
 
 		if (cr.getConfig() != null) {
-			// geolocationOverride: {countryCode: , lat: , long: }
+			// maxmindDefaultOverride: {countryCode: , lat: , long: }
 			final JsonNode geolocations = cr.getConfig().get("maxmindDefaultOverride");
 			if (geolocations != null) {
 				for (final JsonNode geolocation : geolocations) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -325,7 +325,7 @@ public class TrafficRouter {
 			}
 		}
 
-		if (clientLocation.isDefault() && defaultGeolocations.containsKey(clientLocation.getCountryCode())) {
+		if (clientLocation.isDefaultLocation() && defaultGeolocations.containsKey(clientLocation.getCountryCode())) {
 			clientLocation = defaultGeolocations.get(clientLocation.getCountryCode());
 		}
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -325,7 +325,7 @@ public class TrafficRouter {
 			}
 		}
 
-		if (clientLocation.isDefault() == true && defaultGeolocations.containsKey(clientLocation.getCountryCode())) {
+		if (clientLocation.isDefault() && defaultGeolocations.containsKey(clientLocation.getCountryCode())) {
 			clientLocation = defaultGeolocations.get(clientLocation.getCountryCode());
 		}
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -87,7 +87,7 @@ public class TrafficRouter {
 	private final ConsistentHasher consistentHasher = new ConsistentHasher();
 	private SteeringRegistry steeringRegistry;
 
-	private final Map<String, Geolocation> defaultGeolocations = new HashMap<String, Geolocation>();
+	private final Map<String, Geolocation> defaultGeolocationsOverride = new HashMap<String, Geolocation>();
 
 	public TrafficRouter(final CacheRegister cr, 
 			final GeolocationService geolocationService, 
@@ -111,7 +111,7 @@ public class TrafficRouter {
 					final String countryCode = JsonUtils.optString(geolocation, "countryCode");
 					final double lat = JsonUtils.optDouble(geolocation, "lat");
 					final double longitude = JsonUtils.optDouble(geolocation, "long");
-					defaultGeolocations.put(countryCode, new Geolocation(lat, longitude));
+					defaultGeolocationsOverride.put(countryCode, new Geolocation(lat, longitude));
 				}
 			}
 		}
@@ -325,8 +325,8 @@ public class TrafficRouter {
 			}
 		}
 
-		if (clientLocation.isDefaultLocation() && defaultGeolocations.containsKey(clientLocation.getCountryCode())) {
-			clientLocation = defaultGeolocations.get(clientLocation.getCountryCode());
+		if (clientLocation.isDefaultLocation() && defaultGeolocationsOverride.containsKey(clientLocation.getCountryCode())) {
+			clientLocation = defaultGeolocationsOverride.get(clientLocation.getCountryCode());
 		}
 
 		final List<Cache> caches = getCachesByGeo(deliveryService, clientLocation, track);

--- a/traffic_router/geolocation/src/main/java/com/comcast/cdn/traffic_control/traffic_router/geolocation/Geolocation.java
+++ b/traffic_router/geolocation/src/main/java/com/comcast/cdn/traffic_control/traffic_router/geolocation/Geolocation.java
@@ -31,6 +31,7 @@ public class Geolocation {
 	private String city;
 	private String countryCode;
 	private String countryName;
+	private boolean isDefault;
 
 	/**
 	 * Creates an immutable {@link Geolocation}.
@@ -143,6 +144,14 @@ public class Geolocation {
 
 	public void setCountryName(String countryName) {
 		this.countryName = countryName;
+	}
+
+	public boolean isDefault() {
+		return isDefault;
+	}
+
+	public void setIsDefault(boolean isDefault) {
+		this.isDefault = isDefault;
 	}
 
 	@Override

--- a/traffic_router/geolocation/src/main/java/com/comcast/cdn/traffic_control/traffic_router/geolocation/Geolocation.java
+++ b/traffic_router/geolocation/src/main/java/com/comcast/cdn/traffic_control/traffic_router/geolocation/Geolocation.java
@@ -31,7 +31,7 @@ public class Geolocation {
 	private String city;
 	private String countryCode;
 	private String countryName;
-	private boolean isDefault = false;
+	private boolean defaultLocation = false;
 
 	/**
 	 * Creates an immutable {@link Geolocation}.
@@ -146,12 +146,12 @@ public class Geolocation {
 		this.countryName = countryName;
 	}
 
-	public boolean isDefault() {
-		return isDefault;
+	public boolean isDefaultLocation() {
+		return defaultLocation;
 	}
 
-	public void setIsDefault(boolean isDefault) {
-		this.isDefault = isDefault;
+	public void setDefaultLocation(boolean defaultLocation) {
+		this.defaultLocation = defaultLocation;
 	}
 
 	@Override

--- a/traffic_router/geolocation/src/main/java/com/comcast/cdn/traffic_control/traffic_router/geolocation/Geolocation.java
+++ b/traffic_router/geolocation/src/main/java/com/comcast/cdn/traffic_control/traffic_router/geolocation/Geolocation.java
@@ -31,7 +31,7 @@ public class Geolocation {
 	private String city;
 	private String countryCode;
 	private String countryName;
-	private boolean isDefault;
+	private boolean isDefault = false;
 
 	/**
 	 * Creates an immutable {@link Geolocation}.


### PR DESCRIPTION
Maintain a list of country code/coordinate pairs as: CountryCode;Lat,Long - in CRConfig.json to use instead of a default location for a given country. When a default location is indicated, TR checks if that country code has an entry specified in the config. If it does, it will set the client location to use the coordinates in that entry.