### PR TITLE
[Issue 2387] allow cachegroup select by type id

### DIFF
--- a/traffic_ops/testing/compare/testroutes.txt
+++ b/traffic_ops/testing/compare/testroutes.txt
@@ -8,3 +8,5 @@ api/1.3/regions?orderby=id
 api/1.3/servers?orderby=id
 api/1.3/statuses?orderby=id
 api/1.3/profiles?orderby=id
+api/1.3/cachegroups?orderby=id
+api/1.3/cachegroups?type=4

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -314,6 +314,7 @@ func (cachegroup *TOCacheGroup) Read(db *sqlx.DB, parameters map[string]string, 
 		"id":        dbhelpers.WhereColumnInfo{"cachegroup.id", api.IsInt},
 		"name":      dbhelpers.WhereColumnInfo{"cachegroup.name", nil},
 		"shortName": dbhelpers.WhereColumnInfo{"short_name", nil},
+		"type":      dbhelpers.WhereColumnInfo{"cachegroup.type", nil},
 	}
 	where, orderBy, queryValues, errs := dbhelpers.BuildWhereAndOrderBy(parameters, queryParamsToQueryCols)
 	if len(errs) > 0 {


### PR DESCRIPTION
This fixes #2387 

Now allows `.../api/1.3/cachegroups?type=4`, e.g. 