### PR TITLE
Add Grove configurable plugin enable/disabling

### DIFF
--- a/grove/README.md
+++ b/grove/README.md
@@ -66,6 +66,7 @@ The config file is JSON of the following format:
   "port": 8080,
   "cache_size_bytes": 50000,
   "remap_rules_file": "./remap.json",
+  "plugins": ["ats_log", "http_stats", "if_modified_since", "record_stats"],
 ```
 
 The config file has the following fields:
@@ -96,6 +97,7 @@ The config file has the following fields:
 | `server_write_timeout_ms` | The length of time in milliseconds to allow a client to write data, before the connection is terminated. This value should be carefully considered, as too short a timeout will result in terminating legitimate clients with slow connections, while too long a timeout will make the server vulnerable to SlowLoris attacks.|
 | `cache_files` | Groups of cache files to use for disk caching. See [Disk Cache](#disk-cache) |
 | `file_mem_bytes` | The size in bytes of the memory cache to use for each group of cache files. Note this size is used for each group, and thus the total memory used is `file_mem_bytes*len(cache_files)+cache_size_bytes`.  See [Disk Cache](#disk-cache) |
+| `plugins` | An array of plugins to enable |
 
 # Remap Rules
 

--- a/grove/config/config.go
+++ b/grove/config/config.go
@@ -47,6 +47,8 @@ type Config struct {
 	LogLocationDebug   string `json:"log_location_debug"`
 	LogLocationEvent   string `json:"log_location_event"`
 
+	Plugins []string `json:"plugins"`
+
 	ReqTimeoutMS         int `json:"parent_request_timeout_ms"` // TODO rename "parent_request" to distinguish from client requests
 	ReqKeepAliveMS       int `json:"parent_request_keep_alive_ms"`
 	ReqMaxIdleConns      int `json:"parent_request_max_idle_connections"`

--- a/grove/grove.cfg
+++ b/grove/grove.cfg
@@ -2,7 +2,8 @@
   "rfc_compliant": false,
   "port": 8080,
   "cache_size_bytes": 50000,
-  "remap_rules_file": "./remap.json"
+  "remap_rules_file": "./remap.json",
+  "plugins": ["ats_log", "http_stats", "if_modified_since", "record_stats"],
   "log_location_error": "/var/log/grove/grove.log",
   "log_location_event": "/var/log/grove/access.log",
   "log_location_warn": "/var/log/grove/grove.log"

--- a/grove/plugin/hello_context.go
+++ b/grove/plugin/hello_context.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	// AddPlugin(10000, Funcs{startup: helloCtxStart, afterRespond: helloCtxAfterResp})
+	AddPlugin(10000, Funcs{startup: helloCtxStart, afterRespond: helloCtxAfterResp})
 }
 
 func helloCtxStart(icfg interface{}, d StartupData) {

--- a/grove/plugin/hello_world.go
+++ b/grove/plugin/hello_world.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	// AddPlugin(10000, Funcs{startup: hello})
+	AddPlugin(10000, Funcs{startup: hello})
 }
 
 func hello(icfg interface{}, d StartupData) {

--- a/grove/plugin/plugin.go
+++ b/grove/plugin/plugin.go
@@ -132,9 +132,20 @@ func (p pluginsSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 var plugins = pluginsSlice{}
 
-func Get() Plugins {
-	sort.Sort(plugins)
-	return pluginsSlice(plugins)
+func Get(enabled []string) Plugins {
+	enabledM := map[string]struct{}{}
+	for _, name := range enabled {
+		enabledM[name] = struct{}{}
+	}
+	enabledPlugins := pluginsSlice{}
+	for _, plugin := range plugins {
+		if _, ok := enabledM[plugin.name]; !ok {
+			continue
+		}
+		enabledPlugins = append(enabledPlugins, plugin)
+	}
+	sort.Sort(enabledPlugins)
+	return enabledPlugins
 }
 
 type Plugins interface {


### PR DESCRIPTION
Plugins are now enabled via a key in the main `grove.cfg` config file, `"plugins":["foo", "bar"]`. Which plugins are enabled is reloaded on service reload (SIGHUP), and each plugins' Startup hook is called on each reload.