### PR TITLE
Modification to use the LastModified date on a revalidation request.

### DIFF
--- a/grove/cache/retryinggetter.go
+++ b/grove/cache/retryinggetter.go
@@ -132,7 +132,7 @@ func GetAndCache(
 			proxyURLStr = proxyURL.Host
 		}
 		if revalidateObj != nil {
-			req.Header.Set(ModifiedSinceHdr, revalidateObj.RespRespTime.Format(time.RFC1123))
+			req.Header.Set(ModifiedSinceHdr, revalidateObj.LastModified.Format(time.RFC1123))
 		} else {
 			req.Header.Del(ModifiedSinceHdr)
 		}


### PR DESCRIPTION
Fixes revalidation bug found with grove in production on a  delivery service while revalidating the cached manifest.