### PR TITLE
prevents failure of ssl files and processing of remap config params

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -1292,8 +1292,9 @@ sub check_plugins {
 					{
 						($plugin_config_file) = split( /\s+/, $plugin_config_file);
 
-						# Skip parameters that start with '-', since those are probabably parameters, not config files.
+						# Skip parameters that start with '-' or 'proxy.config.', since those are probabably parameters, not config files.
 						last if $plugin_config_file =~ m/^-/; # Exit subblock.
+						last if $plugin_config_file =~ m/^proxy.config./;
 
 						( my @parts ) = split( /\//, $plugin_config_file );
 						$plugin_config_file = $parts[$#parts];
@@ -2563,10 +2564,6 @@ sub set_uri {
 	elsif ( $api_in_use == 1 && defined($cfg_file_tracker->{$filename}->{'url'}) ) {
 		$URI = $cfg_file_tracker->{$filename}->{'url'};
 		( $log_level >> $DEBUG ) && print "DEBUG Setting external download URL.\n";
-	}
-	else {
-		( $log_level >> $ERROR ) && print "ERROR Configuration File API not found!  Please upgrade to Traffic Ops 2.2.  Unable to continue.\n";
-		exit 1;
 	}
 
 	return if (!defined($cfg_file_tracker->{$filename}->{'fname-in-TO'}));


### PR DESCRIPTION
https://github.com/apache/incubator-trafficcontrol/commit/425be777fb485fea43a10392496dd92493988065 introduced a bug that prevents successful completion of a syncds due to ssl keys being defined as config files in order to be located on disk, but having no URI otherwise.  This was due to extra code we didn't really need.

It was also noted that some pparams are getting picked up in remap.config as configuration files that should not be.  This filters some of that out.