### PR TITLE
Fix Traffic Ops Go CRConfig to implement maxmind override logic

### DIFF
--- a/traffic_ops/traffic_ops_golang/crconfig/deliveryservice_test.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/deliveryservice_test.go
@@ -169,6 +169,7 @@ func TestMakeDSes(t *testing.T) {
 	defer db.Close()
 
 	cdn := "mycdn"
+	domain := "mycdn.invalid"
 
 	expected := ExpectedMakeDSes()
 	MockMakeDSes(mock, expected, cdn)
@@ -186,7 +187,7 @@ func TestMakeDSes(t *testing.T) {
 	expectedStaticDNSEntries := ExpectedGetStaticDNSEntries(expected)
 	MockGetStaticDNSEntries(mock, expectedStaticDNSEntries, cdn)
 
-	actual, err := makeDSes(cdn, db)
+	actual, err := makeDSes(cdn, domain, db)
 	if err != nil {
 		t.Fatalf("makeDSes expected: nil error, actual: %v", err)
 	}
@@ -310,6 +311,7 @@ func TestGetDSRegexesDomains(t *testing.T) {
 	defer db.Close()
 
 	cdn := "mycdn"
+	domain := "mycdn.invalid"
 
 	expectedMakeDSes := ExpectedMakeDSes()
 	expectedServerProfileParams := ExpectedGetServerProfileParams(expectedMakeDSes)
@@ -320,7 +322,7 @@ func TestGetDSRegexesDomains(t *testing.T) {
 	expectedMatchsets, expectedDomains := ExpectedGetDSRegexesDomains(expectedDSParams)
 	MockGetDSRegexesDomains(mock, expectedMatchsets, expectedDomains, cdn)
 
-	actualMatchsets, actualDomains, err := getDSRegexesDomains(cdn, db, expectedDSParams)
+	actualMatchsets, actualDomains, err := getDSRegexesDomains(cdn, domain, db)
 	if err != nil {
 		t.Fatalf("getDSRegexesDomains expected: nil error, actual: %v", err)
 	}

--- a/traffic_ops/traffic_ops_golang/routes.go
+++ b/traffic_ops/traffic_ops_golang/routes.go
@@ -233,7 +233,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		// DEPRECATED - use PUT /api/1.2/snapshot/{cdn}
 		{http.MethodGet, `tools/write_crconfig/{cdn}/?$`, crconfig.SnapshotOldGUIHandler(d.DB, d.Config), crconfig.PrivLevel, Authenticated, nil},
 		// DEPRECATED - use GET /api/1.2/cdns/{cdn}/snapshot
-		{http.MethodGet, `CRConfig-Snapshots/{cdn}/CRConfig.json?$`, crconfig.SnapshotGetHandler(d.DB, d.Config), crconfig.PrivLevel, Authenticated, nil},
+		{http.MethodGet, `CRConfig-Snapshots/{cdn}/CRConfig.json?$`, crconfig.SnapshotOldGetHandler(d.DB, d.Config), crconfig.PrivLevel, Authenticated, nil},
 	}
 
 	return routes, rawRoutes, proxyHandler, nil


### PR DESCRIPTION
Also fixes the old CRConfig endpoint to omit the "response" wrapper, and fixes the unit tests.