### PR TITLE
Fix TO old Perl GUI CRConfig diff

### DIFF
--- a/traffic_ops/app/lib/UI/Tools.pm
+++ b/traffic_ops/app/lib/UI/Tools.pm
@@ -73,7 +73,18 @@ sub diff_crconfig_iframe {
     my $self = shift;
     &stash_role($self);
     my $cdn_name = $self->param('cdn_name');
-    my ( $json, $error ) = UI::Topology::gen_crconfig_json( $self, $cdn_name );
+
+    foreach my $cookie ( @{ $self->req->cookies } ) {
+        $self->ua->cookie_jar->add(Mojo::Cookie::Response->new(name => $cookie->{'name'}, value => $cookie->{'value'}, domain => 'localhost', path => '/'));
+    }
+    my $resp = $self->ua->request_timeout(60)->get('/api/1.2/cdns/' . $cdn_name . '/snapshot/new')->res;
+    my $json = undef;
+    my $error = undef;
+    if ( $resp->code ne '200' ) {
+        $error = $resp->message;
+    } else {
+        $json = decode_json($resp->body)->{'response'};
+    }
 
     my ( @ds_text, @loc_text, @cs_text, @csds_text, @rascal_text, @ccr_text, @cfg_text );
     if ( defined $error ) {

--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -848,6 +848,7 @@ sub stringify_cs_ds {
     foreach my $ds ( sort keys %{$csds} ) {
         if ( ref( $csds->{$ds} ) eq 'ARRAY' ) {
             foreach my $map ( @{ $csds->{$ds} } ) {
+                next if !defined $map;
                 push( @strings, "|ds:" . $ds . "|server:" . $server . "|mapped:" . $map . "|" );
             }
         }


### PR DESCRIPTION
Fixes the old Perl GUI CRConfig diff, by changing it to fetch the
new CRConfig from traffic_ops_golang rather than creating it from
the now-unused Perl CRConfig function.