### PR TITLE
sort errors in asn/cdn tests

### DIFF
--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -114,7 +114,7 @@ func TestValidate(t *testing.T) {
 	i := -99
 	asn := TOASN{ASN: &i, CachegroupID: &i}
 
-	errs := asn.Validate(nil)
+	errs := test.SortErrors(asn.Validate(nil))
 	expected := []error{
 		errors.New(`'asn' must be no less than 0`),
 		errors.New(`'cachegroupId' must be no less than 0`),

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -132,11 +132,11 @@ func TestValidate(t *testing.T) {
 	// invalid name, empty domainname
 	n := "not_a_valid_cdn"
 	c := TOCDN{Name: &n}
-	errs := c.Validate(nil)
+	errs := test.SortErrors(c.Validate(nil))
 
 	expectedErrs := []error{
-		errors.New(`'name' invalid characters found - Use alphanumeric . or - .`),
 		errors.New(`'domainName' cannot be blank`),
+		errors.New(`'name' invalid characters found - Use alphanumeric . or - .`),
 	}
 
 	if !reflect.DeepEqual(expectedErrs, errs) {


### PR DESCRIPTION
errors from validation can come out in any order.  It does not matter for the API,  but can affect the tests.   Sort the errors before comparing with expected.