### PR TITLE
better grouping for TP menu

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -54,7 +54,7 @@ under the License.
                     <li class="divider"></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
-                    <li role="menuitem"><a ng-click="viewJobs()">View Invalidate Content Jobs</a></li>
+                    <li role="menuitem"><a ng-click="viewJobs()">View Invalidation Requests</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -54,7 +54,7 @@ under the License.
                     <li class="divider"></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
-                    <li role="menuitem"><a ng-click="viewJobs()">View Invalidate Content Jobs</a></li>
+                    <li role="menuitem"><a ng-click="viewJobs()">View Invalidation Requests</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -52,7 +52,7 @@ under the License.
                     <li class="divider"></li>
                     <li role="menuitem"><a ng-click="viewTargets()">View Targets</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
-                    <li role="menuitem"><a ng-click="viewJobs()">View Invalidate Content Jobs</a></li>
+                    <li role="menuitem"><a ng-click="viewJobs()">View Invalidation Requests</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -50,7 +50,7 @@ under the License.
                     <li class="divider"></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li role="menuitem"><a ng-click="viewRegexes()">View Regexes</a></li>
-                    <li role="menuitem"><a ng-click="viewJobs()">View Invalidate Content Jobs</a></li>
+                    <li role="menuitem"><a ng-click="viewJobs()">View Invalidation Requests</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceJob/form.deliveryServiceJob.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceJob/form.deliveryServiceJob.tpl.html
@@ -22,7 +22,7 @@ under the License.
         <ol class="breadcrumb pull-left">
             <li><a ng-click="navigateToPath('/delivery-services')">Delivery Services</a></li>
             <li><a ng-click="navigateToPath('/delivery-services/' + deliveryService.id + '?type=' + deliveryService.type)">{{deliveryService.xmlId}}</a></li>
-            <li><a ng-click="navigateToPath('/delivery-services/' + deliveryService.id + '/jobs')">Invalidate Content Jobs</a></li>
+            <li><a ng-click="navigateToPath('/delivery-services/' + deliveryService.id + '/jobs')">Invalidation Requests</a></li>
             <li class="active">{{jobName}}</li>
         </ol>
         <div class="clearfix"></div>
@@ -43,7 +43,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttl), 'has-feedback': hasError(jobForm.ttl)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">TTL (hours) *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="ttl" type="number" class="form-control" placeholder="Number of hours until the invalidate content job expires" ng-model="job.ttl" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
+                    <input name="ttl" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttl" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'required')">Required Whole Number</small>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'maxlength')">Too Long</small>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'pattern')">Whole Number</small>

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceJob/new/FormNewDeliveryServiceJobController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceJob/new/FormNewDeliveryServiceJobController.js
@@ -33,7 +33,7 @@ var FormNewDeliveryServiceJobController = function(deliveryService, job, $scope,
 		jobService.createJob(job)
 			.then(
 				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Delivery Service Invalidate Content Job Created' } ], true);
+					messageModel.setMessages([ { level: 'success', text: 'Delivery Service Invalidation Request Created' } ], true);
 					locationUtils.navigateToPath('/delivery-services/' + deliveryService.id + '/jobs');
 				},
 				function(fault) {

--- a/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
@@ -20,7 +20,7 @@ under the License.
 <div class="x_panel">
     <div class="x_title">
         <ol class="breadcrumb">
-            <li><a ng-click="navigateToPath('/jobs')">Invalidate Content Jobs</a></li>
+            <li><a ng-click="navigateToPath('/jobs')">Invalidation Requests</a></li>
             <li class="active">{{jobName}}</li>
         </ol>
         <div class="clearfix"></div>
@@ -50,7 +50,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttl), 'has-feedback': hasError(jobForm.ttl)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">TTL (hours) *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="ttl" type="number" class="form-control" placeholder="Number of hours until the invalidate content job expires" ng-model="job.ttl" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
+                    <input name="ttl" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttl" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'required')">Required Whole Number</small>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'maxlength')">Too Long</small>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'pattern')">Whole Number</small>

--- a/traffic_portal/app/src/common/modules/form/job/new/FormNewJobController.js
+++ b/traffic_portal/app/src/common/modules/form/job/new/FormNewJobController.js
@@ -33,7 +33,7 @@ var FormNewJobController = function(job, $scope, $controller, jobService, messag
 		jobService.createJob(job)
 			.then(
 				function() {
-					messageModel.setMessages([ { level: 'success', text: 'Invalidate Content Job Created' } ], true);
+					messageModel.setMessages([ { level: 'success', text: 'Invalidation Request Created' } ], true);
 					locationUtils.navigateToPath('/jobs');
 				},
 				function(fault) {

--- a/traffic_portal/app/src/common/modules/navigation/navigation.tpl.html
+++ b/traffic_portal/app/src/common/modules/navigation/navigation.tpl.html
@@ -25,9 +25,10 @@ under the License.
     <div id="sidebar-menu" class="main_menu_side hidden-print main_menu">
         <div class="menu_section">
             <ul class="nav side-menu">
+                <li class="side-menu-category" ng-class="{'current-page': isState('trafficPortal.private.dashboard')}"><a href="/#!/dashboard"><i class="fa fa-sm fa-bar-chart"></i> Dashboard</a></li>
+                <li class="side-menu-category" ng-class="{'current-page': isState('trafficPortal.private.cdns')}"><a href="/#!/cdns"><i class="fa fa-sm fa-sitemap"></i> CDNs</a></li>
                 <li class="side-menu-category"><a href="javascript:void(0);"><i class="fa fa-sm fa-chevron-right"></i> Monitor</span></a>
                     <ul class="nav child_menu" style="display: none">
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.dashboard')}"><a href="/#!/dashboard">Dashboard</a></li>
                         <li class="side-menu-category-item" ng-if="::showCacheChecks" ng-class="{'current-page': isState('trafficPortal.private.cacheChecks')}"><a href="/#!/cache-checks">Cache Checks</a></li>
                         <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.cacheStats')}"><a href="/#!/cache-stats">Cache Stats</a></li>
                     </ul>
@@ -38,29 +39,36 @@ under the License.
                         <li class="side-menu-category-item" ng-if="::dsRequestsEnabled" ng-class="{'current-page': isState('trafficPortal.private.deliveryServiceRequests')}"><a href="/#!/delivery-service-requests">Delivery Service Requests</a></li>
                     </ul>
                 </li>
-                <li class="side-menu-category"><a href="javascript:void(0);"><i class="fa fa-sm fa-chevron-right"></i> Admin</span></a>
+                <li class="side-menu-category"><a href="javascript:void(0);"><i class="fa fa-sm fa-chevron-right"></i> Configure</span></a>
                     <ul class="nav child_menu" style="display: none">
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.asns')}"><a href="/#!/asns">ASNs</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.cacheGroups')}"><a href="/#!/cache-groups">Cache Groups</a></li>
-                        <!--<li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.capabilities')}"><a href="/#!/capabilities">Capabilities</a></li>-->
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.cdns')}"><a href="/#!/cdns">CDNs</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.divisions')}"><a href="/#!/divisions">Divisions</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.jobs')}"><a href="/#!/jobs">Jobs</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.physLocations')}"><a href="/#!/phys-locations">Phys Locations</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.parameters')}"><a href="/#!/parameters">Parameters</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.profiles')}"><a href="/#!/profiles">Profiles</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.regions')}"><a href="/#!/regions">Regions</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.roles')}"><a href="/#!/roles">Roles</a></li>
                         <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.servers')}"><a href="/#!/servers">Servers</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.statuses')}"><a href="/#!/statuses">Statuses</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.tenants')}"><a href="/#!/tenants">Tenants</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.profiles')}"><a href="/#!/profiles">Profiles</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.parameters')}"><a href="/#!/parameters">Parameters</a></li>
                         <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.types')}"><a href="/#!/types">Types</a></li>
-                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.users')}"><a href="/#!/users">Users</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.statuses')}"><a href="/#!/statuses">Statuses</a></li>
+                    </ul>
+                </li>
+                <li class="side-menu-category"><a href="javascript:void(0);"><i class="fa fa-sm fa-chevron-right"></i> Topology</span></a>
+                    <ul class="nav child_menu" style="display: none">
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.cacheGroups')}"><a href="/#!/cache-groups">Cache Groups</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.physLocations')}"><a href="/#!/phys-locations">Phys Locations</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.divisions')}"><a href="/#!/divisions">Divisions</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.regions')}"><a href="/#!/regions">Regions</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.asns')}"><a href="/#!/asns">ASNs</a></li>
                     </ul>
                 </li>
                 <li class="side-menu-category"><a href="javascript:void(0);"><i class="fa fa-sm fa-chevron-right"></i> Tools</span></a>
                     <ul class="nav child_menu" style="display: none">
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.jobs')}"><a href="/#!/jobs">Invalidate Content</a></li>
                         <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.iso')}"><a href="/#!/iso">Generate ISO</a></li>
+                    </ul>
+                </li>
+                <li class="side-menu-category"><a href="javascript:void(0);"><i class="fa fa-sm fa-chevron-right"></i> User Admin</span></a>
+                    <ul class="nav child_menu" style="display: none">
+                        <!--<li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.capabilities')}"><a href="/#!/capabilities">Capabilities</a></li>-->
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.users')}"><a href="/#!/users">Users</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.tenants')}"><a href="/#!/tenants">Tenants</a></li>
+                        <li class="side-menu-category-item" ng-class="{'current-page': isState('trafficPortal.private.roles')}"><a href="/#!/roles">Roles</a></li>
                     </ul>
                 </li>
                 <li class="side-menu-category" ng-if="customMenu.items.length > 0"><a href="javascript:void(0);"><i class="fa fa-sm fa-chevron-right"></i> {{::customMenu.name}}</span></a>

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceJobs/table.deliveryServiceJobs.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceJobs/table.deliveryServiceJobs.tpl.html
@@ -22,10 +22,10 @@ under the License.
         <ol class="breadcrumb pull-left">
             <li><a ng-click="navigateToPath('/delivery-services')">Delivery Services</a></li>
             <li><a ng-click="navigateToPath('/delivery-services/' + deliveryService.id + '?type=' + deliveryService.type)">{{::deliveryService.xmlId}}</a></li>
-            <li class="active">Invalidate Content Jobs</li>
+            <li class="active">Invalidation Requests</li>
         </ol>
         <div class="pull-right">
-            <button class="btn btn-primary" title="Create Invalidate Content Job" ng-click="createJob(deliveryService.id)"><i class="fa fa-plus"></i></button>
+            <button class="btn btn-primary" title="Create Invalidation Request" ng-click="createJob(deliveryService.id)"><i class="fa fa-plus"></i></button>
             <button class="btn btn-default" title="Refresh" ng-click="refresh()"><i class="fa fa-refresh"></i></button>
         </div>
         <div class="clearfix"></div>

--- a/traffic_portal/app/src/common/modules/table/jobs/table.jobs.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/jobs/table.jobs.tpl.html
@@ -20,10 +20,10 @@ under the License.
 <div class="x_panel">
     <div class="x_title">
         <ol class="breadcrumb pull-left">
-            <li class="active">Invalidate Content Jobs</li>
+            <li class="active">Invalidation Requests</li>
         </ol>
         <div class="pull-right" role="group" ng-show="!settings.isNew">
-            <button class="btn btn-primary" title="Create Invalidate Content Job" ng-click="createJob()"><i class="fa fa-plus"></i></button>
+            <button class="btn btn-primary" title="Create Invalidation Request" ng-click="createJob()"><i class="fa fa-plus"></i></button>
             <button class="btn btn-default" title="Refresh" ng-click="refresh()"><i class="fa fa-refresh"></i></button>
         </div>
         <div class="clearfix"></div>


### PR DESCRIPTION
Reorganized the TP menu a bit to group logical items. This will help when capabilities are integrated into the menu.

![image](https://user-images.githubusercontent.com/251272/38742469-db4f9338-3ef9-11e8-9853-63deec330d92.png)

Grouping is as such:

Dashboard
CDNs

Configure
- Parameters
- Profiles
- Statuses
- Types

Monitor
- Cache Checks
- Cache Stats

Services
- Delivery Services
- Delivery Service Requests
- Invalidation Requests

Tools
- Generate ISO

Topology
- ASNs
- Cache Groups
- Divisions
- Phys Locations
- Regions
- Servers

User Admin
- Capabilities <-- not visible yet
- Roles
- Tenants
- Users