### PR TITLE
Adding grove to standard pkg build.

### DIFF
--- a/infrastructure/docker/build/Dockerfile-grove
+++ b/infrastructure/docker/build/Dockerfile-grove
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+FROM centos:7
+
+MAINTAINER Chris Lemmons
+
+# top level of trafficcontrol directory must be mounted as a volume:
+# docker run --volume /trafficcontrol:$(pwd) ...
+VOLUME /trafficcontrol
+
+### Common for all sub-component builds
+RUN	yum -y install \
+		epel-release && \
+	yum -y clean all
+RUN	yum -y install \
+		git \
+		rpm-build && \
+	yum -y clean all
+
+### grove specific requirements
+RUN	yum -y install \
+		golang && \
+	yum -y clean all
+###
+
+ADD infrastructure/docker/build/clean_build.sh /
+
+ENV GOPATH=/go
+RUN mkdir -p /go/src/github.com/apache && ln -s /tmp/trafficcontrol /go/src/github.com/apache/incubator-trafficcontrol
+CMD /clean_build.sh grove
+
+# vi:syntax=Dockerfile

--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -78,6 +78,14 @@ services:
     volumes:
       - ../../..:/trafficcontrol:z
 
+  grove_build:
+    image: grove_builder
+    build:
+      dockerfile: infrastructure/docker/build/Dockerfile-grove
+      context: ../../..
+    volumes:
+      - ../../..:/trafficcontrol:z
+
   weasel:
     image: licenseweasel/weasel:0.1
     volumes:


### PR DESCRIPTION
@rob05c, please review.

This shouldn't break the non-docker build, but it adds `./pkg` functionality.