### PR TITLE
revert changes that broke perl unit tests

### DIFF
--- a/traffic_ops/app/lib/API/Topology.pm
+++ b/traffic_ops/app/lib/API/Topology.pm
@@ -1,0 +1,103 @@
+package API::Topology;
+#
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+##
+##
+#
+## JvD Note: you always want to put Utils as the first use. Sh*t don't work if it's after the Mojo lines.
+#
+
+
+use Mojo::Base 'Mojolicious::Controller';
+use JSON;
+use MojoPlugins::Response;
+use UI::Utils;
+use UI::Topology;
+use Data::Dumper;
+
+sub SnapshotCRConfig {
+    my $self = shift;
+    my $cdn_id = $self->param('id');
+    my $cdn_name = $self->param('cdn_name');
+    my $cdn;
+
+    if ( !&is_oper($self) ) {
+        return $self->forbidden("You must be an ADMIN or OPER to perform this operation!");
+    }
+
+    if ( defined $cdn_id ) {
+        $cdn = $self->db->resultset("Cdn")->find( { id => $cdn_id } );
+        $cdn_name = $cdn->name if defined $cdn;
+    }
+
+    if ( !defined $cdn ) {
+        $cdn = $self->db->resultset('Cdn')->find( { name => $cdn_name } );
+        if ( !defined($cdn) ) {
+            return $self->not_found();
+        }
+    }
+
+    my @cdn_names = $self->db->resultset('Server')->search({ 'type.name' => 'EDGE' }, { prefetch => [ 'cdn', 'type' ], group_by => 'cdn.name' } )->get_column('cdn.name')->all();
+    my $num = grep /^$cdn_name$/, @cdn_names;
+    if ($num <= 0) {
+        return $self->alert("CDN_name [" . $cdn_name. "] is not found in edge server cdn");
+    }
+
+    my $json = &UI::Topology::gen_crconfig_json($self, $cdn_name);
+    &UI::Topology::write_crconfig_json_to_db($self, $cdn_name, $json);
+    &UI::Utils::log($self, "Snapshot of CRConfig performed for $cdn_name", "APICHANGE");
+    return $self->success("SUCCESS");
+}
+
+sub get_snapshot {
+    my $self        = shift;
+    my $cdn_name    = $self->param('name');
+
+    if ( !&is_oper($self) ) {
+        return $self->forbidden();
+    }
+
+    my $cdn = $self->db->resultset('Cdn')->find( { name => $cdn_name } );
+    if ( !defined($cdn) ) {
+        return $self->not_found();
+    }
+
+    my $snapshot = $self->db->resultset('Snapshot')->search( { cdn => $cdn_name } )->get_column('content')->single();
+    if ( !defined($snapshot) ) {
+        return $self->success( {} );
+    }
+
+    $self->success( decode_json($snapshot) );
+}
+
+sub get_new_snapshot {
+    my $self        = shift;
+    my $cdn_name    = $self->param('name');
+
+    if ( !&is_oper($self) ) {
+        return $self->forbidden();
+    }
+
+    my $cdn = $self->db->resultset('Cdn')->find( { name => $cdn_name } );
+    if ( !defined($cdn) ) {
+        return $self->not_found();
+    }
+
+    my $json = &UI::Topology::gen_crconfig_json($self, $cdn_name);
+
+    $self->success( $json );
+}
+
+1;

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -338,8 +338,7 @@ sub ui_routes {
 	$r->get('/tools/queue_updates')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#queue_updates', namespace => $namespace );
 	$r->get('/tools/snapshot_crconfig')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#snapshot_crconfig', namespace => $namespace );
 	$r->get('/tools/diff_crconfig/:cdn_name')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#diff_crconfig_iframe', namespace => $namespace );
-	# flash_and_close is a helper for the traffic_ops_golang migration, to allow Go handlers to intercept GUI routes, do their work, then redirect to this to perform the GUI operation
-	$r->get('/tools/flash_and_close/:msg')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#flash_and_close', namespace => $namespace );
+	$r->get('/tools/write_crconfig/:cdn_name')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#write_crconfig', namespace => $namespace );
 	$r->get('/tools/invalidate_content/')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#invalidate_content', namespace => $namespace );
 
 	# -- Topology - CCR Config, rewrote in json
@@ -448,6 +447,13 @@ sub api_routes {
 
 	# -- CDNS: ROUTING
 	$r->get("/api/$version/cdns/routing")->over( authenticated => 1, not_ldap => 1 )->to( 'Cdn#routing', namespace => $namespace );
+
+	# -- CDNS: SNAPSHOT
+	$r->get("/api/$version/cdns/:name/snapshot")->over( authenticated => 1, not_ldap => 1 )->to( 'Topology#get_snapshot', namespace => $namespace );
+	$r->get("/api/$version/cdns/:name/snapshot/new")->over( authenticated => 1, not_ldap => 1 )->to( 'Topology#get_new_snapshot', namespace => $namespace );
+	$r->put( "/api/$version/cdns/:id/snapshot" => [ id => qr/\d+/ ] )->over( authenticated => 1, not_ldap => 1 )
+	->to( 'Topology#SnapshotCRConfig', namespace => $namespace );
+	$r->put("/api/$version/snapshot/:cdn_name")->over( authenticated => 1, not_ldap => 1 )->to( 'Topology#SnapshotCRConfig', namespace => $namespace );
 
 	# -- CDNS: METRICS
 	#WARNING: this is an intentionally "unauthenticated" route.

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -338,7 +338,8 @@ sub ui_routes {
 	$r->get('/tools/queue_updates')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#queue_updates', namespace => $namespace );
 	$r->get('/tools/snapshot_crconfig')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#snapshot_crconfig', namespace => $namespace );
 	$r->get('/tools/diff_crconfig/:cdn_name')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#diff_crconfig_iframe', namespace => $namespace );
-	$r->get('/tools/write_crconfig/:cdn_name')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#write_crconfig', namespace => $namespace );
+	# flash_and_close is a helper for the traffic_ops_golang migration, to allow Go handlers to intercept GUI routes, do their work, then redirect to this to perform the GUI operation
+	$r->get('/tools/flash_and_close/:msg')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#flash_and_close', namespace => $namespace );
 	$r->get('/tools/invalidate_content/')->over( authenticated => 1, not_ldap => 1 )->to( 'Tools#invalidate_content', namespace => $namespace );
 
 	# -- Topology - CCR Config, rewrote in json

--- a/traffic_ops/app/lib/UI/Tools.pm
+++ b/traffic_ops/app/lib/UI/Tools.pm
@@ -105,23 +105,11 @@ sub diff_crconfig_iframe {
     );
 }
 
-sub write_crconfig {
-    my $self     = shift;
-    my $cdn_name = $self->param('cdn_name');
-    my ( $json, $error ) = UI::Topology::gen_crconfig_json( $self, $cdn_name );
-    if ( defined $error ) {
-        $self->flash( alertmsg => $error );
-    }
-    else {
-        if ( !&is_oper($self) ) {
-            $self->flash( alertmsg => "No can do. Get more privs." );
-        } else {
-            UI::Topology::write_crconfig_json_to_db( $self, $cdn_name, $json );
-            &log( $self, "Snapshot CRConfig created.", "OPER" );
-            $self->flash( alertmsg => "Successfully wrote CRConfig.json!" );
-        }
-    }
-    return $self->redirect_to('/utils/close_fancybox');
+sub flash_and_close {
+    my $self = shift;
+		my $msg = $self->param('msg');
+		$self->flash( alertmsg => $msg );
+		return $self->redirect_to('/utils/close_fancybox');
 }
 
 sub queue_updates {

--- a/traffic_ops/app/lib/UI/Tools.pm
+++ b/traffic_ops/app/lib/UI/Tools.pm
@@ -105,11 +105,23 @@ sub diff_crconfig_iframe {
     );
 }
 
-sub flash_and_close {
-    my $self = shift;
-		my $msg = $self->param('msg');
-		$self->flash( alertmsg => $msg );
-		return $self->redirect_to('/utils/close_fancybox');
+sub write_crconfig {
+    my $self     = shift;
+    my $cdn_name = $self->param('cdn_name');
+    my ( $json, $error ) = UI::Topology::gen_crconfig_json( $self, $cdn_name );
+    if ( defined $error ) {
+        $self->flash( alertmsg => $error );
+    }
+    else {
+        if ( !&is_oper($self) ) {
+            $self->flash( alertmsg => "No can do. Get more privs." );
+        } else {
+            UI::Topology::write_crconfig_json_to_db( $self, $cdn_name, $json );
+            &log( $self, "Snapshot CRConfig created.", "OPER" );
+            $self->flash( alertmsg => "Successfully wrote CRConfig.json!" );
+        }
+    }
+    return $self->redirect_to('/utils/close_fancybox');
 }
 
 sub queue_updates {

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -573,6 +573,22 @@ sub gen_crconfig_json {
     return ($data_obj);
 }
 
+sub write_crconfig_json_to_db {
+    my $self          = shift;
+    my $cdn_name      = shift;
+    my $crconfig_db   = shift;
+    my $crconfig_json = encode_json($crconfig_db);
+
+    my $snapshot = $self->db->resultset('Snapshot')->find( { cdn => $cdn_name } );
+    if ( defined($snapshot) ) {
+        $snapshot->update({ content => $crconfig_json });
+    } else {
+        my $insert = $self->db->resultset('Snapshot')->create( { cdn => $cdn_name, content => $crconfig_json } );
+        $insert->insert();
+    }
+
+}
+
 sub diff_crconfig_json {
     my $self     = shift;
     my $json     = shift;


### PR DESCRIPTION
Perl changes in #1889 broke unit tests.   Selectively added back code needed for that to pass again.