### PR TITLE
Properly unmarshal null DeepCachingType value as "NEVER"

### DIFF
--- a/lib/go-tc/enum.go
+++ b/lib/go-tc/enum.go
@@ -224,6 +224,10 @@ func DeepCachingTypeFromString(s string) DeepCachingType {
 
 // UnmarshalJSON unmarshals a JSON representation of a DeepCachingType (i.e. a string) or returns an error if the DeepCachingType is invalid
 func (t *DeepCachingType) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*t = DeepCachingTypeNever
+		return nil
+	}
 	s, err := strconv.Unquote(string(data))
 	if err != nil {
 		return errors.New(string(data) + " JSON not quoted")

--- a/lib/go-tc/enum_test.go
+++ b/lib/go-tc/enum_test.go
@@ -63,13 +63,23 @@ func TestDeepCachingType(t *testing.T) {
 
 	// make sure we get the right default when marshalled within a new delivery service
 	var ds DeliveryService
-	txt, err := json.MarshalIndent(ds, ``, `  `)
+	_, err := json.MarshalIndent(ds, ``, `  `)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	t.Log(string(txt))
 	c = ds.DeepCachingType.String()
 	if c != "NEVER" {
 		t.Errorf(`Default "%s" expected to be "NEVER"`, c)
+	}
+
+	// make sure null values are handled properly
+	byt := []byte(`{"deepCachingType": null}`)
+	err = json.Unmarshal(byt, &ds)
+	if err != nil {
+		t.Errorf(`Expected to be able to unmarshall a null deepCachingType as "NEVER", instead got error "%v"`, err.Error())
+	}
+	c = ds.DeepCachingType.String()
+	if c != "NEVER" {
+		t.Errorf(`null deepCachingType expected to be "NEVER", got "%s"`, c)
 	}
 }


### PR DESCRIPTION
If the client received DeliveryService JSON that contained a `null` value in `deepCachingType`, it was unable to unmarshal the value properly. In this case, `null` should be unmarshalled as the default `"NEVER"`.