### PR TITLE
TO: allow ssl connection to db to be required

### DIFF
--- a/traffic_ops/app/conf/development/database.conf
+++ b/traffic_ops/app/conf/development/database.conf
@@ -6,5 +6,6 @@
 	"user": "traffic_ops",
 	"password": "twelve",
 	"port": "5432",
+	"ssl": false,
 	"type": "Pg"
 }

--- a/traffic_ops/app/conf/integration/database.conf
+++ b/traffic_ops/app/conf/integration/database.conf
@@ -5,5 +5,6 @@
    "user": "traffic_ops",
    "password": "twelve",
    "port": "5432",
+   "ssl": false,
    "type": "Pg"
 }

--- a/traffic_ops/app/conf/production/database.conf
+++ b/traffic_ops/app/conf/production/database.conf
@@ -6,5 +6,6 @@
 	"user": "traffic_ops",
 	"password": "password",
 	"port": "5432",
+	"ssl": false,
 	"type": "Pg"
 }

--- a/traffic_ops/app/conf/test/database.conf
+++ b/traffic_ops/app/conf/test/database.conf
@@ -5,5 +5,6 @@
    "user": "traffic_ops",
    "password": "twelve",
    "port": "5432",
+   "ssl": false,
    "type": "Pg"
 }

--- a/traffic_ops/app/lib/Schema.pm
+++ b/traffic_ops/app/lib/Schema.pm
@@ -48,7 +48,9 @@ sub get_dsn {
 	our $hostname = $db_info->{hostname};
 	our $port     = $db_info->{port};
 	our $type     = $db_info->{type};
-	our $dsn      = "DBI:$type:database=$dbname;host=$hostname;port=$port";
+	# add `ssl: true` to database.conf to require ssl
+	our $reqssl   = $db_info->{ssl} ? 'require' : 'disable';
+	our $dsn      = "DBI:$type:database=$dbname;host=$hostname;port=$port;sslmode=$reqssl";
 }
 
 sub get_dbinfo {


### PR DESCRIPTION
support was already partially there -- this completes it by adding to the DBI connect string for mojolicious as well as adding the ssl entry in the database.conf.   Enable it by setting to `true`