### PR TITLE
[Issue-1920] - requires portal role (or equivalent/above) to manage delivery service steering targets

### DIFF
--- a/docs/source/development/traffic_ops_api/v12/steering_target.rst
+++ b/docs/source/development/traffic_ops_api/v12/steering_target.rst
@@ -146,7 +146,7 @@ Steering Targets
 
   Authentication Required: Yes
 
-  Role(s) Required: Admin or Steering
+  Role(s) Required: Portal
 
   **Request Route Parameters**
 
@@ -226,7 +226,7 @@ Steering Targets
 
   Authentication Required: Yes
 
-  Role(s) Required: Admin or Steering
+  Role(s) Required: Portal
 
   **Request Route Parameters**
 
@@ -306,7 +306,7 @@ Steering Targets
 
   Authentication Required: Yes
 
-  Role(s) Required: Admin or Steering
+  Role(s) Required: Portal
 
   **Request Route Parameters**
 

--- a/traffic_ops/app/lib/API/DeliveryService/SteeringTarget.pm
+++ b/traffic_ops/app/lib/API/DeliveryService/SteeringTarget.pm
@@ -104,7 +104,7 @@ sub update {
 	my $target_ds_id   = $self->param('target_id');
 	my $params         = $self->req->json;
 
-	if ( !&is_admin($self) && !&is_steering($self) ) {
+	if ( !&is_portal($self) ) {
 		return $self->forbidden();
 	}
 
@@ -175,7 +175,7 @@ sub create {
 	my $steering_ds_id = $self->param('id');
 	my $target_ds_id   = $params->{targetId};
 
-	if ( !&is_admin($self) && !&is_steering($self) ) {
+	if ( !&is_portal($self) ) {
 		return $self->forbidden();
 	}
 
@@ -246,7 +246,7 @@ sub delete {
 	my $steering_ds_id = $self->param('id');
 	my $target_ds_id   = $self->param('target_id');
 
-	if ( !&is_admin($self) && !&is_steering($self) ) {
+	if ( !&is_portal($self) ) {
 		return $self->forbidden();
 	}
 


### PR DESCRIPTION
This won't have any affect on the users (steering or admin) that current use these apis. 

fixes #1920 