### PR TITLE
Fix org_server_fqdn trailing slash issue

### DIFF
--- a/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
+++ b/traffic_ops/app/lib/API/Configs/ApacheTrafficServer.pm
@@ -2237,9 +2237,8 @@ sub cachegroup_profiles {
 		if ( $row->type->name eq 'ORG' ) {
 			my $rs_ds = $self->db->resultset('DeliveryserviceServer')->search( { server => $row->id }, { prefetch => ['deliveryservice'] } );
 			while ( my $ds_row = $rs_ds->next ) {
-				my $ds_domain = $ds_row->deliveryservice->org_server_fqdn;
-				$ds_domain =~ s/https?:\/\/(.*)/$1/;
-				push( @{ $deliveryservices->{$ds_domain} }, $row );
+				my $org_uri = URI->new( $ds_row->deliveryservice->org_server_fqdn );
+				push( @{ $deliveryservices->{ $org_uri->host } }, $row );
 			}
 		}
 		else {
@@ -2405,7 +2404,7 @@ sub parent_dot_config { #fix qstring - should be ignore for quika
 					@ranked_parents = sort by_parent_rank @{ $parent_info->{ $org_uri->host } };
 				}
 				else {
-					$self->app->log->debug( "BUG: Did not match an origin: " . $org_uri );
+					$self->app->log->warn( "BUG: Did not match a multi-site origin: " . $org_uri );
 				}
 
 				my @parent_info;

--- a/traffic_ops/app/lib/API/Deliveryservice.pm
+++ b/traffic_ops/app/lib/API/Deliveryservice.pm
@@ -1582,6 +1582,16 @@ sub is_valid_org_server_fqdn {
 		return "invalid. Must start with http:// or https://.";
 	}
 
+	$value =~ s{^https?://}{};
+	$value =~ s/:(.*)$//;
+	my $port = defined($1) ? $1 : 80;
+	if ( !&is_hostname($value) ) {
+		return "invalid. '" . $value . "' is not a valid org server hostname (rfc1123)";
+	}
+	if ( $port !~ /\d*/ || $port < 1 || 65535 < $port ) {
+		return "invalid. " . $port . " is not a valid port number";
+	}
+
 	return undef;
 }
 

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -148,9 +148,9 @@ under the License.
                     <span uib-popover-html="label('orgServerFqdn', 'desc')" popover-trigger="mouseenter" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">* {{label('orgServerFqdn', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="orgServerFqdn" type="text" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" ng-pattern="/^(https?:\/\/)/" required autofocus>
+                    <input name="orgServerFqdn" type="text" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" ng-pattern="/^(https?:\/\/)([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d{1,5})?$/" required autofocus>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'required')">Required</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'pattern')">Must start with http:// or https://</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'pattern')">Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.orgServerFqdn != dsCurrent.orgServerFqdn">Current Value: [ {{dsCurrent.orgServerFqdn}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.orgServerFqdn)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -148,9 +148,9 @@ under the License.
                     <span uib-popover-html="label('orgServerFqdn', 'desc')" popover-trigger="mouseenter" popover-placement="top" popover-append-to-body="true" popover-class="popover-class">* {{label('orgServerFqdn', 'title')}}</span>
                 </label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="orgServerFqdn" type="text" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" ng-pattern="/^(https?:\/\/)/" required autofocus>
+                    <input name="orgServerFqdn" type="text" class="form-control" placeholder="http(s)//:" ng-model="deliveryService.orgServerFqdn" ng-pattern="/^(https?:\/\/)([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d{1,5})?$/" required autofocus>
                     <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'required')">Required</small>
-                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'pattern')">Must start with http:// or https://</small>
+                    <small class="input-error" ng-show="hasPropertyError(deliveryServiceForm.orgServerFqdn, 'pattern')">Must start with http:// or https:// and be followed by a valid hostname with an optional port (no trailing slash)</small>
                     <small class="input-diff" ng-show="settings.isRequest && open() && deliveryService.orgServerFqdn != dsCurrent.orgServerFqdn">Current Value: [ {{dsCurrent.orgServerFqdn}} ]</small>
                     <span ng-show="hasError(deliveryServiceForm.orgServerFqdn)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>


### PR DESCRIPTION
Make the API validation match the form validation of the old TO UI.
Make TP validation match the API validation.
Fix issue with existing org_server_fqdns with trailing slashes causing
an invalid parent.config generation for MSO.

Fixes #2062.