### PR TITLE
TO Go DS API: initialDispersion not required for DNS DSes

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv12.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservicesv12.go
@@ -250,7 +250,7 @@ func validateTypeFields(db *sqlx.DB, ds *tc.DeliveryServiceNullableV12) []error 
 
 	errs := validation.Errors{
 		"initialDispersion": validation.Validate(ds.InitialDispersion,
-			validation.By(requiredIfMatchesTypeName([]string{DNSRegexType, HTTPRegexType}, typeName))),
+			validation.By(requiredIfMatchesTypeName([]string{HTTPRegexType}, typeName))),
 		"ipv6RoutingEnabled": validation.Validate(ds.IPV6RoutingEnabled,
 			validation.By(requiredIfMatchesTypeName([]string{SteeringRegexType, DNSRegexType, HTTPRegexType}, typeName))),
 		"missLat": validation.Validate(ds.MissLat,


### PR DESCRIPTION
In the Perl version of POST and PUT /api/1.2/deliveryservices, `initialDispersion` is not required for DNS delivery services. Traffic Portal follows this assumption and is currently unable to create DNS delivery services because the Go version is requiring it.