### PR TITLE
Remove broken, unused, internal steering API POST endpoint

### DIFF
--- a/traffic_ops/app/db/migrations/20180402000000_remove_internal_steering_post.sql
+++ b/traffic_ops/app/db/migrations/20180402000000_remove_internal_steering_post.sql
@@ -1,0 +1,25 @@
+/*
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+DELETE FROM api_capability WHERE http_method = 'POST' and route = '/internal/api/*/steering';
+
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+INSERT INTO api_capability (http_method, route, capability) VALUES ('POST', '/internal/api/*/steering', 'ds-steering-write') ON CONFLICT (http_method, route, capability) DO NOTHING;

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -233,7 +233,6 @@ insert into api_capability (http_method, route, capability) values ('GET', '/api
 insert into api_capability (http_method, route, capability) values ('GET', '/api/*/deliveryservice_matches', 'ds-read') ON CONFLICT (http_method, route, capability) DO NOTHING; -- 92
 insert into api_capability (http_method, route, capability) values ('GET', '/internal/api/*/steering', 'ds-steering-read') ON CONFLICT (http_method, route, capability) DO NOTHING; -- 96
 insert into api_capability (http_method, route, capability) values ('GET', '/internal/api/*/steering/*', 'ds-steering-read') ON CONFLICT (http_method, route, capability) DO NOTHING; -- 97
-insert into api_capability (http_method, route, capability) values ('POST', '/internal/api/*/steering', 'ds-steering-write') ON CONFLICT (http_method, route, capability) DO NOTHING; -- 98
 insert into api_capability (http_method, route, capability) values ('PUT', '/internal/api/*/steering/*', 'ds-steering-write') ON CONFLICT (http_method, route, capability) DO NOTHING; -- 99
 insert into api_capability (http_method, route, capability) values ('GET', '/api/*/steering/*/targets', 'ds-steering-target-read') ON CONFLICT (http_method, route, capability) DO NOTHING; -- 96
 insert into api_capability (http_method, route, capability) values ('GET', '/api/*/steering/*/targets/*', 'ds-steering-target-read') ON CONFLICT (http_method, route, capability) DO NOTHING; -- 96

--- a/traffic_ops/app/lib/API/DeliveryService/Steering.pm
+++ b/traffic_ops/app/lib/API/DeliveryService/Steering.pm
@@ -127,61 +127,6 @@ sub find_steering {
     return $response;
 }
 
-sub add() {
-    my $self = shift;
-
-    if (!&is_admin($self)) {
-        return $self->render(json => {"message" => "unauthorized"}, status => 401);
-    }
-
-    my $steering_xml_id = $self->req->json->{'deliveryService'};
-
-    if (!$steering_xml_id || !$self->req->json->{'targets'}) {
-        return $self->render(json => {"message" => "bad request"}, status => 400);
-    }
-
-    if (!(ref($self->req->json->{'targets'}) eq "ARRAY")) {
-        return $self->render(json => {"message" => "bad request"}, status => 400);
-    }
-
-    my $target_xml_ids = [];
-    foreach my $target (@{$self->req->json->{'targets'}}) {
-        if (!(ref($target) eq "HASH") || !$target->{'deliveryService'}) {
-            return $self->render(json => {"message" => "bad request"}, status => 400);
-        }
-        push(@{$target_xml_ids}, $target->{'deliveryService'});
-    }
-
-    my $ds = $self->get_ds_id($steering_xml_id);
-
-    if (!$ds) {
-        return $self->render(json => {}, status => 409);
-    }
-
-    my $rows = [];
-
-    foreach my $xml_id (@{$target_xml_ids}) {
-        my $target_ds = $self->get_ds_id($xml_id);
-
-        if (!$target_ds) {
-            return $self->render(json => {}, status => 409);
-        }
-
-        push(@{$rows}, [$ds, $target_ds])
-    }
-
-    my $transaction_guard = $self->db->txn_scope_guard;
-
-    for my $row (@{$rows}) {
-        $self->db->resultset('SteeringTarget')->create({deliveryservice => $row->[0], target => $row->[1], weight => 0});
-    }
-
-    $transaction_guard->commit;
-
-    $self->res->headers->header('Location', '/internal/api/1.2/steering/' . $steering_xml_id . ".json");
-    return $self->render(json => {}, status => 201);
-}
-
 sub get_ds_id {
     my $self = shift;
     my $xml_id = shift;

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -533,7 +533,6 @@ sub api_routes {
 	# -- DELIVERYSERVICES: STEERING DELIVERYSERVICES
 	$r->get("/internal/api/$version/steering")->over( authenticated => 1, not_ldap => 1 )->to( 'Steering#index', namespace => 'API::DeliveryService' );
 	$r->get("/internal/api/$version/steering/:xml_id")->over( authenticated => 1, not_ldap => 1 )->to( 'Steering#index', namespace => 'API::DeliveryService' );
-	$r->post("/internal/api/$version/steering")->over( authenticated => 1, not_ldap => 1 )->to( 'Steering#add', namespace => 'API::DeliveryService' );
 	$r->put("/internal/api/$version/steering/:xml_id")->over( authenticated => 1, not_ldap => 1 )->to( 'Steering#update', namespace => 'API::DeliveryService' );
 
 	$r->get("/api/$version/steering/:id/targets" => [ id => qr/\d+/ ] )->over( authenticated => 1, not_ldap => 1 )->to( 'SteeringTarget#index', namespace => 'API::DeliveryService' );


### PR DESCRIPTION
This endpoint is broken and has been for quite some time. Since nobody
has bothered to fix it yet, it's clearly not being used. Further, we
already have a non-internal API endpoint for creating Steering Targets.