### PR TITLE
Fix TO Go "CRUDer" GetRefTypes to new, not shared

### DIFF
--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -45,15 +45,9 @@ type TOASNV11 tc.ASNNullable
 
 type TOASNV12 TOASNV11
 
-func GetRefTypeV11() *TOASNV11 {
-	asn := TOASNV11(tc.ASNNullable{})
-	return &asn
-}
+func GetRefTypeV11() *TOASNV11 { return &TOASNV11{} }
 
-func GetRefTypeV12() *TOASNV12 {
-	asn := TOASNV12(tc.ASNNullable{})
-	return &asn
-}
+func GetRefTypeV12() *TOASNV12 { return &TOASNV12{} }
 
 func (asn TOASNV11) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -39,12 +39,7 @@ import (
 
 type TOCacheGroup v13.CacheGroupNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOCacheGroup{}
-
-func GetRefType() *TOCacheGroup {
-	return &refType
-}
+func GetRefType() *TOCacheGroup { return &TOCacheGroup{} }
 
 func (cachegroup TOCacheGroup) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -41,12 +41,7 @@ import (
 //we need a type alias to define functions on
 type TOCDN v13.CDNNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOCDN{}
-
-func GetRefType() *TOCDN {
-	return &refType
-}
+func GetRefType() *TOCDN { return &TOCDN{} }
 
 func (cdn TOCDN) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
@@ -40,12 +40,7 @@ import (
 //we need a type alias to define functions on
 type TOCoordinate v13.CoordinateNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOCoordinate{}
-
-func GetRefType() *TOCoordinate {
-	return &refType
-}
+func GetRefType() *TOCoordinate { return &TOCoordinate{} }
 
 func (coordinate TOCoordinate) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
@@ -38,12 +38,7 @@ import (
 //we need a type alias to define functions on
 type TODeliveryServiceRequestComment tc.DeliveryServiceRequestCommentNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TODeliveryServiceRequestComment{}
-
-func GetRefType() *TODeliveryServiceRequestComment {
-	return &refType
-}
+func GetRefType() *TODeliveryServiceRequestComment { return &TODeliveryServiceRequestComment{} }
 
 func (comment TODeliveryServiceRequestComment) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
@@ -38,13 +38,8 @@ import (
 // TODeliveryServiceRequest provides a type alias to define functions on
 type TODeliveryServiceRequest tc.DeliveryServiceRequestNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TODeliveryServiceRequest(tc.DeliveryServiceRequestNullable{})
-
 // GetRefType is used to decode the JSON for deliveryservice requests
-func GetRefType() *TODeliveryServiceRequest {
-	return &refType
-}
+func GetRefType() *TODeliveryServiceRequest { return &TODeliveryServiceRequest{} }
 
 func (req TODeliveryServiceRequest) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -42,12 +42,7 @@ import (
 // TODeliveryServiceRequest provides a type alias to define functions on
 type TODeliveryServiceServer tc.DeliveryServiceServer
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TODeliveryServiceServer(tc.DeliveryServiceServer{})
-
-func GetRefType() *TODeliveryServiceServer {
-	return &refType
-}
+func GetRefType() *TODeliveryServiceServer { return &TODeliveryServiceServer{} }
 
 func (dss TODeliveryServiceServer) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"deliveryservice", api.GetIntKey}, {"server", api.GetIntKey}}
@@ -288,7 +283,6 @@ type DSServerIds struct {
 
 type TODSServerIds DSServerIds
 
-
 func createServersForDsIdRef() *TODSServerIds {
 	var dsserversRef = TODSServerIds(DSServerIds{})
 	return &dsserversRef
@@ -307,7 +301,7 @@ func GetReplaceHandler(db *sqlx.DB) http.HandlerFunc {
 		}
 
 		// get list of server Ids to insert
-		payload :=  createServersForDsIdRef() 
+		payload := createServersForDsIdRef()
 
 		if err := json.NewDecoder(r.Body).Decode(payload); err != nil {
 			log.Errorf("Error trying to decode the request body: %s", err)
@@ -387,7 +381,7 @@ func GetReplaceHandler(db *sqlx.DB) http.HandlerFunc {
 		i := 0
 		respServers := []int{}
 
-		for _ , server := range servers {
+		for _, server := range servers {
 			dtos := map[string]interface{}{"id": dsId, "server": server}
 			resultRows, err := tx.NamedQuery(insertIdsQuery(), dtos)
 			if err != nil {
@@ -434,7 +428,6 @@ func GetReplaceHandler(db *sqlx.DB) http.HandlerFunc {
 }
 
 type TODeliveryServiceServers tc.DeliveryServiceServers
-
 
 func createServersRef() *TODeliveryServiceServers {
 	serversRef := TODeliveryServiceServers(tc.DeliveryServiceServers{})
@@ -628,7 +621,7 @@ func GetReadHandler(db *sqlx.DB, filter tc.Filter) http.HandlerFunc {
 			return
 		}
 
-		dssres := tc.DSServersAttrResponse{ servers }
+		dssres := tc.DSServersAttrResponse{servers}
 		respBts, err := json.Marshal(dssres)
 		if err != nil {
 			handleErrs(http.StatusInternalServerError, err)

--- a/traffic_ops/traffic_ops_golang/division/divisions.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions.go
@@ -39,12 +39,7 @@ import (
 //we need a type alias to define functions on
 type TODivision tc.DivisionNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TODivision(tc.DivisionNullable{})
-
-func GetRefType() *TODivision {
-	return &refType
-}
+func GetRefType() *TODivision { return &TODivision{} }
 
 func (division TODivision) GetAuditName() string {
 	if division.Name != nil {
@@ -155,7 +150,7 @@ func (division *TODivision) Create(db *sqlx.DB, user auth.CurrentUser) (error, t
 
 func (division *TODivision) Read(db *sqlx.DB, parameters map[string]string, user auth.CurrentUser) ([]interface{}, []error, tc.ApiErrorType) {
 	if strings.HasSuffix(parameters["name"], ".json") {
-		parameters["name"] = parameters["name"][:len(parameters["name"]) - len(".json")]
+		parameters["name"] = parameters["name"][:len(parameters["name"])-len(".json")]
 	}
 	// Query Parameters to Database Query column mappings
 	// see the fields mapped in the SQL query

--- a/traffic_ops/traffic_ops_golang/origin/origins.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins.go
@@ -43,12 +43,7 @@ import (
 //we need a type alias to define functions on
 type TOOrigin v13.Origin
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOOrigin{}
-
-func GetRefType() *TOOrigin {
-	return &refType
-}
+func GetRefType() *TOOrigin { return &TOOrigin{} }
 
 func (origin *TOOrigin) SetID(i int) {
 	origin.ID = &i

--- a/traffic_ops/traffic_ops_golang/parameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters.go
@@ -51,12 +51,7 @@ var (
 //we need a type alias to define functions on
 type TOParameter tc.ParameterNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOParameter(tc.ParameterNullable{})
-
-func GetRefType() *TOParameter {
-	return &refType
-}
+func GetRefType() *TOParameter { return &TOParameter{} }
 
 func (parameter TOParameter) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{IDQueryParam, api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -38,12 +38,7 @@ import (
 //we need a type alias to define functions on
 type TOPhysLocation tc.PhysLocationNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOPhysLocation(tc.PhysLocationNullable{})
-
-func GetRefType() *TOPhysLocation {
-	return &refType
-}
+func GetRefType() *TOPhysLocation { return &TOPhysLocation{} }
 
 func (pl TOPhysLocation) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -49,12 +49,7 @@ const (
 type TOProfile v13.ProfileNullable
 type TOParameter v13.ParameterNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOProfile{}
-
-func GetRefType() *TOProfile {
-	return &refType
-}
+func GetRefType() *TOProfile { return &TOProfile{} }
 
 func (prof TOProfile) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{IDQueryParam, api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -45,12 +45,7 @@ const (
 //we need a type alias to define functions on
 type TOProfileParameter v13.ProfileParameterNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOProfileParameter(v13.ProfileParameterNullable{})
-
-func GetRefType() *TOProfileParameter {
-	return &refType
-}
+func GetRefType() *TOProfileParameter { return &TOProfileParameter{} }
 
 func (pp TOProfileParameter) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{ProfileIDQueryParam, api.GetIntKey}, {ParameterIDQueryParam, api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -35,12 +35,7 @@ import (
 //we need a type alias to define functions on
 type TORegion tc.Region
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TORegion(tc.Region{})
-
-func GetRefType() *TORegion {
-	return &refType
-}
+func GetRefType() *TORegion { return &TORegion{} }
 
 func (region TORegion) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -39,12 +39,7 @@ import (
 //we need a type alias to define functions on
 type TORole v13.Role
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TORole{}
-
-func GetRefType() *TORole {
-	return &refType
-}
+func GetRefType() *TORole { return &TORole{} }
 
 func (role TORole) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -41,12 +41,7 @@ import (
 //we need a type alias to define functions on
 type TOServer v13.ServerNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOServer{}
-
-func GetRefType() *TOServer {
-	return &refType
-}
+func GetRefType() *TOServer { return &TOServer{} }
 
 func (server *TOServer) SetID(i int) {
 	server.ID = &i

--- a/traffic_ops/traffic_ops_golang/status/statuses.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses.go
@@ -38,12 +38,7 @@ import (
 //we need a type alias to define functions on
 type TOStatus tc.StatusNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOStatus(tc.StatusNullable{})
-
-func GetRefType() *TOStatus {
-	return &refType
-}
+func GetRefType() *TOStatus { return &TOStatus{} }
 
 func (status TOStatus) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -38,12 +38,7 @@ import (
 //we need a type alias to define functions on
 type TOType tc.TypeNullable
 
-//the refType is passed into the handlers where a copy of its type is used to decode the json.
-var refType = TOType(tc.TypeNullable{})
-
-func GetRefType() *TOType {
-	return &refType
-}
+func GetRefType() *TOType { return &TOType{} }
 
 func (typ TOType) GetKeyFieldsInfo() []api.KeyFieldInfo {
 	return []api.KeyFieldInfo{{"id", api.GetIntKey}}


### PR DESCRIPTION
Using shared objects between threads is dangerous, and there's no
reason for it, the cost to create these structs is insignificant.

Moreover, this was specifically causing issues with reused structs
being copied, and pointers being shared. The simple and safe solution
is to not share data between threads.