### PR TITLE
Add Grove logrotate rules to rpm.  

### DIFF
--- a/grove/build/build_rpm.sh
+++ b/grove/build/build_rpm.sh
@@ -25,7 +25,7 @@ echo "$BUILDDIR" > ~/.rpmmacros
 go build -v -ldflags "-X main.Version=$VERSION"
 
 # tar
-tar -cvzf $BUILDDIR/SOURCES/grove-${VERSION}.tgz grove conf/grove.cfg build/grove.init
+tar -cvzf $BUILDDIR/SOURCES/grove-${VERSION}.tgz grove conf/grove.cfg build/grove.init build/grove.logrotate
 
 # build RPM
 rpmbuild --define "version ${VERSION}" -ba build/grove.spec

--- a/grove/build/grove.spec
+++ b/grove/build/grove.spec
@@ -48,6 +48,9 @@ mkdir -p -m 777 %{buildroot}/var/log/%{name}
 mkdir -p -m 777 %{buildroot}/etc/init.d/
 cp -p  build/%{name}.init %{buildroot}/etc/init.d/%{name}
 
+mkdir -p -m 777 %{buildroot}/etc/logrotate.d/
+cp -p build/%{name}.logrotate %{buildroot}/etc/logrotate.d/%{name}
+
 %clean
 echo "cleaning"
 rm -r -f %{buildroot}
@@ -56,4 +59,5 @@ rm -r -f %{buildroot}
 /usr/sbin/%{name}
 /var/log/%{name}
 %config(noreplace) /etc/%{name}
+%config(noreplace) /etc/logrotate.d/%{name}
 /etc/init.d/%{name}

--- a/grove/grove.cfg
+++ b/grove/grove.cfg
@@ -3,4 +3,7 @@
   "port": 8080,
   "cache_size_bytes": 50000,
   "remap_rules_file": "./remap.json"
+  "log_location_error": "/var/log/grove/grove.log",
+  "log_location_event": "/var/log/grove/access.log",
+  "log_location_warn": "/var/log/grove/grove.log"
 }


### PR DESCRIPTION
This PR updates the grove.spec file and the build_rpm.sh so that an rpm install will add the grove log rotation rules to log rotate.  Also updates the grove.cfg to define loggers that match the log rotation rules.  Fixes Issue #2206 