### PR TITLE
TO go: `go get` prior to running unit tests for the golang.org/x dependencies

### DIFF
--- a/traffic_ops/app/bin/tests/Dockerfile-golangtest
+++ b/traffic_ops/app/bin/tests/Dockerfile-golangtest
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.10
+FROM golang:1.8
 MAINTAINER Dan Kirkwood <dangogh@apache.org>
 ARG DIR=github.com/apache/incubator-trafficcontrol
 
@@ -20,6 +20,6 @@ ADD lib /go/src/$DIR/lib
 
 WORKDIR /go/src/$DIR/traffic_ops/traffic_ops_golang
 
-CMD bash -c 'go get -v && go test -cover -v $(go list ./...)'
+CMD bash -c 'go get -v && go test -cover -v $(go list ./...)' ../../lib/go-*
 #
 # vi:syntax=Dockerfile

--- a/traffic_ops/app/bin/tests/Dockerfile-golangtest
+++ b/traffic_ops/app/bin/tests/Dockerfile-golangtest
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.8
+FROM golang:1.10
 MAINTAINER Dan Kirkwood <dangogh@apache.org>
 ARG DIR=github.com/apache/incubator-trafficcontrol
 
@@ -20,6 +20,6 @@ ADD lib /go/src/$DIR/lib
 
 WORKDIR /go/src/$DIR/traffic_ops/traffic_ops_golang
 
-CMD bash -c 'go test -v $(go list ./... | grep -v /vendor/)'
+CMD bash -c 'go get -v && go test -cover -v $(go list ./...)'
 #
 # vi:syntax=Dockerfile

--- a/traffic_ops/app/bin/tests/Dockerfile-golangtest
+++ b/traffic_ops/app/bin/tests/Dockerfile-golangtest
@@ -20,6 +20,6 @@ ADD lib /go/src/$DIR/lib
 
 WORKDIR /go/src/$DIR/traffic_ops/traffic_ops_golang
 
-CMD bash -c 'go get -v && go test -cover -v $(go list ./...)' ../../lib/go-*
+CMD bash -c 'go get -v && go test -cover -v $(go list ./...) ../../lib/go-*'
 #
 # vi:syntax=Dockerfile


### PR DESCRIPTION
unit tests in jenkins started failing when `golang.org/x` dependencies were removed from the vendor dir.   This gets those dependencies in the docker container prior to running the tests.