### PR TITLE
Enable Origin API integration tests

### DIFF
--- a/traffic_ops/testing/api/v13/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v13/deliveryservices_test.go
@@ -51,7 +51,6 @@ func TestDeliveryServices(t *testing.T) {
 func CreateTestDeliveryServices(t *testing.T) {
 	log.Debugln("CreateTestDeliveryServices")
 
-	// TODO delete on DS delete
 	pl := tc.Parameter{
 		ConfigFile: "remap.config",
 		Name:       "location",
@@ -216,6 +215,16 @@ func DeleteTestDeliveryServices(t *testing.T) {
 		if err == nil && foundDS != nil {
 			failed = true
 			t.Errorf("expected Delivery Service: %s to be deleted\n", ds.XMLID)
+		}
+	}
+
+	// clean up parameter created in CreateTestDeliveryServices()
+	params, _, err := TOSession.GetParameterByNameAndConfigFile("location", "remap.config")
+	for _, param := range params {
+		deleted, _, err := TOSession.DeleteParameterByID(param.ID)
+		if err != nil {
+			failed = true
+			t.Errorf("cannot DELETE parameter by ID (%d): %v - %v\n", param.ID, err, deleted)
 		}
 	}
 

--- a/traffic_ops/testing/api/v13/origins_test.go
+++ b/traffic_ops/testing/api/v13/origins_test.go
@@ -97,8 +97,7 @@ func CreateTestOrigins(t *testing.T) {
 		origin.ProfileID = &respProfile.ID
 		origin.DeliveryServiceID = &respDeliveryServices[0].ID
 
-		resp, _, err := TOSession.CreateOrigin(origin)
-		log.Debugln("Response: ", origin.Name, " ", resp)
+		_, _, err = TOSession.CreateOrigin(origin)
 		if err != nil {
 			t.Errorf("could not CREATE origins: %v\n", err)
 			failed = true

--- a/traffic_ops/testing/api/v13/origins_test.go
+++ b/traffic_ops/testing/api/v13/origins_test.go
@@ -22,26 +22,34 @@ import (
 )
 
 func TestOrigins(t *testing.T) {
-
 	CreateTestCDNs(t)
 	defer DeleteTestCDNs(t)
 	CreateTestTypes(t)
 	defer DeleteTestTypes(t)
 	CreateTestProfiles(t)
 	defer DeleteTestProfiles(t)
+	CreateTestStatuses(t)
+	defer DeleteTestStatuses(t)
+	CreateTestDivisions(t)
+	defer DeleteTestDivisions(t)
+	CreateTestRegions(t)
+	defer DeleteTestRegions(t)
+	CreateTestPhysLocations(t)
+	defer DeleteTestPhysLocations(t)
 	CreateTestCacheGroups(t)
 	defer DeleteTestCacheGroups(t)
+	CreateTestServers(t)
+	defer DeleteTestServers(t)
+	CreateTestDeliveryServices(t)
+	defer DeleteTestDeliveryServices(t)
 	CreateTestCoordinates(t)
 	defer DeleteTestCoordinates(t)
-	// TODO: add deliveryservices once their API integration tests are implemented
 	// TODO: add tenants once their API integration tests are implemented
-	log.Debugln("TestOrigins() not implemented, requires Delivery Service API tests")
 
-	//CreateTestOrigins(t)
-	//defer DeleteTestOrigins(t)
-	//UpdateTestOrigins(t)
-	//GetTestOrigins(t)
-
+	CreateTestOrigins(t)
+	defer DeleteTestOrigins(t)
+	UpdateTestOrigins(t)
+	GetTestOrigins(t)
 }
 
 func CreateTestOrigins(t *testing.T) {
@@ -63,6 +71,17 @@ func CreateTestOrigins(t *testing.T) {
 	}
 	respCacheGroup := respCacheGroups[0]
 
+	// GET deliveryservices
+	respDeliveryServices, _, err := TOSession.GetDeliveryServices()
+	if err != nil {
+		t.Errorf("cannot GET Delivery Services - %v\n", err)
+		failed = true
+	}
+	if len(respDeliveryServices) == 0 {
+		t.Errorf("no delivery services found")
+		failed = true
+	}
+
 	// GET coordinate1 coordinate
 	respCoordinates, _, err := TOSession.GetCoordinateByName("coordinate1")
 	if err != nil {
@@ -76,6 +95,7 @@ func CreateTestOrigins(t *testing.T) {
 		origin.CachegroupID = &respCacheGroup.ID
 		origin.CoordinateID = &respCoordinate.ID
 		origin.ProfileID = &respProfile.ID
+		origin.DeliveryServiceID = &respDeliveryServices[0].ID
 
 		resp, _, err := TOSession.CreateOrigin(origin)
 		log.Debugln("Response: ", origin.Name, " ", resp)


### PR DESCRIPTION
Now that Delivery Service API integration tests exists, they can be
leveraged to finalize the Origin API integration tests.