### PR TITLE
TO: in rpm build, set permissions of conf files to not be world-readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - /api/1.3/system/info
   - /api/1.3/types (R)
 - Fair Queuing Pacing: Using the FQ Pacing Rate parameter in Delivery Services allows operators to limit the rate of individual sessions to the edge cache. This feature requires a Trafficserver RPM containing the fq_pacing experimental plugin AND setting 'fq' as the default Linux qdisc in sysctl. 
+- Traffic Ops rpm changed to remove world-read permission from configuration files.
 
 ### Changed
 - Reformatted this CHANGELOG file to the keep-a-changelog format

--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -217,10 +217,11 @@ fi
 
 %files
 %defattr(644,root,root,755)
-%attr(755,root,root) %{PACKAGEDIR}/app/bin/*
-%attr(755,root,root) %{PACKAGEDIR}/app/script/*
-%attr(755,root,root) %{PACKAGEDIR}/app/db/*.pl
-%config(noreplace)/opt/traffic_ops/app/conf/*
+%attr(755,%{TRAFFIC_OPS_USER},%{TRAFFIC_OPS_GROUP}) %{PACKAGEDIR}/app/bin/*
+%attr(755,%{TRAFFIC_OPS_USER},%{TRAFFIC_OPS_GROUP}) %{PACKAGEDIR}/app/script/*
+%attr(755,%{TRAFFIC_OPS_USER},%{TRAFFIC_OPS_GROUP}) %{PACKAGEDIR}/app/db/*.pl
+%config(noreplace) %attr(750,%{TRAFFIC_OPS_USER},%{TRAFFIC_OPS_GROUP}) /opt/traffic_ops/app/conf
+%config(noreplace) %attr(750,%{TRAFFIC_OPS_USER},%{TRAFFIC_OPS_GROUP}) /opt/traffic_ops/app/db/dbconf.yml
 %config(noreplace)/var/www/files/osversions.cfg
 %{PACKAGEDIR}/app/cpanfile
 %{PACKAGEDIR}/app/db


### PR DESCRIPTION
This fixes #1107 

Q: What effect should I expect to see with this PR?
A: create a new rpm and install on a fresh machine.  The permissions on all files and directories within /opt/traffic_ops/app/conf will be owned by trafops:trafops and will not be world-readable.