### PR TITLE
[Issue 1916 backport] Fix TO golang build in rpm

### DIFF
--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -19,6 +19,7 @@
 %define TRAFFIC_OPS_USER trafops
 %define TRAFFIC_OPS_GROUP trafops
 %define TRAFFIC_OPS_LOG_DIR /var/log/traffic_ops
+%define debug_package %{nil}
 
 Summary:          Traffic Ops UI
 Name:             traffic_ops


### PR DESCRIPTION
(cherry picked from commit 824f865a044d6f6d358a7c5d858ea8b49458beee)

Fixes #1916 for 2.2.x