### PR TITLE
[Issue 1916] extra flag needed for go build in rpm

### DIFF
--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -19,6 +19,7 @@
 %define TRAFFIC_OPS_USER trafops
 %define TRAFFIC_OPS_GROUP trafops
 %define TRAFFIC_OPS_LOG_DIR /var/log/traffic_ops
+%define debug_package %{nil}
 
 Summary:          Traffic Ops UI
 Name:             traffic_ops


### PR DESCRIPTION
This fixes #1916 