### PR TITLE
ORT: Removing unnecessary errors

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -2651,7 +2651,7 @@ sub open_file_get_contents {
 		chomp($line);
 		( $log_level >> $TRACE ) && print "TRACE Line from cfg file on disk:\t$line.\n";
 		if ( $line =~ m/^\#/ || $line =~ m/^$/ ) {
-			if ( ( $line !~ m/DO NOT EDIT - Generated for / && $line !~ m/$header_comment/ ) && $line !~ m/12M NOTE\:/ ) {
+			if ( ( $line !~ m/DO NOT EDIT - Generated for / && $line !~ m/$header_comment/ ) && $line !~ m/TRAFFIC OPS NOTE\:/ ) {
 				next;
 			}
 		}
@@ -2710,10 +2710,10 @@ sub diff_file_lines {
 					}
 				}
 			}
-			elsif ( ( $line =~ m/DO NOT EDIT - Generated for / && $line =~ m/$header_comment/ ) || $line =~ m/12M NOTE\:/ ) {
+			elsif ( ( $line =~ m/DO NOT EDIT - Generated for / && $line =~ m/$header_comment/ ) || $line =~ m/TRAFFIC OPS NOTE\:/ ) {
 				my $found_it = 0;
 				foreach my $line_disk (@disk_file_lines) {
-					if ( ( $line =~ m/DO NOT EDIT - Generated for / && $line =~ m/$header_comment/ ) || $line =~ m/12M NOTE\:/ ) {
+					if ( ( $line =~ m/DO NOT EDIT - Generated for / && $line =~ m/$header_comment/ ) || $line =~ m/TRAFFIC OPS NOTE\:/ ) {
 						$found_it++;
 					}
 				}
@@ -2741,7 +2741,7 @@ sub diff_file_lines {
 					}
 				}
 			}
-			elsif ( ( $line =~ m/DO NOT EDIT - Generated for / && $line =~ m/$header_comment/ ) || $line =~ m/12M NOTE\:/ ) {
+			elsif ( ( $line =~ m/DO NOT EDIT - Generated for / && $line =~ m/$header_comment/ ) || $line =~ m/TRAFFIC OPS NOTE\:/ ) {
 				next;
 			}
 			else {


### PR DESCRIPTION
The diff was not showing the source/destination due to improper handling of notes.

Fix will...

- Prevent wrong ERROR printing on the screen due to traffic ops comments
- Prevent having to run `traffic_ctl config reload` when not needed

```
ERROR Lines for /opt/trafficserver/etc/trafficserver/volume.config from Traffic Ops do not match file on disk.
ERROR Config file volume.config line only in TrOps:	# TRAFFIC OPS NOTE: This is running with forced volumes - the size is irrelevant
ERROR Lines for /opt/trafficserver/etc/trafficserver//hosting.config from Traffic Ops do not match file on disk.
ERROR Config file hosting.config line only in TrOps:	# TRAFFIC OPS NOTE: volume 1 is the Disk volume
ERROR Config file hosting.config line only in TrOps:	# TRAFFIC OPS NOTE: volume 2 is the RAM volume
```
