### PR TITLE
Fixes #1915 to make http_no_cache services support origin ports

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1890,7 +1890,14 @@ sub server_cache_dot_config {
 		if ( $ds->{type} eq "HTTP_NO_CACHE" ) {
 			my $org_fqdn = $ds->{org};
 			$org_fqdn =~ s/https?:\/\///;
-			$text .= "dest_domain=" . $org_fqdn . " scheme=http action=never-cache\n";
+			$org_fqdn =~ m/.*?:(\d+).*/;
+			my $org_port = $1;
+
+			if (defined($org_port)) {
+				$text .= "dest_domain=" . $org_fqdn . " port=" . $org_port . " scheme=http action=never-cache\n";
+			} else {
+				$text .= "dest_domain=" . $org_fqdn . " scheme=http action=never-cache\n";
+			}
 		}
 	}
 
@@ -1918,7 +1925,14 @@ sub profile_cache_dot_config {
 		if ( $ds->{type} eq "HTTP_NO_CACHE" ) {
 			my $org_fqdn = $ds->{org};
 			$org_fqdn =~ s/https?:\/\///;
-			$text .= "dest_domain=" . $org_fqdn . " scheme=http action=never-cache\n";
+			$org_fqdn =~ m/.*?:(\d+).*/;
+			my $org_port = $1;
+			
+			if (defined($org_port)) {
+				$text .= "dest_domain=" . $org_fqdn . " port=" . $org_port . " scheme=http action=never-cache\n";
+			} else {
+				$text .= "dest_domain=" . $org_fqdn . " scheme=http action=never-cache\n";
+			}
 		}
 	}
 

--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -1890,10 +1890,11 @@ sub server_cache_dot_config {
 		if ( $ds->{type} eq "HTTP_NO_CACHE" ) {
 			my $org_fqdn = $ds->{org};
 			$org_fqdn =~ s/https?:\/\///;
-			$org_fqdn =~ m/.*?:(\d+).*/;
-			my $org_port = $1;
+			$org_fqdn =~ m/(.*?):(\d+).*/;
+			my $org_port = $2;
 
 			if (defined($org_port)) {
+				$org_fqdn = $1;
 				$text .= "dest_domain=" . $org_fqdn . " port=" . $org_port . " scheme=http action=never-cache\n";
 			} else {
 				$text .= "dest_domain=" . $org_fqdn . " scheme=http action=never-cache\n";
@@ -1925,10 +1926,11 @@ sub profile_cache_dot_config {
 		if ( $ds->{type} eq "HTTP_NO_CACHE" ) {
 			my $org_fqdn = $ds->{org};
 			$org_fqdn =~ s/https?:\/\///;
-			$org_fqdn =~ m/.*?:(\d+).*/;
-			my $org_port = $1;
+			$org_fqdn =~ m/(.*?):(\d+).*/;
+			my $org_port = $2;
 			
 			if (defined($org_port)) {
+				$org_fqdn = $1;
 				$text .= "dest_domain=" . $org_fqdn . " port=" . $org_port . " scheme=http action=never-cache\n";
 			} else {
 				$text .= "dest_domain=" . $org_fqdn . " scheme=http action=never-cache\n";

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -1013,7 +1013,15 @@ sub cache_dot_config {
 		if ( $remap->{type} eq "HTTP_NO_CACHE" ) {
 			my $org_fqdn = $remap->{org};
 			$org_fqdn =~ s/https?:\/\///;
-			$text .= "dest_domain=" . $org_fqdn . " scheme=http action=never-cache\n";
+			$org_fqdn =~ m/(.*?):(\d+).*/;
+			my $org_port = $2;
+
+			if (defined($org_port)) {
+				$org_fqdn = $1;
+				$text .= "dest_domain=" . $org_fqdn . " port=" . $org_port . " scheme=http action=never-cache\n";
+			} else { 
+				$text .= "dest_domain=" . $org_fqdn . " scheme=http action=never-cache\n";
+			}
 		}
 	}
 	return $text;


### PR DESCRIPTION
Change how the Origin FQDN is parsed so it will properly split out the origin port if present.'

This should fix #1915 