### PR TITLE
TO golang API -- add validations to phys_locations

### DIFF
--- a/lib/go-tc/physlocations.go
+++ b/lib/go-tc/physlocations.go
@@ -19,25 +19,21 @@ package tc
  * under the License.
  */
 
-type PhysLocationsResponse struct {
-	Response []PhysLocation `json:"response"`
-}
-
 type PhysLocation struct {
-	Address     string `json:"address" db:"address"`
-	City        string `json:"city" db:"city"`
-	Comments    string `json:"comments" db:"comments"`
-	Email       string `json:"email" db:"email"`
-	ID          int    `json:"id" db:"id"`
-	LastUpdated Time   `json:"lastUpdated" db:"last_updated"`
-	Name        string `json:"name" db:"name"`
-	Phone       string `json:"phone" db:"phone"`
-	POC         string `json:"poc" db:"poc"`
-	RegionID    int    `json:"regionId" db:"region"`
-	RegionName  string `json:"region" db:"region_name"`
-	ShortName   string `json:"shortName" db:"short_name"`
-	State       string `json:"state" db:"state"`
-	Zip         string `json:"zip" db:"zip"`
+	Address     string    `json:"address" db:"address"`
+	City        string    `json:"city" db:"city"`
+	Comments    string    `json:"comments" db:"comments"`
+	Email       string    `json:"email" db:"email"`
+	ID          int       `json:"id" db:"id"`
+	LastUpdated TimeNoMod `json:"lastUpdated" db:"last_updated"`
+	Name        string    `json:"name" db:"name"`
+	Phone       string    `json:"phone" db:"phone"`
+	POC         string    `json:"poc" db:"poc"`
+	RegionID    int       `json:"regionId" db:"region"`
+	RegionName  string    `json:"region" db:"region_name"`
+	ShortName   string    `json:"shortName" db:"short_name"`
+	State       string    `json:"state" db:"state"`
+	Zip         string    `json:"zip" db:"zip"`
 }
 
 // PhysLocationNullable - a struct version that allows for all fields to be null
@@ -45,18 +41,18 @@ type PhysLocationNullable struct {
 	//
 	// NOTE: the db: struct tags are used for testing to map to their equivalent database column (if there is one)
 	//
-	Address     *string `json:"address" db:"address"`
-	City        *string `json:"city" db:"city"`
-	Comments    *string `json:"comments" db:"comments"`
-	Email       *string `json:"email" db:"email"`
-	ID          *int    `json:"id" db:"id"`
-	LastUpdated Time    `json:"lastUpdated" db:"last_updated"`
-	Name        *string `json:"name" db:"name"`
-	Phone       *string `json:"phone" db:"phone"`
-	POC         *string `json:"poc" db:"poc"`
-	RegionID    *int    `json:"regionId" db:"region"`
-	RegionName  *string `json:"region" db:"region_name"`
-	ShortName   *string `json:"shortName" db:"short_name"`
-	State       *string `json:"state" db:"state"`
-	Zip         *string `json:"zip" db:"zip"`
+	Address     *string   `json:"address" db:"address"`
+	City        *string   `json:"city" db:"city"`
+	Comments    *string   `json:"comments" db:"comments"`
+	Email       *string   `json:"email" db:"email"`
+	ID          *int      `json:"id" db:"id"`
+	LastUpdated TimeNoMod `json:"lastUpdated" db:"last_updated"`
+	Name        *string   `json:"name" db:"name"`
+	Phone       *string   `json:"phone" db:"phone"`
+	POC         *string   `json:"poc" db:"poc"`
+	RegionID    *int      `json:"regionId" db:"region"`
+	RegionName  *string   `json:"region" db:"region_name"`
+	ShortName   *string   `json:"shortName" db:"short_name"`
+	State       *string   `json:"state" db:"state"`
+	Zip         *string   `json:"zip" db:"zip"`
 }

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -20,6 +20,8 @@ package physlocation
  */
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -39,7 +41,7 @@ func getTestPhysLocations() []tc.PhysLocation {
 		City:        "Denver",
 		Email:       "d.t@gmail.com",
 		ID:          1,
-		LastUpdated: tc.Time{Time: time.Now()},
+		LastUpdated: tc.TimeNoMod{Time: time.Now()},
 		Name:        "physLocation1",
 		Phone:       "303-210-0000",
 		POC:         "Dennis Thompson",
@@ -122,5 +124,23 @@ func TestInterfaces(t *testing.T) {
 	}
 	if _, ok := i.(api.Identifier); !ok {
 		t.Errorf("PhysLocation must be Identifier")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	p := TOPhysLocation{}
+	errs := test.SortErrors(p.Validate(nil))
+	expected := test.SortErrors([]error{
+		errors.New("'state' cannot be blank"),
+		errors.New("'zip' cannot be blank"),
+		errors.New("'address' cannot be blank"),
+		errors.New("'city' cannot be blank"),
+		errors.New("'name' cannot be blank"),
+		errors.New("'regionId' cannot be blank"),
+		errors.New("'shortName' cannot be blank"),
+	})
+
+	if !reflect.DeepEqual(expected, errs) {
+		t.Errorf("expected %++v,  got %++v", expected, errs)
 	}
 }

--- a/traffic_ops/traffic_ops_golang/test/helpers.go
+++ b/traffic_ops/traffic_ops_golang/test/helpers.go
@@ -21,6 +21,7 @@ package test
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 )
 
@@ -39,4 +40,23 @@ func ColsFromStructByTag(tagName string, thing interface{}) []string {
 		}
 	}
 	return cols
+}
+
+// sortableErrors provides ordering a list of errors for easier comparison with an expected list
+type sortableErrors []error
+
+func (s sortableErrors) Len() int {
+	return len(s)
+}
+func (s sortableErrors) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortableErrors) Less(i, j int) bool {
+	return s[i].Error() < s[j].Error()
+}
+
+// SortErrors sorts the list of errors lexically
+func SortErrors(p []error) []error {
+	sort.Sort(sortableErrors(p))
+	return p
 }


### PR DESCRIPTION
Expected effect:  POST/PUT to `api/1.3/phys_locations` errors on missing or invalid data.

NOTE: foreign key violation for cachegroupId is currently handled directly by the db (as it is in Perl).  Improvements are planned for future.