### PR TITLE
Fix TM nil panic

### DIFF
--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -106,7 +106,10 @@ func (h CRConfigHistoryThreadsafe) Add(i *CRConfigStat) {
 
 	if *h.len != 0 {
 		last := (*h.hist)[(*h.pos-1)%*h.limit]
-		if i.ReqAddr == last.ReqAddr && *i.Stats.DateUnixSeconds == *last.Stats.DateUnixSeconds && *i.Stats.CDNName == *last.Stats.CDNName {
+		datesEqual := (i.Stats.DateUnixSeconds == nil && last.Stats.DateUnixSeconds == nil) || (i.Stats.DateUnixSeconds != nil && last.Stats.DateUnixSeconds != nil && *i.Stats.DateUnixSeconds == *last.Stats.DateUnixSeconds)
+		cdnsEqual := (i.Stats.CDNName == nil && last.Stats.CDNName == nil) || (i.Stats.CDNName != nil && last.Stats.CDNName != nil && *i.Stats.CDNName == *last.Stats.CDNName)
+		reqAddrsEqual := i.ReqAddr == last.ReqAddr
+		if reqAddrsEqual && datesEqual && cdnsEqual {
 			return
 		}
 	}


### PR DESCRIPTION
This fixes a nil panic, if there's an error getting the CRConfig from Traffic Ops (either a connection request error, or JSON unmarshal error).