### PR TITLE
TO golang asns point fixes

### DIFF
--- a/lib/go-tc/asns.go
+++ b/lib/go-tc/asns.go
@@ -25,7 +25,7 @@ type ASNsResponse struct {
 
 type ASN struct {
 	ASN          int       `json:"asn" db:"asn"`
-	Cachegroup   string    `json:"cachegroup" db:"cachegroup"`
+	Cachegroup   string    `json:"cachegroup"`
 	CachegroupID int       `json:"cachegroupId" db:"cachegroup_id"`
 	ID           int       `json:"id" db:"id"`
 	LastUpdated  TimeNoMod `json:"lastUpdated" db:"last_updated"`
@@ -33,7 +33,7 @@ type ASN struct {
 
 type ASNNullable struct {
 	ASN          *int       `json:"asn" db:"asn"`
-	Cachegroup   *string    `json:"cachegroup" db:"cachegroup"`
+	Cachegroup   *string    `json:"cachegroup"`
 	CachegroupID *int       `json:"cachegroupId" db:"cachegroup_id"`
 	ID           *int       `json:"id" db:"id"`
 	LastUpdated  *TimeNoMod `json:"lastUpdated" db:"last_updated"`

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -34,18 +34,21 @@ import (
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
-func getTestASNs() []tc.ASN {
-	ASNs := []tc.ASN{}
-	testCase := tc.ASN{
-		ASN:         1,
-		Cachegroup:  "Yukon",
-		ID:          1,
-		LastUpdated: tc.TimeNoMod{Time: time.Now()},
+func getTestASNs() []TOASN {
+	ASNs := []TOASN{}
+	i := 1
+	c := "Yukon"
+	testCase := TOASN{
+		ASN:          &i,
+		Cachegroup:   &c,
+		CachegroupID: &i,
+		ID:           &i,
+		LastUpdated:  &tc.TimeNoMod{Time: time.Now()},
 	}
 	ASNs = append(ASNs, testCase)
 
 	testCase2 := testCase
-	testCase2.ASN = 2
+	*testCase2.ASN = 2
 	ASNs = append(ASNs, testCase2)
 
 	return ASNs
@@ -62,16 +65,15 @@ func TestGetASNs(t *testing.T) {
 	defer db.Close()
 
 	testCase := getTestASNs()
-	cols := test.ColsFromStructByTag("db", tc.ASN{})
+	cols := test.ColsFromStructByTag("db", TOASN{})
 	rows := sqlmock.NewRows(cols)
 
 	for _, ts := range testCase {
 		rows = rows.AddRow(
-			ts.ASN,
-			ts.Cachegroup,
-			ts.CachegroupID,
-			ts.ID,
-			ts.LastUpdated,
+			*ts.ASN,
+			*ts.CachegroupID,
+			*ts.ID,
+			*ts.LastUpdated,
 		)
 	}
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)


### PR DESCRIPTION
this fixes #1958 
this fixes #1959 

Use the tc.ASNNullable struct to enable testing of presence of required fields in JSON;
Fix sql queries to use `cachegroup` as an id rather than a name (to match Perl)