### PR TITLE
[Issue 1687] - adds manage ssl keys, url sig keys and uri signing keys menu items to…

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -51,12 +51,6 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, type, t
 
     $scope.dsRequestsEnabled = propertiesModel.properties.dsRequests.enabled;
 
-	$scope.manageKeys = {
-		sslKeys: deliveryService.protocol > 0,
-		urlSigKeys: deliveryService.signingAlgorithm == 'url_sig',
-		uriSigningKeys: deliveryService.signingAlgorithm == 'uri_signing'
-	};
-
 	$scope.edgeFQDNs = function(ds) {
         var urlString = '';
         if (_.isArray(ds.exampleURLs) && ds.exampleURLs.length > 0) {

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -38,14 +38,13 @@ under the License.
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
                     <li class="divider"></li>
-                    <li role="menuitem"><a ng-if="manageKeys.sslKeys" ng-click="manageSslKeys()">Manage SSL Keys</a></li>
-                    <li role="menuitem"><a ng-if="manageKeys.urlSigKeys" ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
-                    <li role="menuitem"><a ng-if="manageKeys.uriSigningKeys" ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
-                    <li class="divider" ng-if="manageKeys.sslKeys || manageKeys.urlSigKeys || manageKeys.uriSigningKeys"></li>
+                    <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
+                    <li role="menuitem"><a ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
+                    <li role="menuitem"><a ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
+                    <li class="divider"></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
                     <li role="menuitem"><a ng-click="viewJobs()">View Invalidate Content Jobs</a></li>
-                    <li role="menuitem"><a ng-click="viewStaticDnsEntries()">View Static DNS Entries</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -38,14 +38,13 @@ under the License.
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
                     <li class="divider"></li>
-                    <li role="menuitem"><a ng-if="manageKeys.sslKeys" ng-click="manageSslKeys()">Manage SSL Keys</a></li>
-                    <li role="menuitem"><a ng-if="manageKeys.urlSigKeys" ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
-                    <li role="menuitem"><a ng-if="manageKeys.uriSigningKeys" ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
-                    <li class="divider" ng-if="manageKeys.sslKeys || manageKeys.urlSigKeys || manageKeys.uriSigningKeys"></li>
+                    <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
+                    <li role="menuitem"><a ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
+                    <li role="menuitem"><a ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
+                    <li class="divider"></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
                     <li role="menuitem"><a ng-click="viewJobs()">View Invalidate Content Jobs</a></li>
-                    <li role="menuitem"><a ng-click="viewStaticDnsEntries()">View Static DNS Entries</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -38,14 +38,11 @@ under the License.
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
                     <li class="divider"></li>
-                    <li role="menuitem"><a ng-if="manageKeys.sslKeys" ng-click="manageSslKeys()">Manage SSL Keys</a></li>
-                    <li role="menuitem"><a ng-if="manageKeys.urlSigKeys" ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
-                    <li role="menuitem"><a ng-if="manageKeys.uriSigningKeys" ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
-                    <li class="divider" ng-if="manageKeys.sslKeys || manageKeys.urlSigKeys || manageKeys.uriSigningKeys"></li>
+                    <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
+                    <li class="divider"></li>
                     <li role="menuitem"><a ng-click="viewTargets()">View Targets</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
                     <li role="menuitem"><a ng-click="viewJobs()">View Invalidate Content Jobs</a></li>
-                    <li role="menuitem"><a ng-click="viewStaticDnsEntries()">View Static DNS Entries</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -38,14 +38,9 @@ under the License.
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
                     <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
                     <li class="divider"></li>
-                    <li role="menuitem"><a ng-if="manageKeys.sslKeys" ng-click="manageSslKeys()">Manage SSL Keys</a></li>
-                    <li role="menuitem"><a ng-if="manageKeys.urlSigKeys" ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
-                    <li role="menuitem"><a ng-if="manageKeys.uriSigningKeys" ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
-                    <li class="divider" ng-if="manageKeys.sslKeys || manageKeys.urlSigKeys || manageKeys.uriSigningKeys"></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
                     <li role="menuitem"><a ng-click="viewJobs()">View Invalidate Content Jobs</a></li>
-                    <li role="menuitem"><a ng-click="viewStaticDnsEntries()">View Static DNS Entries</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
… TP for a ds. always show these menu items even if not applicable to the ds. this is to satisfy ds requests where keys may have to be managed before the ds is actually changed.

plus, static dns entries for a ds doesn't work properly so removing that menu item.