### PR TITLE
Add docs per-DS routing migration

### DIFF
--- a/docs/source/admin/traffic_ops/migration_from_20_to_22.rst
+++ b/docs/source/admin/traffic_ops/migration_from_20_to_22.rst
@@ -16,6 +16,21 @@
 Traffic Ops - Migrating from 2.0 to 2.2
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+Per-DeliveryService Routing Names
+---------------------------------
+Before this release, DNS Delivery Services were hardcoded to use the name "edge", i.e. "edge.myds.mycdn.com", and HTTP Delivery Services use the name "tr" (or previously "ccr"), i.e. "tr.myds.mycdn.com". As of 2.2, Routing Names will default to "cdn" if left unspecified and can be set to any arbitrary non-dotted hostname.
+
+Pre-2.2 the HTTP Routing Name is configurable via the http.routing.name option in in the Traffic Router http.properties config file. If your CDN uses that option to change the name from "tr" to something else, then you will need to perform the following steps for each CDN affected:
+
+1. In Traffic Ops, create the following profile parameter (double-check for typos, trailing spaces, etc):
+  * **name**: upgrade_http_routing_name
+  * **config file**: temp
+  * **value**: whatever value is used for the affected CDN's http.routing.name
+
+2. Add this parameter to a single profile in the affected CDN
+
+With those profile parameters in place Traffic Ops can be safely upgraded to 2.2. Before taking a post-upgrade snapshot, make sure to check your Delivery Service example URLs for unexpected Routing Name changes. Once Traffic Ops has been upgraded to 2.2 and a post-upgrade snapshot has been taken, your Traffic Routers can be upgraded to 2.2 (Traffic Routers must be upgraded after Traffic Ops so that they can work with custom per-DeliveryService Routing Names).
+
 Apache Traffic Server 7.x (Cachekey Plugin)
 -------------------------------------------
 In Traffic Ops 2.2 we have added support for Apache Traffic Server 7.x. With 7.x comes support for the new cachekey plugin which replaces the cacheurl plugin which is now deprecated.  


### PR DESCRIPTION
Specifically, moving the migration info from CHANGELOG.md into docs.

(cherry picked from commit 7c4ce34c15462716306c44ec3f5662e52220244a)