### PR TITLE
Fixed a SOA sorting issue in Traffic Router

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/RRSetsBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/RRSetsBuilder.java
@@ -52,6 +52,10 @@ public class RRSetsBuilder {
 			return -1;
 		}
 
+		if (rrSet2.getType() == Type.SOA) {
+			return 1;
+		}
+
 		return rrSet1.getType() - rrSet2.getType();
 	};
 


### PR DESCRIPTION
Fixed an issue in Traffic Router where SOA records might not be sorted if they appear last in the input data.