### PR TITLE
Add missing Close() deferral after DB queries

### DIFF
--- a/traffic_ops/traffic_ops_golang/physlocation/trimmed.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/trimmed.go
@@ -39,6 +39,7 @@ func getTrimmed(db *sql.DB) ([]tc.PhysLocationTrimmed, error) {
 	if err != nil {
 		return nil, errors.New("querying trimmed physical locations: " + err.Error())
 	}
+	defer rows.Close()
 	ps := []tc.PhysLocationTrimmed{}
 	for rows.Next() {
 		name := ""

--- a/traffic_ops/traffic_ops_golang/profile/trimmed.go
+++ b/traffic_ops/traffic_ops_golang/profile/trimmed.go
@@ -20,8 +20,8 @@ package profile
  */
 
 import (
-	"errors"
 	"database/sql"
+	"errors"
 	"net/http"
 
 	"github.com/apache/incubator-trafficcontrol/lib/go-tc"
@@ -39,6 +39,7 @@ func getTrimmedProfiles(db *sql.DB) ([]tc.ProfileTrimmed, error) {
 	if err != nil {
 		return nil, errors.New("querying trimmed profiles: " + err.Error())
 	}
+	defer rows.Close()
 	profiles := []tc.ProfileTrimmed{}
 	for rows.Next() {
 		name := ""


### PR DESCRIPTION
The 1.1/profiles/trimmed and 1.1/phys_locations/trimmed endpoints were
missing a deferred Close() after initializing a Query().