### PR TITLE
[Issue 2096] Fix TR issue with capital letters in CDN domain. fixes #2096

### DIFF
--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -136,6 +136,8 @@ func (cdn *TOCDN) Create(db *sqlx.DB, user auth.CurrentUser) (error, tc.ApiError
 		log.Error.Printf("could not begin transaction: %v", err)
 		return tc.DBError, tc.SystemError
 	}
+	// make sure that cdn.DomainName is lowercase
+	*cdn.DomainName = strings.ToLower(*cdn.DomainName)
 	resultRows, err := tx.NamedQuery(insertQuery(), cdn)
 	if err != nil {
 		if pqErr, ok := err.(*pq.Error); ok {
@@ -243,6 +245,8 @@ func (cdn *TOCDN) Update(db *sqlx.DB, user auth.CurrentUser) (error, tc.ApiError
 		return tc.DBError, tc.SystemError
 	}
 	log.Debugf("about to run exec query: %s with cdn: %++v", updateQuery(), cdn)
+	// make sure that cdn.DomainName is lowercase
+	*cdn.DomainName = strings.ToLower(*cdn.DomainName)
 	resultRows, err := tx.NamedQuery(updateQuery(), cdn)
 	if err != nil {
 		if pqErr, ok := err.(*pq.Error); ok {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
@@ -353,12 +353,14 @@ public class ConfigHandler {
 							if (dso != null && dso.size() > 0) {
 								int i = 0;
 								for (final JsonNode nameNode : dso) {
-									final String name = nameNode.asText().toLowerCase();
+									//final String name = nameNode.asText().toLowerCase();
+									final String name = nameNode.asText();
 									if (i == 0) {
 										references.add(new DeliveryServiceReference(ds, name));
 									}
 
-									final String tld = JsonUtils.optString(cacheRegister.getConfig(), "domain_name").toLowerCase();
+									//final String tld = JsonUtils.optString(cacheRegister.getConfig(), "domain_name").toLowerCase();
+									final String tld = JsonUtils.optString(cacheRegister.getConfig(), "domain_name");
 
 									if (name.endsWith(tld)) {
 										final String reName = name.replaceAll("^.*?\\.", "");

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
@@ -353,13 +353,11 @@ public class ConfigHandler {
 							if (dso != null && dso.size() > 0) {
 								int i = 0;
 								for (final JsonNode nameNode : dso) {
-									//final String name = nameNode.asText().toLowerCase();
 									final String name = nameNode.asText();
 									if (i == 0) {
 										references.add(new DeliveryServiceReference(ds, name));
 									}
 
-									//final String tld = JsonUtils.optString(cacheRegister.getConfig(), "domain_name").toLowerCase();
 									final String tld = JsonUtils.optString(cacheRegister.getConfig(), "domain_name");
 
 									if (name.endsWith(tld)) {


### PR DESCRIPTION
[Issue 2096] Fix TR creates two files in /opt/traffic_router/var/auto-zones for each DS when CDN domain contains capitals

Removed .toLowerCase() of domain name in ConfigHandler when creating DeliveryServiceReferences for a cache - instead, treat the domain as it is in CRConfig.

Change golang API to make CDN domain name lowercase on INSERT and UPDATE.