### PR TITLE
Add Grove vendors to .rat-excludes

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -67,3 +67,6 @@ asaskevich(?:                        MIT. Properly documented in LICENSE ){0}
 go-ozzo(?:                           MIT. Properly documented in LICENSE ){0}
 ldap.v2(?:                           MIT. Properly documented in LICENSE ){0}
 asn1-ber.v1(?:                       MIT. Properly documented in LICENSE ){0}
+bytefmt(?:                           Apache 2.0. Properly documented in LICENSE ){0}
+siphash(?:                           CC0. Properly documented in LICENSE ){0}
+bbolt(?:                             MIT. Properly documented in LICENSE ){0}


### PR DESCRIPTION
Tested with rat, succeeds with `0 Unknown Licenses`