### PR TITLE
TO golang -- adds ping route

### DIFF
--- a/traffic_ops/client/v13/ping.go
+++ b/traffic_ops/client/v13/ping.go
@@ -1,0 +1,39 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package v13
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const (
+	API_v13_PING = "/api/1.3/ping"
+)
+
+// Ping returns a static json object to show that traffic_ops is responsive
+func (to *Session) Ping() (map[string]string, ReqInf, error) {
+	resp, remoteAddr, err := to.request(http.MethodGet, API_v13_PING, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
+	if err != nil {
+		return nil, reqInf, err
+	}
+	defer resp.Body.Close()
+
+	var data map[string]string
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	return data, reqInf, nil
+}

--- a/traffic_ops/testing/api/v13/ping_test.go
+++ b/traffic_ops/testing/api/v13/ping_test.go
@@ -1,0 +1,24 @@
+package v13
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"testing"
+)
+
+func TestPing(t *testing.T) {
+	TOSession.Ping()
+}

--- a/traffic_ops/traffic_ops_golang/ping.go
+++ b/traffic_ops/traffic_ops_golang/ping.go
@@ -1,0 +1,34 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// pingHandler simply returns a canned response to show that the server is responding
+func pingHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m := map[string]string{"ping": "pong"}
+		enc := json.NewEncoder(w)
+		enc.Encode(m)
+	}
+}

--- a/traffic_ops/traffic_ops_golang/ping/ping.go
+++ b/traffic_ops/traffic_ops_golang/ping/ping.go
@@ -1,0 +1,34 @@
+package ping
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// PingHandler simply returns a canned response to show that the server is responding
+func PingHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m := map[string]string{"ping": "pong"}
+		enc := json.NewEncoder(w)
+		enc.Encode(m)
+	}
+}

--- a/traffic_ops/traffic_ops_golang/ping/ping_test.go
+++ b/traffic_ops/traffic_ops_golang/ping/ping_test.go
@@ -1,4 +1,4 @@
-package main
+package ping
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,15 +20,25 @@ package main
  */
 
 import (
-	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 // pingHandler simply returns a canned response to show that the server is responding
-func pingHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		m := map[string]string{"ping": "pong"}
-		enc := json.NewEncoder(w)
-		enc.Encode(m)
+func TestPingHandler(t *testing.T) {
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("GET", "ping", nil)
+	if err != nil {
+		t.Error("Error creating new request")
+	}
+
+	PingHandler()(w, r)
+
+	// note the newline...
+	expected := `{"ping":"pong"}
+`
+	if w.Body.String() != expected {
+		t.Error("Expected body", expected, "got", w.Body.String())
 	}
 }

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -141,6 +141,10 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		//Parameters
 		{1.3, http.MethodGet, `parameters/?(\.json)?$`, parametersHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 
+		//Ping
+		{1.2, http.MethodGet, `ping$`, pingHandler(), auth.PrivLevelReadOnly, Authenticated, nil},
+
+		//Servers
 		{1.2, http.MethodGet, `servers/?(\.json)?$`, serversHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.2, http.MethodGet, `servers/{id}$`, serversHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 		{1.2, http.MethodPost, `servers/{id}/deliveryservices$`, assignDeliveryServicesToServerHandler(d.DB), auth.PrivLevelOperations, Authenticated, nil},

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -36,6 +36,7 @@ import (
 	dsrequest "github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice/request"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/division"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/physlocation"
+	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/ping"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/region"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/status"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/systeminfo"
@@ -142,7 +143,7 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{1.3, http.MethodGet, `parameters/?(\.json)?$`, parametersHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Ping
-		{1.2, http.MethodGet, `ping$`, pingHandler(), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.2, http.MethodGet, `ping$`, ping.PingHandler(), auth.PrivLevelReadOnly, Authenticated, nil},
 
 		//Servers
 		{1.2, http.MethodGet, `servers/?(\.json)?$`, serversHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},


### PR DESCRIPTION
Q: What effect is expected from this change?
A: `GET /api/1.2/ping` will return `{"ping":"pong"}` with a 200 status
`curl -I .../api/1.2/ping` will show
```
X-Server-Name: traffic_ops_golang/0.1
```

 rather than 

```
Server: Mojolicious (Perl)
```