### PR TITLE
Add TO Go CDN name routes

### DIFF
--- a/lib/go-tc/alerts.go
+++ b/lib/go-tc/alerts.go
@@ -89,6 +89,10 @@ func HandleErrorsWithType(errs []error, errType ApiErrorType, handleErrs func(st
 	}
 }
 
+func HandleErrWithType(err error, errType ApiErrorType, handleErrs func(status int, errs ...error)) {
+	HandleErrorsWithType([]error{err}, errType, handleErrs)
+}
+
 func (alerts *Alerts) ToStrings() []string {
 	alertStrs := []string{}
 	for _, alrt := range alerts.Alerts {

--- a/traffic_ops/traffic_ops_golang/api/change_log.go
+++ b/traffic_ops/traffic_ops_golang/api/change_log.go
@@ -26,8 +26,6 @@ import (
 	"github.com/apache/incubator-trafficcontrol/lib/go-log"
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
 	"github.com/apache/incubator-trafficcontrol/traffic_ops/traffic_ops_golang/auth"
-
-	"github.com/jmoiron/sqlx"
 )
 
 type ChangeLog struct {
@@ -50,7 +48,7 @@ const (
 	Deleted   = "Deleted"
 )
 
-func CreateChangeLog(level string, action string, i Identifier, user auth.CurrentUser, db *sqlx.DB) error {
+func CreateChangeLog(level string, action string, i Identifier, user auth.CurrentUser, db *sql.DB) error {
 	t, ok := i.(ChangeLogger)
 	if !ok {
 		keys, _ := i.GetKeys()
@@ -65,7 +63,7 @@ func CreateChangeLog(level string, action string, i Identifier, user auth.Curren
 	return CreateChangeLogMsg(level, user, db, msg)
 }
 
-func CreateChangeLogBuildMsg(level string, action string, user auth.CurrentUser, db *sqlx.DB, objType string, auditName string, keys map[string]interface{}) error {
+func CreateChangeLogBuildMsg(level string, action string, user auth.CurrentUser, db *sql.DB, objType string, auditName string, keys map[string]interface{}) error {
 	keyStr := "{ "
 	for key, value := range keys {
 		keyStr += key + ":" + fmt.Sprintf("%v", value) + " "
@@ -75,7 +73,7 @@ func CreateChangeLogBuildMsg(level string, action string, user auth.CurrentUser,
 	return CreateChangeLogMsg(level, user, db, msg)
 }
 
-func CreateChangeLogMsg(level string, user auth.CurrentUser, db *sqlx.DB, msg string) error {
+func CreateChangeLogMsg(level string, user auth.CurrentUser, db *sql.DB, msg string) error {
 	query := `INSERT INTO log (level, message, tm_user) VALUES ($1, $2, $3)`
 	log.Debugf("about to exec %s with %s", query, msg)
 	if _, err := db.Exec(query, level, msg, user.ID); err != nil {

--- a/traffic_ops/traffic_ops_golang/api/change_log_test.go
+++ b/traffic_ops/traffic_ops_golang/api/change_log_test.go
@@ -64,7 +64,7 @@ func TestCreateChangeLog(t *testing.T) {
 
 	mock.ExpectExec("INSERT").WithArgs(ApiChange, expectedMessage, 1).WillReturnResult(sqlmock.NewResult(1, 1))
 	user := auth.CurrentUser{ID: 1}
-	err = CreateChangeLog(ApiChange, Created, &i, user, db)
+	err = CreateChangeLog(ApiChange, Created, &i, user, db.DB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -247,7 +247,7 @@ func UpdateHandler(typeRef Updater, db *sqlx.DB) http.HandlerFunc {
 			return
 		}
 		//auditing here
-		CreateChangeLog(ApiChange, Updated, u, *user, db)
+		CreateChangeLog(ApiChange, Updated, u, *user, db.DB)
 		//form response to send across the wire
 		resp := struct {
 			Response interface{} `json:"response"`
@@ -332,7 +332,7 @@ func DeleteHandler(typeRef Deleter, db *sqlx.DB) http.HandlerFunc {
 		}
 		//audit here
 		log.Debugf("changelog for delete on object")
-		CreateChangeLog(ApiChange, Deleted, d, *user, db)
+		CreateChangeLog(ApiChange, Deleted, d, *user, db.DB)
 		//
 		resp := struct {
 			tc.Alerts
@@ -398,7 +398,7 @@ func CreateHandler(typeRef Creator, db *sqlx.DB) http.HandlerFunc {
 			return
 		}
 
-		CreateChangeLog(ApiChange, Created, i, *user, db)
+		CreateChangeLog(ApiChange, Created, i, *user, db.DB)
 
 		resp := struct {
 			Response interface{} `json:"response"`

--- a/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
@@ -562,7 +562,7 @@ func Delete(dbx *sqlx.DB) http.HandlerFunc {
 		}
 
 		log.Debugf("changelog for delete on object")
-		api.CreateChangeLogMsg(api.ApiChange, *user, dbx, fmt.Sprintf(`deleted deliveryservice_regex {"ds": %d, "regex": %d}`, dsID, regexID))
+		api.CreateChangeLogMsg(api.ApiChange, *user, db, fmt.Sprintf(`deleted deliveryservice_regex {"ds": %d, "regex": %d}`, dsID, regexID))
 		resp := struct {
 			tc.Alerts
 		}{tc.CreateAlerts(tc.SuccessLevel, "deliveryservice_regex was deleted.")}

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -106,6 +106,8 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{1.1, http.MethodPut, `cdns/{id}$`, api.UpdateHandler(cdn.GetRefType(), d.DB), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodPost, `cdns/?$`, api.CreateHandler(cdn.GetRefType(), d.DB), auth.PrivLevelOperations, Authenticated, nil},
 		{1.1, http.MethodDelete, `cdns/{id}$`, api.DeleteHandler(cdn.GetRefType(), d.DB), auth.PrivLevelOperations, Authenticated, nil},
+		{1.1, http.MethodGet, `cdns/name/{name}$`, api.ReadHandler(cdn.GetRefType(), d.DB), auth.PrivLevelReadOnly, Authenticated, nil},
+		{1.1, http.MethodDelete, `cdns/name/{name}$`, cdn.DeleteNameHandler(d.DB.DB), auth.PrivLevelOperations, Authenticated, nil},
 
 		//CDN: Monitoring: Traffic Monitor
 		{1.1, http.MethodGet, `cdns/{name}/configs/monitoring(\.json)?$`, monitoringHandler(d.DB), auth.PrivLevelReadOnly, Authenticated, nil},


### PR DESCRIPTION
Adds GET and DELETE cdns/name, moves all CDN routes to 1.2 (which
implicitly serve 1.3+), and removes the Perl routes.