### PR TITLE
Adds Docker Compose configuration for creating a Traffic_Ops Dev environment

### DIFF
--- a/infrastructure/docker/traffic_ops/Dockerfile_psql
+++ b/infrastructure/docker/traffic_ops/Dockerfile_psql
@@ -1,3 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+############################################################
+# Dockerfile to initialized Traffic Ops Database container 
+# Based on CentOS 7.2
+############################################################
+
 FROM centos/systemd
 
 RUN yum install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm

--- a/infrastructure/docker/traffic_ops/Dockerfile_psql
+++ b/infrastructure/docker/traffic_ops/Dockerfile_psql
@@ -1,0 +1,20 @@
+FROM centos/systemd
+
+RUN yum install -y https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm
+
+RUN yum -y install \
+  postgresql96 \
+  nmap-ncat \
+  cpanminus && \
+  yum clean all
+
+ENV POSTGRES_HOME $POSTGRES_HOME
+ENV PGPASSWORD $PGPASSWORD 
+ENV DB_USERNAME $DB_USERNAME
+ENV DB_NAME $DB_NAME
+ENV DB_USER_PASS $DB_USER_PASS 
+ENV DB_SERVER $DB_SERVER
+ENV DB_PORT $DB_PORT
+
+ADD dbInit.sh /
+CMD /dbInit.sh

--- a/infrastructure/docker/traffic_ops/dbInit.sh
+++ b/infrastructure/docker/traffic_ops/dbInit.sh
@@ -1,4 +1,26 @@
 #!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+############################################################
+# Script for creating the database user account for traffic
+# ops. 
+# Used while the Docker Image is initializing itself
+############################################################
 
 while ! nc $DB_SERVER $DB_PORT </dev/null; do # &>/dev/null; do
         echo "waiting for $DB_SERVER:$DB_PORT"

--- a/infrastructure/docker/traffic_ops/dbInit.sh
+++ b/infrastructure/docker/traffic_ops/dbInit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+while ! nc $DB_SERVER $DB_PORT </dev/null; do # &>/dev/null; do
+        echo "waiting for $DB_SERVER:$DB_PORT"
+        sleep 3
+done
+psql -h $DB_SERVER -U postgres -c "CREATE USER $DB_USERNAME WITH ENCRYPTED PASSWORD '$DB_USER_PASS'"
+createdb $DB_NAME -h $DB_SERVER -U postgres --owner $DB_USERNAME

--- a/infrastructure/docker/traffic_ops/docker-compose.yml
+++ b/infrastructure/docker/traffic_ops/docker-compose.yml
@@ -23,7 +23,11 @@
 # and type 'docker-compose up -d'
 #
 # You should then be able to go to https://localhost and test Traffic Ops or the go api.
-# if you make code changes to the Go proxy then you
+# if you make code changes to the Go proxy then you just need to rebuild it and then
+# restart Traffic Ops:
+#
+# bash -c "clear && docker exec trafficops_to_server_1 /bin/bash /etc/init.d/traffic_ops /bin/bash /etc/init.d/traffic_ops start; sleep 5"
+#
 
 ---
 version: '2'

--- a/infrastructure/docker/traffic_ops/docker-compose.yml
+++ b/infrastructure/docker/traffic_ops/docker-compose.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# To use this compose you should first build Traffic Ops and then copy the RPM to :
+#
+# incubator-trafficcontrol/infrastructure/docker/traffic_ops/traffic_ops.rpm
+#
+# You should then just be able to go to the directory incubator-trafficcontrol/infrastructure/docker/traffic_ops/
+# and type 'docker-compose up -d'
+#
+# You should then be able to go to https://localhost and test Traffic Ops or the go api.
+# if you make code changes to the Go proxy then you
+
+---
+version: '2'
+
+volumes:
+  incubator-trafficcontrol:
+  traffic_ops:
+  conf:
+
+services:
+  db:
+    image: postgres:9.6.6
+    ports: 
+      - "5432:5432"
+
+  db_init:
+    environment:
+      POSTGRES_HOME: /usr/pgsql-9.6
+      PGPASSWORD: secretrootpass
+      DB_USERNAME: traffic_ops
+      DB_NAME: traffic_ops
+      DB_USER_PASS: twelve
+      DB_SERVER: db
+      DB_PORT: 5432
+    build:
+      context: .
+      dockerfile: Dockerfile_psql
+    depends_on: 
+      - db
+
+  to_server:
+    environment:
+      DB_SERVER: db
+      DB_PORT: 5432
+      DB_NAME: traffic_ops
+      DB_ROOT_PASS: null
+      DB_USER_PASS: twelve
+      DB_USER: traffic_ops
+      ADMIN_USER: superroot
+      ADMIN_PASS: passward
+      CERT_COUNTRY: US
+      CERT_STATE: Colorado
+      CERT_CITY: Denver
+      CERT_COMPANY: NotComcast
+      TRAFFIC_VAULT_PASS: tvsecret
+      DOMAIN: trafficops_default
+    ports: 
+      - "443:443"
+    build:
+      context: .
+      args:
+        RPM: traffic_ops.rpm 
+    volumes:
+      - ../../../traffic_ops/traffic_ops_golang/traffic_ops_golang:/opt/traffic_ops/app/bin/traffic_ops_golang
+    depends_on:
+      - db_init


### PR DESCRIPTION
This PR converts these API methods to Go:
		GET    api/1.1/deliveryserviceserver
		POST api/1.1/deliveryserviceserver
		POST api/1.1/deliveryservices/{xml_id}/servers
		GET.   api/1.1/deliveryservices/{id}/servers
		GET    api/1.1/deliveryservices/{id}/unassigned_servers

I also added a Docker Compose file to: infrastructure/docker/traffic_ops which will quickly create a local traffic_ops and postgres Dev environment for quickly testing changes to the traffic_ops_golang proxy. 	
