### PR TITLE
TO golang -- adds validation rules for ASNs, CDNs APIs

### DIFF
--- a/lib/go-tc/asns.go
+++ b/lib/go-tc/asns.go
@@ -24,9 +24,17 @@ type ASNsResponse struct {
 }
 
 type ASN struct {
-	ASN          int    `json:"asn" db:"asn"`
-	Cachegroup   string `json:"cachegroup" db:"cachegroup"`
-	CachegroupID int    `json:"cachegroupId" db:"cachegroup_id"`
-	ID           int    `json:"id" db:"id"`
-	LastUpdated  Time   `json:"lastUpdated" db:"last_updated"`
+	ASN          int       `json:"asn" db:"asn"`
+	Cachegroup   string    `json:"cachegroup" db:"cachegroup"`
+	CachegroupID int       `json:"cachegroupId" db:"cachegroup_id"`
+	ID           int       `json:"id" db:"id"`
+	LastUpdated  TimeNoMod `json:"lastUpdated" db:"last_updated"`
+}
+
+type ASNNullable struct {
+	ASN          *int       `json:"asn" db:"asn"`
+	Cachegroup   *string    `json:"cachegroup" db:"cachegroup"`
+	CachegroupID *int       `json:"cachegroupId" db:"cachegroup_id"`
+	ID           *int       `json:"id" db:"id"`
+	LastUpdated  *TimeNoMod `json:"lastUpdated" db:"last_updated"`
 }

--- a/lib/go-tc/cdns.go
+++ b/lib/go-tc/cdns.go
@@ -24,11 +24,19 @@ type CDNsResponse struct {
 }
 
 type CDN struct {
-	DNSSECEnabled bool   `json:"dnssecEnabled" db:"dnssec_enabled"`
-	DomainName    string `json:"domainName" db:"domain_name"`
-	ID            int    `json:"id" db:"id"`
-	LastUpdated   Time   `json:"lastUpdated" db:"last_updated"`
-	Name          string `json:"name" db:"name"`
+	DNSSECEnabled bool      `json:"dnssecEnabled" db:"dnssec_enabled"`
+	DomainName    string    `json:"domainName" db:"domain_name"`
+	ID            int       `json:"id" db:"id"`
+	LastUpdated   TimeNoMod `json:"lastUpdated" db:"last_updated"`
+	Name          string    `json:"name" db:"name"`
+}
+
+type CDNNullable struct {
+	DNSSECEnabled *bool      `json:"dnssecEnabled" db:"dnssec_enabled"`
+	DomainName    *string    `json:"domainName" db:"domain_name"`
+	ID            *int       `json:"id" db:"id"`
+	LastUpdated   *TimeNoMod `json:"lastUpdated" db:"last_updated"`
+	Name          *string    `json:"name" db:"name"`
 }
 
 // CDNSSLKeysResponse ...

--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -47,15 +47,15 @@ func GetRefType() *TOASN {
 }
 
 //Implementation of the Identifier, Validator interface functions
-func (asn *TOASN) GetID() (int, bool) {
+func (asn TOASN) GetID() (int, bool) {
 	return asn.ID, true
 }
 
-func (asn *TOASN) GetAuditName() string {
+func (asn TOASN) GetAuditName() string {
 	return strconv.Itoa(asn.ASN)
 }
 
-func (asn *TOASN) GetType() string {
+func (asn TOASN) GetType() string {
 	return "asn"
 }
 
@@ -63,10 +63,13 @@ func (asn *TOASN) SetID(i int) {
 	asn.ID = i
 }
 
-func (asn *TOASN) Validate(db *sqlx.DB) []error {
+func (asn TOASN) Validate(db *sqlx.DB) []error {
 	errs := []error{}
-	if asn.ASN < 1 {
-		errs = append(errs, errors.New(`ASN 'asn' is required.`))
+	if asn.ASN < 0 {
+		errs = append(errs, errors.New(`asn must be a positive integer`))
+	}
+	if asn.CachegroupID < 0 {
+		errs = append(errs, errors.New(`cachegroupId must be a positive integer`))
 	}
 	return errs
 }

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -40,7 +40,7 @@ func getTestASNs() []tc.ASN {
 		ASN:         1,
 		Cachegroup:  "Yukon",
 		ID:          1,
-		LastUpdated: tc.Time{Time: time.Now()},
+		LastUpdated: tc.TimeNoMod{Time: time.Now()},
 	}
 	ASNs = append(ASNs, testCase)
 
@@ -111,18 +111,13 @@ func TestInterfaces(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	asn := TOASN{ASN: -99, CachegroupID: -99}
-	/*
-		ASN          int    `json:"asn" db:"asn"`
-		Cachegroup   string `json:"cachegroup" db:"cachegroup"`
-		CachegroupID int    `json:"cachegroupId" db:"cachegroup_id"`
-		ID           int    `json:"id" db:"id"`
-		LastUpdated  Time   `json:"lastUpdated" db:"last_updated"`
-	*/
+	i := -99
+	asn := TOASN{ASN: &i, CachegroupID: &i}
+
 	errs := asn.Validate(nil)
 	expected := []error{
-		errors.New(`asn must be a positive integer`),
-		errors.New(`cachegroupId must be a positive integer`),
+		errors.New(`'asn' must be no less than 0`),
+		errors.New(`'cachegroupId' must be no less than 0`),
 	}
 	if !reflect.DeepEqual(expected, errs) {
 		t.Errorf(`expected %v,  got %v`, expected, errs)

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -20,6 +20,8 @@ package asn
  */
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -105,5 +107,24 @@ func TestInterfaces(t *testing.T) {
 	}
 	if _, ok := i.(api.Identifier); !ok {
 		t.Errorf("asn must be Identifier")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	asn := TOASN{ASN: -99, CachegroupID: -99}
+	/*
+		ASN          int    `json:"asn" db:"asn"`
+		Cachegroup   string `json:"cachegroup" db:"cachegroup"`
+		CachegroupID int    `json:"cachegroupId" db:"cachegroup_id"`
+		ID           int    `json:"id" db:"id"`
+		LastUpdated  Time   `json:"lastUpdated" db:"last_updated"`
+	*/
+	errs := asn.Validate(nil)
+	expected := []error{
+		errors.New(`asn must be a positive integer`),
+		errors.New(`cachegroupId must be a positive integer`),
+	}
+	if !reflect.DeepEqual(expected, errs) {
+		t.Errorf(`expected %v,  got %v`, expected, errs)
 	}
 }

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -42,7 +42,7 @@ func getTestCDNs() []tc.CDN {
 		DomainName:    "domainName",
 		ID:            1,
 		Name:          "cdn1",
-		LastUpdated:   tc.Time{Time: time.Now()},
+		LastUpdated:   tc.TimeNoMod{Time: time.Now()},
 	}
 	cdns = append(cdns, testCDN)
 
@@ -129,17 +129,28 @@ func TestInterfaces(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	c := TOCDN{Name: "not-a-valid-cdn"}
+	// invalid name, empty domainname
+	n := "not_a_valid_cdn"
+	c := TOCDN{Name: &n}
 	errs := c.Validate(nil)
 
 	expectedErrs := []error{
-		errors.New(`'name' invalid characters found`),
+		errors.New(`'name' invalid characters found - Use alphanumeric . or - .`),
 		errors.New(`'domainName' cannot be blank`),
 	}
 
 	if !reflect.DeepEqual(expectedErrs, errs) {
 		t.Errorf("expected %s, got %s", expectedErrs, errs)
 	}
-	c.Name = "This.is.2.a_Valid___CDNNAME."
-	c.DomainName = `awesome-cdn.example.net`
+
+	//  name,  domainname both valid
+	n = "This.is.2.a-Valid---CDNNAME."
+	d := `awesome-cdn.example.net`
+	c = TOCDN{Name: &n, DomainName: &d}
+	expectedErrs = []error{}
+	errs = c.Validate(nil)
+	if !reflect.DeepEqual(expectedErrs, errs) {
+		t.Errorf("expected %s, got %s", expectedErrs, errs)
+	}
+
 }

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -20,6 +20,9 @@ package cdn
  */
 
 import (
+	"errors"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,6 +92,21 @@ func TestReadCDNs(t *testing.T) {
 	}
 }
 
+func TestFuncs(t *testing.T) {
+	if strings.Index(selectQuery(), "SELECT") != 0 {
+		t.Errorf("expected selectQuery to start with SELECT")
+	}
+	if strings.Index(insertQuery(), "INSERT") != 0 {
+		t.Errorf("expected insertQuery to start with INSERT")
+	}
+	if strings.Index(updateQuery(), "UPDATE") != 0 {
+		t.Errorf("expected updateQuery to start with UPDATE")
+	}
+	if strings.Index(deleteQuery(), "DELETE") != 0 {
+		t.Errorf("expected deleteQuery to start with DELETE")
+	}
+
+}
 func TestInterfaces(t *testing.T) {
 	var i interface{}
 	i = &TOCDN{}
@@ -108,4 +126,20 @@ func TestInterfaces(t *testing.T) {
 	if _, ok := i.(api.Identifier); !ok {
 		t.Errorf("cdn must be Identifier")
 	}
+}
+
+func TestValidate(t *testing.T) {
+	c := TOCDN{Name: "not-a-valid-cdn"}
+	errs := c.Validate(nil)
+
+	expectedErrs := []error{
+		errors.New(`'name' invalid characters found`),
+		errors.New(`'domainName' cannot be blank`),
+	}
+
+	if !reflect.DeepEqual(expectedErrs, errs) {
+		t.Errorf("expected %s, got %s", expectedErrs, errs)
+	}
+	c.Name = "This.is.2.a_Valid___CDNNAME."
+	c.DomainName = `awesome-cdn.example.net`
 }


### PR DESCRIPTION
This fixes #1939 

When performing a POST or PUT to the `/api/1.3/asns` or `.../cdns` endpoint with incorrect data, expect a `400 Bad Request` status and with error messages that the request failed.