### PR TITLE
Add TO Go cdns/metric_types route 501

### DIFF
--- a/docs/source/api/v11/cdn.rst
+++ b/docs/source/api/v11/cdn.rst
@@ -384,6 +384,8 @@ Metrics
 
 **GET /api/1.1/cdns/metric_types/:metric/start_date/:start/end_date/:end**
 
+*Note: this route is not currently implemented in Traffic Ops. See https://github.com/apache/incubator-trafficcontrol/issues/2309*
+
   Retrieves edge metrics of one or all locations (cache groups).
 
   Authentication Required: Yes

--- a/docs/source/api/v12/cdn.rst
+++ b/docs/source/api/v12/cdn.rst
@@ -639,7 +639,10 @@ Routing
 Metrics
 +++++++
 
+
 **GET /api/1.2/cdns/metric_types/:metric/start_date/:start/end_date/:end**
+
+*Note: this route is not currently implemented in Traffic Ops. See https://github.com/apache/incubator-trafficcontrol/issues/2309*
 
   Retrieves edge metrics of one or all locations (cache groups).
 


### PR DESCRIPTION
The cdns/metric_types route is documented in the API, and has a Perl
route, but the Perl function it points to doesn't exist. As such,
this adds a note to the docs, and adds a Go route returning an HTTP
501 Not Implemented code.

See Github Issue #2309